### PR TITLE
Force qualifier update for p2.core.feature

### DIFF
--- a/features/org.eclipse.equinox.p2.core.feature/forceQualifierUpdate.txt
+++ b/features/org.eclipse.equinox.p2.core.feature/forceQualifierUpdate.txt
@@ -24,4 +24,4 @@ Bug 574602 - Eclipse 4.21 prerequisites: Orbit
 Bug 574602 - Eclipse 4.21 prerequisites: Orbit
 Bug 576389 - Touch bundle for org.bouncycastle.bcprov version update
 Bug 578120 - Update to latest Orbit - bouncycastle and mina sshd updates
-Update to latest Orbit - bouncycastle
+Use deps from Orbit


### PR DESCRIPTION
As some included bundles have changed with the move away from Orbit to
Maven.