### PR TITLE
Use Tycho-CI-Friendly-Versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 .META-INF_*
 pom.tycho
 .tycho-consumer-pom.xml
+apiAnalyzer-workspace/

--- a/bundles/org.eclipse.equinox.frameworkadmin.test/pom.xml
+++ b/bundles/org.eclipse.equinox.frameworkadmin.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
     <groupId>org.eclipse</groupId>
-    <version>4.26.0-SNAPSHOT</version>
+    <version>${releaseVersion}${qualifier}</version>
     <relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.p2.tests.discovery/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests.discovery/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
     <groupId>org.eclipse</groupId>
-    <version>4.26.0-SNAPSHOT</version>
+    <version>${releaseVersion}${qualifier}</version>
     <relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.p2.tests.reconciler.product/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests.reconciler.product/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
-		<version>4.26.0-SNAPSHOT</version>
+		<version>${releaseVersion}${qualifier}</version>
 		<relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
 	</parent>
 

--- a/bundles/org.eclipse.equinox.p2.tests.ui/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
 		<groupId>org.eclipse</groupId>
-		<version>4.26.0-SNAPSHOT</version>
+                <version>${releaseVersion}${qualifier}</version>
 		<relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
 	</parent>
 

--- a/bundles/org.eclipse.equinox.p2.tests.verifier/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests.verifier/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
     <groupId>org.eclipse</groupId>
-    <version>4.26.0-SNAPSHOT</version>
+    <version>${releaseVersion}${qualifier}</version>
     <relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.p2.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.eclipse</groupId>
 		<artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>
-		<version>4.26.0-SNAPSHOT</version>
+		<version>${releaseVersion}${qualifier}</version>
 		<relativePath>../../org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent</relativePath>
 	</parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2</groupId>
     <artifactId>rt.equinox.p2</artifactId>
-    <version>4.26.0-SNAPSHOT</version>
+    <version>${releaseVersion}${qualifier}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.eclipse.equinox.p2.examples</artifactId>

--- a/org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent/pom.xml
+++ b/org.eclipse.equinox.p2.releng/org.eclipse.equinox.p2.tests-parent/pom.xml
@@ -14,8 +14,8 @@
   <parent>
 	<groupId>org.eclipse.equinox.p2</groupId>
 	<artifactId>rt.equinox.p2</artifactId>
-	<version>4.26.0-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+	<version>${releaseVersion}${qualifier}</version>
+    <relativePath>../..</relativePath>
   </parent>
   <groupId>org.eclipse</groupId>
   <artifactId>org.eclipse.equinox.p2.tests-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,16 @@
   <groupId>org.eclipse.equinox.p2</groupId>
   <artifactId>rt.equinox.p2</artifactId>
   <packaging>pom</packaging>
+  <version>${releaseVersion}${qualifier}</version>
 
   <properties>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-equinox/p2.git</tycho.scmUrl>
+    <releaseVersion>4.26.0</releaseVersion>
+    <!-- Defines the default Qualifier if no format is given-->
+    <!-- can be overriden with -Dtycho.buildqualifier.format=yyyyMMddHHmm for a dynamic qualifier or -Dqualifier=abcd for a static value -->
+    <qualifier>-SNAPSHOT</qualifier>
+    <!-- disabled for now, should be enabled later! -->
+    <addMavenDescriptor>false</addMavenDescriptor>
   </properties>
 
   <!-- 


### PR DESCRIPTION
This will make it easier to publish correct maven-metadata and deploy to
eclipse-maven-repository.

See https://github.com/eclipse/tycho/blob/master/RELEASE_NOTES.md#enhanced-support-for-maven-ci-friendly-versions

Also enables controlling the inclusion of pom