### PR TITLE
Use parseInt in RepositoryTransport instead of valueOf

### DIFF
--- a/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryTransport.java
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryTransport.java
@@ -292,7 +292,7 @@ public class RepositoryTransport extends Transport {
 			String value = System.getProperty(TIMEOUT_RETRY);
 			if (value != null) {
 				try {
-					int retry = Integer.valueOf(value).intValue();
+					int retry = Integer.parseInt(value);
 					if (retry > 0) {
 						Integer retryCount = null;
 						if (socketExceptionRetry == null) {


### PR DESCRIPTION
Done with the corresponding JDT cleanup