### PR TITLE
Add missing Package-Import of org.eclipse.core.runtime.preferences

### DIFF
--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.touchpoint.eclipse;singleton:=true
-Bundle-Version: 2.3.100.qualifier
+Bundle-Version: 2.3.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.touchpoint.eclipse.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -18,6 +18,7 @@ Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.5.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.xml.parsers,
+ org.eclipse.core.runtime.preferences;version="[3.0.0,4.0.0)",
  org.eclipse.equinox.frameworkadmin;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.internal.p2.artifact.processors.pgp,
  org.eclipse.equinox.internal.p2.core.helpers,


### PR DESCRIPTION
Fix a predicted compilation error in the current I-Build: https://ci.eclipse.org/releng/job/I-build-4.24/96 
(at least I have corresponding errors in my workspace).

That failure is due to the replacement of embedded OSGi sources by their 'original' OSGi bundles performed in 
https://github.com/eclipse-equinox/equinox.bundles/pull/39

@tjwatson, @laeubi that's the same scenario like in https://github.com/eclipse-equinox/equinox.bundles/pull/31
But this time it is the other way round: `org.osgi.service.prefs` was imported which seems to have made `org.eclipse.core.runtime.preferences` available for compilation.
