### PR TITLE
Move equinox.server.p2 into p2 repository

### DIFF
--- a/features/org.eclipse.equinox.p2.sdk/feature.xml
+++ b/features/org.eclipse.equinox.p2.sdk/feature.xml
@@ -43,6 +43,14 @@
          id="org.eclipse.equinox.p2.user.ui.source"
          version="0.0.0"/>
 
+   <includes
+         id="org.eclipse.equinox.server.p2"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.equinox.server.p2.source"
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.equinox.p2.installer"
          download-size="0"

--- a/features/org.eclipse.equinox.server.p2/.project
+++ b/features/org.eclipse.equinox.server.p2/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.equinox.server.p2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/org.eclipse.equinox.server.p2/.settings/org.eclipse.core.runtime.prefs
+++ b/features/org.eclipse.equinox.server.p2/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/features/org.eclipse.equinox.server.p2/build.properties
+++ b/features/org.eclipse.equinox.server.p2/build.properties
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright (c) 2011 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bin.includes = feature.xml,\
+               build.properties,\
+               feature.properties
+src.includes = build.properties,\
+               feature.properties,\
+               feature.xml

--- a/features/org.eclipse.equinox.server.p2/feature.properties
+++ b/features/org.eclipse.equinox.server.p2/feature.properties
@@ -1,0 +1,39 @@
+###############################################################################
+# Copyright (c) 2010, 2011 IBM, Composent, Inc. and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#     IBM - initial API and implementation
+###############################################################################
+# feature.properties
+# contains externalized strings for feature.xml
+# "%foo" in feature.xml corresponds to the key "foo" in this file
+# java.io.Properties file (ISO 8859-1 with "\" escapes)
+# This file should be translated.
+
+# "featureName" property - name of the feature
+featureName=p2 Server Feature
+
+# "providerName" property - name of the company that provides the feature
+providerName=Eclipse Equinox Project
+
+# "copyright" property - text of the "Feature Update Copyright"
+copyright=\
+Copyright (c) 2010 IBM, Composent, Inc. and others.\n\
+
+This program and the accompanying materials\n\
+are made available under the terms of the Eclipse Public License 2.0\n\
+which accompanies this distribution, and is available at\n\
+https://www.eclipse.org/legal/epl-2.0/
+
+SPDX-License-Identifier: EPL-2.0\n\
+\n\
+Contributors:\n\
+    IBM - initial API and implementation\n
+################ end of copyright property ####################################

--- a/features/org.eclipse.equinox.server.p2/feature.xml
+++ b/features/org.eclipse.equinox.server.p2/feature.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.equinox.server.p2"
+      label="%featureName"
+      version="1.12.500.qualifier"
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="0.0.0">
+
+   <copyright>
+      %copyright
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <requires>
+      <import feature="org.eclipse.ecf.core.feature" version="1.5.0" match="compatible"/>
+      <import feature="org.eclipse.ecf.core.ssl.feature" version="1.1.0" match="compatible"/>
+      <import feature="org.eclipse.ecf.filetransfer.feature" version="3.13.7" match="compatible"/>
+      <import feature="org.eclipse.ecf.filetransfer.httpclient5.feature" version="1.0.0" match="compatible"/>
+      <import feature="org.eclipse.ecf.filetransfer.ssl.feature" version="1.1.0" match="compatible"/>
+   </requires>
+
+   <plugin
+         id="org.eclipse.equinox.p2.artifact.repository"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.console"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.director"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.engine"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.garbagecollector"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.metadata"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.metadata.repository"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.repository"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.touchpoint.eclipse"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.touchpoint.natives"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.simpleconfigurator.manipulator"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.sat4j.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.sat4j.pb"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.frameworkadmin"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.frameworkadmin.equinox"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.preferences"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.osgi.service.prefs"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.security"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.app"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.jarprocessor"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.equinox.p2.transport.ecf"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/features/org.eclipse.equinox.server.p2/forceQualifierUpdate.txt
+++ b/features/org.eclipse.equinox.server.p2/forceQualifierUpdate.txt
@@ -1,0 +1,26 @@
+# To force a version qualifier update add the bug here
+Bug 403352 - Update all parent versions to match our build stream
+Bug 406851 - Consume new SAT4J
+Bug 406845 - Update repository of ECF in parent pom
+Bug 406845 - Update repository of ECF in parent pom (new update)
+Bug 409051 - Consume new SAT4J (2.3.5)
+Bug 409868 - pickup new build of ECF
+Bug 414457 - Comparator report indicates problem with org.eclipse.equinox.p2.ui.discovery
+Bug 416293 - build failed due to issue in Starter Kit or p2.core.feature
+Bug 423196 - Filetransfer update for Luna M5: httpcomponents 4.2.5/4.2.6
+Bug 419647 - React to ECF feature restructuring
+Bug 429353 - change "includes ECF source" to "requires" in p2.sdk
+Bug 432209 - needs to touch 3 equinox/p2 features, for qualifier change in org.sat4j.pb
+Bug 434703 - equinox-sdk "product build" fails after ECF update
+Bug 436039 - Hard to explain build failure in I20140528-0115
+Bug 436758 - Installing a bundle that requires Java 7 when running 6 with -clean cannot recover
+Bug 444669 - Update to new ECF, with new HTTPComponents
+Bug 453675 - touch org.eclipse.equinox.server.p2 for new httpcomponents
+Bug 458346 - Unusual, hard to decipher error in I-build
+Bug 462096 - Latest X-build fails on "equinox-sdk" product due to dependencies missing
+Bug 506597 - Build failure on I20161026-2000
+Bug 528810 - Compilation failure in I20171214-2000
+Bug 444188 - EclipsePreferences is not thread safe
+Bug 553238 - Unanticipated comparator errors in I20191119-1800
+Bug 568610 - 4.18 I-Build: I20201106-1800 - BUILD FAILED
+[Features] Leverage transitive inclusion and build source-features: https://github.com/eclipse-equinox/equinox.bundles/pull/20

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
     <module>features/org.eclipse.equinox.p2.sdk</module>
     <module>features/org.eclipse.equinox.p2.rcp.feature</module>
     <module>features/org.eclipse.equinox.p2.user.ui</module>
+    <module>features/org.eclipse.equinox.server.p2</module>
 
     <module>examples</module>
   </modules>
@@ -149,4 +150,5 @@
       </plugin>
     </plugins>
   </build>
+
 </project>


### PR DESCRIPTION
In https://github.com/eclipse-equinox/equinox.bundles/pull/40#issuecomment-1116670974 it was discussed to move the o.e.equinox.server.p2 feature into the p2 repository since it mainly consists of p2 plug-ins and therefore should reside in the same repository.

This the addition part of the move. The removal is performed in https://github.com/eclipse-equinox/equinox.bundles/pull/42.