### PR TITLE
Remove the help icon from the restart after installation dialog

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui;singleton:=true
-Bundle-Version: 2.7.500.qualifier
+Bundle-Version: 2.7.600.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.ProvUIActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ApplyProfileChangesDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ApplyProfileChangesDialog.java
@@ -31,31 +31,38 @@ public class ApplyProfileChangesDialog extends MessageDialog {
 	public static final int PROFILE_IGNORE = 0;
 	public static final int PROFILE_APPLYCHANGES = 1;
 	public static final int PROFILE_RESTART = 2;
-	private final static String[] yesNo = new String[] {ProvUIMessages.ApplyProfileChangesDialog_Restart, IDialogConstants.NO_LABEL};
-	private final static String[] yesNoApply = new String[] {ProvUIMessages.ApplyProfileChangesDialog_Restart, ProvUIMessages.ApplyProfileChangesDialog_NotYet, ProvUIMessages.ApplyProfileChangesDialog_ApplyChanges};
+	private final static String[] yesNo = new String[] { ProvUIMessages.ApplyProfileChangesDialog_Restart,
+			IDialogConstants.NO_LABEL };
+	private final static String[] yesNoApply = new String[] { ProvUIMessages.ApplyProfileChangesDialog_Restart,
+			ProvUIMessages.ApplyProfileChangesDialog_NotYet, ProvUIMessages.ApplyProfileChangesDialog_ApplyChanges };
 
 	private int returnCode = PROFILE_IGNORE;
 
 	private ApplyProfileChangesDialog(Shell parent, String title, String message, boolean mustRestart) {
 		super(parent, title, null, // accept the default window icon
-				message, QUESTION, mustRestart ? yesNo : yesNoApply, 0); // yes is the default
+				message, NONE, mustRestart ? yesNo : yesNoApply, 0); // yes is the default
 	}
 
 	/**
 	 * Prompt the user for restart or apply profile changes.
 	 *
-	 * @param parent the parent shell of the dialog, or <code>null</code> if none
+	 * @param parent      the parent shell of the dialog, or <code>null</code> if
+	 *                    none
 	 * @param mustRestart indicates whether the user must restart to get the
-	 * 		changes.  If <code>false</code>, then the user may choose to apply
-	 * 		the changes to the running profile rather than restarting.
-	 * @return one of PROFILE_IGNORE (do nothing), PROFILE_APPLYCHANGES
-	 * 		(attempt to apply the changes), or PROFILE_RESTART (restart the system).
+	 *                    changes. If <code>false</code>, then the user may choose
+	 *                    to apply the changes to the running profile rather than
+	 *                    restarting.
+	 * @return one of PROFILE_IGNORE (do nothing), PROFILE_APPLYCHANGES (attempt to
+	 *         apply the changes), or PROFILE_RESTART (restart the system).
 	 */
 	public static int promptForRestart(Shell parent, boolean mustRestart) {
 		String title = ProvUIMessages.PlatformUpdateTitle;
 		IProduct product = Platform.getProduct();
-		String productName = product != null && product.getName() != null ? product.getName() : ProvUIMessages.ApplicationInRestartDialog;
-		String message = NLS.bind(mustRestart ? ProvUIMessages.PlatformRestartMessage : ProvUIMessages.OptionalPlatformRestartMessage, productName);
+		String productName = product != null && product.getName() != null ? product.getName()
+				: ProvUIMessages.ApplicationInRestartDialog;
+		String message = NLS.bind(
+				mustRestart ? ProvUIMessages.PlatformRestartMessage : ProvUIMessages.OptionalPlatformRestartMessage,
+				productName);
 		ApplyProfileChangesDialog dialog = new ApplyProfileChangesDialog(parent, title, message, mustRestart);
 		if (dialog.open() == Window.CANCEL)
 			return PROFILE_IGNORE;
@@ -70,17 +77,17 @@ public class ApplyProfileChangesDialog extends MessageDialog {
 	@Override
 	protected void buttonPressed(int id) {
 		switch (id) {
-			case 0:
-				// YES
-				returnCode = PROFILE_RESTART;
-				break;
-			case 1:
-				// NO
-				returnCode = PROFILE_IGNORE;
-				break;
-			default:
-				returnCode = PROFILE_APPLYCHANGES;
-				break;
+		case 0:
+			// YES
+			returnCode = PROFILE_RESTART;
+			break;
+		case 1:
+			// NO
+			returnCode = PROFILE_IGNORE;
+			break;
+		default:
+			returnCode = PROFILE_APPLYCHANGES;
+			break;
 		}
 
 		super.buttonPressed(id);

--- a/features/org.eclipse.equinox.p2.rcp.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.rcp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.rcp.feature"
       label="%featureName"
-      version="1.4.1600.qualifier"
+      version="1.4.1700.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.sdk/feature.xml
+++ b/features/org.eclipse.equinox.p2.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.sdk"
       label="%featureName"
-      version="3.11.1600.qualifier"
+      version="3.11.1700.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.user.ui/feature.xml
+++ b/features/org.eclipse.equinox.p2.user.ui/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.user.ui"
       label="%featureName"
-      version="2.4.1600.qualifier"
+      version="2.4.1700.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Operating system Ui guidelines do not recommend the usage of the help
icon in a dialog. For example check the screenshots in the Windows
guidelines for dialogs.

Operating System UI Guidelines

Windows UI guidence
https://docs.microsoft.com/en-us/windows/apps/design/controls/dialogs-and-flyouts/dialogs

Gnome UI guidence
https://developer.gnome.org/hig/patterns/feedback/dialogs.html

Mac UI guidence
https://developer.apple.com/design/human-interface-guidelines/components/presentation/alerts/