### PR TITLE
Stop using hamcrest-library in p2 tests.

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
@@ -54,7 +54,6 @@ Require-Bundle: org.eclipse.equinox.frameworkadmin,
  org.eclipse.equinox.p2.operations;bundle-version="2.1.0",
  org.eclipse.equinox.p2.ui.sdk.scheduler,
  org.eclipse.equinox.p2.artifact.repository;bundle-version="[1.3.0,2.0.0)",
- org.hamcrest.library;bundle-version="1.3.0",
  org.mockito.mockito-core,
  net.bytebuddy.byte-buddy
 Eclipse-RegisterBuddy: org.eclipse.equinox.p2.artifact.repository

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/JREActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/JREActionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Code 9 and others.
+ * Copyright (c) 2008, 2022 Code 9 and others.
  *
  * This
  * program and the accompanying materials are made available under the terms of
@@ -19,13 +19,11 @@ package org.eclipse.equinox.p2.tests.publisher.actions;
 import static org.eclipse.equinox.p2.tests.publisher.actions.StatusMatchers.errorStatus;
 import static org.eclipse.equinox.p2.tests.publisher.actions.StatusMatchers.okStatus;
 import static org.eclipse.equinox.p2.tests.publisher.actions.StatusMatchers.statusWithMessageWhich;
-import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
@@ -216,7 +214,7 @@ public class JREActionTest extends ActionTest {
 		// check provided capabilities
 		Collection<IProvidedCapability> fooProvidedCapabilities = foo.getProvidedCapabilities();
 		int expected = expectedProvidedPackages + expectedProvidedEEs;
-		assertThat(fooProvidedCapabilities.size(), anyOf(is(expected), greaterThan(expected)));
+		assertTrue(fooProvidedCapabilities.size() >= expected);
 	}
 
 	private void verifyConfigIU(String id, Version jreVersion) {


### PR DESCRIPTION
Not only it's one dependency less but even the assertion is easier to
understand.