### PR TITLE
Remove inclusion of sat4j in feature.xml (#28)

### DIFF
--- a/features/org.eclipse.equinox.p2.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.core.feature/feature.xml
@@ -112,20 +112,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.sat4j.core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.sat4j.pb"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.equinox.frameworkadmin"
          download-size="0"
          install-size="0"

--- a/features/org.eclipse.equinox.p2.sdk/feature.xml
+++ b/features/org.eclipse.equinox.p2.sdk/feature.xml
@@ -470,20 +470,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.sat4j.core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.sat4j.pb"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.equinox.p2.operations"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
sat4j is already included transtively by Require-Bundle for
org.eclipse.equinox.p2.director. So we don't need to add it
explicitly, and that will facilitate further verison upgrades
as the version wouldn't be statically replaced.