### PR TITLE
Remove the help icon from the revert profile page

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RevertProfilePage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RevertProfilePage.java
@@ -272,15 +272,21 @@ public class RevertProfilePage extends InstallationPage implements ICopyable {
 		revertAction = new Action() {
 			@Override
 			public void run() {
-				int result = MessageDialog.open(MessageDialog.QUESTION, getShell(), ProvUIMessages.RevertDialog_Title,
-						ProvUIMessages.RevertDialog_ConfirmRestartMessage, SWT.NONE,
-						ProvUIMessages.RevertProfilePage_RevertLabel, ProvUIMessages.RevertDialog_CancelButtonLabel);
-				if (result != Window.OK)
+				PlainMessageDialog dialog = PlainMessageDialog.getBuilder(getShell(), ProvUIMessages.RevertDialog_Title)
+						.message(ProvUIMessages.RevertDialog_ConfirmRestartMessage)
+						.buttonLabels(java.util.List.of(ProvUIMessages.RevertProfilePage_RevertLabel,
+								ProvUIMessages.RevertDialog_CancelButtonLabel))
+						.build();
+
+				int result = dialog.open();
+				if (result != Window.OK) {
 					return;
+				}
 				boolean finish = revert();
 				if (finish) {
 					getPageContainer().closeModalContainers();
 				}
+
 			}
 		};
 		revertAction.setText(ProvUIMessages.RevertProfilePage_RevertLabel);


### PR DESCRIPTION
To trigger this dialog use Help -> About -> Installation Details ->
Installation History and select an older state and press the Revert
button.

Operating system Ui guidelines do not recommend the usage of the help
icon in a dialog. For example check the screenshots in the Windows
guidelines for dialogs.

Operating System UI Guidelines

Windows UI guidence
https://docs.microsoft.com/en-us/windows/apps/design/controls/dialogs-and-flyouts/dialogs

Gnome UI guidence
https://developer.gnome.org/hig/patterns/feedback/dialogs.html

Mac UI guidence
https://developer.apple.com/design/human-interface-guidelines/components/presentation/alerts/