### PR TITLE
Use try-with-resources to close Stream opened by Files.list in SimpleBackupStore

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/core/BackupTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/core/BackupTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.stream.Stream;
 import org.eclipse.equinox.internal.p2.touchpoint.natives.SimpleBackupStore;
 import org.eclipse.equinox.p2.tests.AbstractProvisioningTest;
 
@@ -147,7 +148,10 @@ public class BackupTest extends AbstractProvisioningTest {
 
 		store.restore();
 		assertFileContent("Restore of A failed - not original content", aTxt.toFile(), "A");
-		assertTrue("Empty directory not restored ok", Files.isDirectory(bDir) && Files.list(bDir).count() == 0);
+		assertTrue("Empty directory not restored ok", Files.isDirectory(bDir));
+		try (Stream<Path> s = Files.list(bDir)) {
+			assertFalse("Empty directory not restored ok", s.findAny().isPresent());
+		}
 		assertNoGarbage(store);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.touchpoint.natives;singleton:=true
-Bundle-Version: 1.4.300.qualifier
+Bundle-Version: 1.4.400.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.touchpoint.natives.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/SimpleBackupStore.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/SimpleBackupStore.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
+import java.util.stream.Stream;
 import org.eclipse.osgi.util.NLS;
 
 /**
@@ -271,9 +272,11 @@ public class SimpleBackupStore implements IBackupStore {
 			throw new IllegalArgumentException(NLS.bind(Messages.BackupStore_not_a_directory, file.getAbsolutePath()));
 		}
 
-		if (Files.list(path).count() > 0) {
-			throw new IllegalArgumentException(
-					NLS.bind(Messages.BackupStore_directory_not_empty, file.getAbsolutePath()));
+		try (Stream<Path> s = Files.list(path)) {
+			if (s.count() > 0) {
+				throw new IllegalArgumentException(
+						NLS.bind(Messages.BackupStore_directory_not_empty, file.getAbsolutePath()));
+			}
 		}
 
 		return moveDirToBackup(path);

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/SimpleBackupStore.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/SimpleBackupStore.java
@@ -273,7 +273,7 @@ public class SimpleBackupStore implements IBackupStore {
 		}
 
 		try (Stream<Path> s = Files.list(path)) {
-			if (s.count() > 0) {
+			if (s.findAny().isPresent()) {
 				throw new IllegalArgumentException(
 						NLS.bind(Messages.BackupStore_directory_not_empty, file.getAbsolutePath()));
 			}
@@ -508,12 +508,13 @@ public class SimpleBackupStore implements IBackupStore {
 	}
 
 	/**
-	 * Makes sure a directory exists in the backup store without touching the original directory content
+	 * Makes sure a directory exists in the backup store without touching the
+	 * original directory content
 	 * 
 	 * @param path
 	 * 
-	 * @return false if the directory is already created in the backup store, false if a placeholder had
-	 *         to be created and backed up.
+	 * @return false if the directory is already created in the backup store, false
+	 *         if a placeholder had to be created and backed up.
 	 * 
 	 * @throws IOException
 	 */
@@ -699,12 +700,10 @@ public class SimpleBackupStore implements IBackupStore {
 				try {
 					Files.delete(buDir);
 				} catch (DirectoryNotEmptyException e) {
-					String children = Files.list(buDir)
-							.map(p -> p.relativize(buDir))
-							.map(Path::toString)
+					String children = Files.list(buDir).map(p -> p.relativize(buDir)).map(Path::toString)
 							.collect(joining(",")); //$NON-NLS-1$
-					unrestorable.put(buDir, new IOException(String.format(
-							"Directory %s not empty: %s", buDir, children, e))); //$NON-NLS-1$
+					unrestorable.put(buDir,
+							new IOException(String.format("Directory %s not empty: %s", buDir, children, e))); //$NON-NLS-1$
 				} catch (IOException e) {
 					unrestorable.put(buDir, e);
 				}

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/SimpleBackupStore.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/SimpleBackupStore.java
@@ -700,10 +700,11 @@ public class SimpleBackupStore implements IBackupStore {
 				try {
 					Files.delete(buDir);
 				} catch (DirectoryNotEmptyException e) {
-					String children = Files.list(buDir).map(p -> p.relativize(buDir)).map(Path::toString)
-							.collect(joining(",")); //$NON-NLS-1$
-					unrestorable.put(buDir,
-							new IOException(String.format("Directory %s not empty: %s", buDir, children, e))); //$NON-NLS-1$
+					try (Stream<Path> s = Files.list(buDir)) {
+						String children = s.map(p -> p.relativize(buDir)).map(Path::toString).collect(joining(",")); //$NON-NLS-1$
+						unrestorable.put(buDir,
+								new IOException(String.format("Directory %s not empty: %s", buDir, children, e))); //$NON-NLS-1$
+					}
 				} catch (IOException e) {
 					unrestorable.put(buDir, e);
 				}


### PR DESCRIPTION
This is a fix for Bug 579807

https://bugs.eclipse.org/bugs/show_bug.cgi?id=579807.

The change in SimpleBackupStore to use the Java NIO API does not close the stream opened by a call to Files.list. This can cause subsequent operations on the directory to fail. Specifically in CleanupZipAction the directory can still exists after deletion but in a inaccessible state.

On machines where this issue occurs the existing test case CleanupzipActionTest#testDirectoryCleanup will fail. In my experience these are Windows Server 2016 instances on AWS.