### PR TITLE
Fix p2.tests.reconciler product

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests.reconciler.product/reconciler.product
+++ b/bundles/org.eclipse.equinox.p2.tests.reconciler.product/reconciler.product
@@ -131,7 +131,6 @@
       <plugin id="org.eclipse.osgi"/>
       <plugin id="org.eclipse.osgi.compatibility.state" fragment="true"/>
       <plugin id="org.eclipse.osgi.services"/>
-      <plugin id="org.eclipse.osgi.util"/>
       <plugin id="org.eclipse.swt"/>
       <plugin id="org.eclipse.swt.cocoa.macosx.x86_64" fragment="true"/>
       <plugin id="org.eclipse.swt.gtk.linux.x86_64" fragment="true"/>


### PR DESCRIPTION
Second attempt to fix the p2.tests.reconciler product without improving it to use features.

With the latest changes in Equinox (https://github.com/eclipse-equinox/equinox.framework/issues/40) o.e.osgi.util was replaced by the corresponding 'original' OSGi-reference bundles that are required+re-exported by o.e.osgi.util. Unfortunately the re-export does not help in plug-in based products, but 'o.e.osgi.util' seems not to be necessary so it is just removed.
