### PR TITLE
Fix creation of generic-capabilities with multiple versions

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.publisher.eclipse;singleton:=true
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Activator: org.eclipse.pde.internal.publishing.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.tests;singleton:=true
-Bundle-Version: 1.8.800.qualifier
+Bundle-Version: 1.8.900.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.equinox.p2.tests.TestActivator
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.p2.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>org.eclipse.equinox</groupId>
 	<artifactId>org.eclipse.equinox.p2.tests</artifactId>
-	<version>1.8.800-SNAPSHOT</version>
+	<version>1.8.900-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>

--- a/bundles/org.eclipse.equinox.p2.tests/testData/multiVersionCapability/bundle1/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests/testData/multiVersionCapability/bundle1/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: testMultiVersionCapability
+Bundle-Version: 1.0.0.qualifier
+Provide-Capability: 
+ cap0;cap0=name0;uses:="some.other",
+ cap1;cap1=name1;version:Version="1.0";uses:="some.other",
+ cap2;cap2=name2;version:List<Version>="1.1";uses:="some.other",
+ cap3;cap3=name3;version:List<Version>="1,2.1";uses:="some.other"


### PR DESCRIPTION
This PR aims to fix the flawed read/processing of provided Generic-capbailities that have a list of versions, which was discovered in https://github.com/eclipse-equinox/equinox.framework/pull/44#issuecomment-1116711351.

I think I should add some tests for this.
Furthermore I would like to test this fix first locally with Tycho as described here:
https://github.com/eclipse/tycho/blob/master/CONTRIBUTING.md#building-tycho-against-a-locally-built-version-of-p2