### PR TITLE
Bug 368073 - Allow users to opt out of uploading download statistics

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.artifact.repository;singleton:=true
-Bundle-Version: 1.4.400.qualifier
+Bundle-Version: 1.4.500.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.artifact.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/MirrorRequest.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/MirrorRequest.java
@@ -48,6 +48,13 @@ public class MirrorRequest extends ArtifactRequest {
 	public static final int ARTIFACT_PROCESSING_ERROR = 2;
 
 	/**
+	 * A boolean property controlling whether reporting download statistics is
+	 * enabled.
+	 */
+	public static final boolean DOWNLOAD_STATS_ENABLED = !"false" //$NON-NLS-1$
+			.equals(Activator.getContext().getProperty("eclipse.p2.reportDownloadStatistics")); //$NON-NLS-1$
+
+	/**
 	 * Maximum number of times a request for a single artifact should be tried
 	 */
 	private static final int MAX_RETRY_REQUEST = 200;
@@ -245,6 +252,9 @@ public class MirrorRequest extends ArtifactRequest {
 	 * Collect download statistics, if specified by the descriptor and the source repository
 	 */
 	private void collectStats(IArtifactDescriptor sourceDescriptor, IProgressMonitor monitor) {
+		if (!DOWNLOAD_STATS_ENABLED) {
+			return;
+		}
 		final String statsProperty = sourceDescriptor.getProperty(PROP_DOWNLOAD_STATS);
 		if (statsProperty == null)
 			return;


### PR DESCRIPTION
Add a new system property `eclipse.p2.reportDownloadStatistics` which allows to opt out of reporting download statistics to `p2.statsURI/download.stats` defined in the artifact repository.

This is especially useful in situations where the P2 director `org.eclipse.equinox.p2.director` is used to build distributions from local repository mirrors.

The download statistics reporting could take a significant amount of time and there was no way to opt out other than modifying the local repository mirror and removing the `p2.statsURI` / `download.stats` properties from `artifacts.xml`.