### PR TITLE
The use of sat4j by p2 leaks solver instances via threads spawned by sat4j

### DIFF
--- a/bundles/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.director;singleton:=true
-Bundle-Version: 2.5.200.qualifier
+Bundle-Version: 2.5.300.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.equinox.internal.p2.director.DirectorActivator
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Projector.java
+++ b/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Projector.java
@@ -1083,4 +1083,11 @@ public class Projector {
 	public void setUserDefined(boolean containsKey) {
 		userDefinedFunction = containsKey;
 	}
+
+	public void close() {
+		if (dependencyHelper != null) {
+			dependencyHelper.reset();
+			dependencyHelper = null;
+		}
+	}
 }

--- a/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/SimplePlanner.java
+++ b/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/SimplePlanner.java
@@ -459,6 +459,7 @@ public class SimplePlanner implements IPlanner {
 			case CANCEL: {
 				IProvisioningPlan plan = engine.createPlan(profile, context);
 				plan.setStatus(s);
+				projector.close();
 				return plan;
 			}
 
@@ -469,6 +470,7 @@ public class SimplePlanner implements IPlanner {
 						|| Boolean.parseBoolean(context.getProperty(EXPLANATION))))) {
 					IProvisioningPlan plan = engine.createPlan(profile, context);
 					plan.setStatus(s);
+					projector.close();
 					return plan;
 				}
 
@@ -484,6 +486,7 @@ public class SimplePlanner implements IPlanner {
 
 				IProvisioningPlan plan = engine.createPlan(profile, context);
 				plan.setStatus(plannerStatus);
+				projector.close();
 				return plan;
 			}
 
@@ -520,13 +523,15 @@ public class SimplePlanner implements IPlanner {
 				return (IProvisioningPlan) resolutionResult;
 			}
 
-			Collection<IInstallableUnit> newState = ((Projector) resolutionResult).extractSolution();
+			Projector projector = (Projector) resolutionResult;
+			Collection<IInstallableUnit> newState = projector.extractSolution();
 			Collection<IInstallableUnit> fullState = new ArrayList<>();
 			fullState.addAll(newState);
 			newState = AttachmentHelper.attachFragments(newState.iterator(),
-					((Projector) resolutionResult).getFragmentAssociation());
+					projector.getFragmentAssociation());
 
-			IProvisioningPlan temporaryPlan = generatePlan((Projector) resolutionResult, newState, pcr, context);
+			IProvisioningPlan temporaryPlan = generatePlan(projector, newState, pcr, context);
+			projector.close();
 
 			// Create a plan for installing necessary pieces to complete the installation
 			// (e.g touchpoint actions)


### PR DESCRIPTION
Add a close method to Projector which resets the dependency helper,
which ensures that any threads are canceled.

Call the close method after the usage of the Projector has completed.

https://github.com/eclipse-equinox/p2/issues/45