### PR TITLE
Some FileReader.CancelHandler jobs never terminate #36

### DIFF
--- a/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/FileReader.java
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/FileReader.java
@@ -147,7 +147,6 @@ public final class FileReader extends FileTransferJob implements IFileTransferLi
 	 * job to monitor for cancelation.
 	 */
 	protected class CancelHandler extends Job {
-		private boolean done = false;
 
 		protected CancelHandler() {
 			super(Messages.FileTransport_cancelCheck);
@@ -156,7 +155,7 @@ public final class FileReader extends FileTransferJob implements IFileTransferLi
 
 		@Override
 		public IStatus run(IProgressMonitor jobMonitor) {
-			while (!done && !jobMonitor.isCanceled()) {
+			while (FileReader.this.cancelJob == this && !jobMonitor.isCanceled()) {
 				try {
 					Thread.sleep(1000);
 				} catch (InterruptedException e) {


### PR DESCRIPTION
Terminate the job's loop when the enclosing FileReader no longer has a reference to the CancelHandler job.