### PR TITLE
WIP: POM and product version changes for 4.25 release

### DIFF
--- a/bundles/org.eclipse.equinox.frameworkadmin.test/pom.xml
+++ b/bundles/org.eclipse.equinox.frameworkadmin.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
     <groupId>org.eclipse</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.p2.director.app/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.director.app/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2</groupId>
     <artifactId>rt.equinox.p2</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.p2.installer/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.installer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2</groupId>
     <artifactId>rt.equinox.p2</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.p2.reconciler.dropins/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.reconciler.dropins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2</groupId>
     <artifactId>rt.equinox.p2</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.p2.tests.discovery/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests.discovery/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
     <groupId>org.eclipse</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.p2.tests.reconciler.product/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests.reconciler.product/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
-		<version>4.24.0-SNAPSHOT</version>
+		<version>4.25.0-SNAPSHOT</version>
 		<relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
 	</parent>
 

--- a/bundles/org.eclipse.equinox.p2.tests.ui/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
 		<groupId>org.eclipse</groupId>
-		<version>4.24.0-SNAPSHOT</version>
+		<version>4.25.0-SNAPSHOT</version>
 		<relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
 	</parent>
 

--- a/bundles/org.eclipse.equinox.p2.tests.verifier/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests.verifier/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
     <groupId>org.eclipse</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.p2.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
-		<version>4.24.0-SNAPSHOT</version>
+		<version>4.25.0-SNAPSHOT</version>
 		<relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
 	</parent>
 

--- a/bundles/org.eclipse.equinox.p2.ui.admin.rcp/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.ui.admin.rcp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2</groupId>
     <artifactId>rt.equinox.p2</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/examples/org.eclipse.equinox.p2.examples.rcp.discovery/pom.xml
+++ b/examples/org.eclipse.equinox.p2.examples.rcp.discovery/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2</groupId>
     <artifactId>org.eclipse.equinox.p2.examples</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/examples/org.eclipse.equinox.p2.examples.rcp.prestartupdate/pom.xml
+++ b/examples/org.eclipse.equinox.p2.examples.rcp.prestartupdate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2</groupId>
     <artifactId>org.eclipse.equinox.p2.examples</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.eclipse.equinox.p2.examples.rcp.prestartupdate</artifactId>

--- a/examples/org.eclipse.equinox.p2.examples.rcp.sdkbundlevisibility/pom.xml
+++ b/examples/org.eclipse.equinox.p2.examples.rcp.sdkbundlevisibility/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2</groupId>
     <artifactId>org.eclipse.equinox.p2.examples</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.eclipse.equinox.p2.examples.rcp.sdkbundlevisibility</artifactId>

--- a/examples/org.eclipse.equinox.p2.examples.rcp.sdknoautoupdates/pom.xml
+++ b/examples/org.eclipse.equinox.p2.examples.rcp.sdknoautoupdates/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2</groupId>
     <artifactId>org.eclipse.equinox.p2.examples</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/examples/org.eclipse.equinox.p2.examples.rcp.sdkui/pom.xml
+++ b/examples/org.eclipse.equinox.p2.examples.rcp.sdkui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2</groupId>
     <artifactId>org.eclipse.equinox.p2.examples</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2</groupId>
     <artifactId>rt.equinox.p2</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.eclipse.equinox.p2.examples</artifactId>

--- a/org.eclipse.equinox.p2.releng/default.target
+++ b/org.eclipse.equinox.p2.releng/default.target
@@ -6,7 +6,7 @@
 <unit id="org.eclipse.platform.sdk" version="0.0.0"/>
 <unit id="org.eclipse.core.tests.harness" version="0.0.0"/>
 <unit id="org.eclipse.test.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.24-I-builds"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.25-I-builds"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.bouncycastle.bcprov" version="0.0.0"/>

--- a/org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent/pom.xml
+++ b/org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent/pom.xml
@@ -14,7 +14,7 @@
   <parent>
 	<groupId>org.eclipse.equinox.p2</groupId>
 	<artifactId>rt.equinox.p2</artifactId>
-	<version>4.24.0-SNAPSHOT</version>
+	<version>4.25.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
   </parent>
   <groupId>org.eclipse</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
Tracked in [eclipse.platform.releng.aggregator#290](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/290) and [eclipse.platform.releng.aggregator#291](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/291)

Need to wait to merge until after 4.24 Release