### PR TITLE
Add consistent null checks to ServiceHelper

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.core;singleton:=true
-Bundle-Version: 2.9.100.qualifier
+Bundle-Version: 2.9.200.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.equinox.internal.p2.core.Activator
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/ServiceHelper.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/ServiceHelper.java
@@ -38,11 +38,12 @@ public class ServiceHelper {
 	}
 
 	public static <T> T getService(BundleContext context, Class<T> clazz, String filter) {
+		if (context == null)
+			return null;
 		Collection<ServiceReference<T>> references;
 		try {
 			references = context.getServiceReferences(clazz, filter);
 		} catch (InvalidSyntaxException e) {
-			// TODO Auto-generated catch block
 			return null;
 		}
 		if (references.isEmpty())
@@ -74,11 +75,12 @@ public class ServiceHelper {
 	}
 
 	public static Object getService(BundleContext context, String name, String filter) {
+		if (context == null)
+			return null;
 		ServiceReference<?>[] references;
 		try {
 			references = context.getServiceReferences(name, filter);
 		} catch (InvalidSyntaxException e) {
-			// TODO Auto-generated catch block
 			return null;
 		}
 		if (references == null || references.length == 0)


### PR DESCRIPTION
currently only half of the methods do a null check for the bundle
context the other simply run ino a NPE. This adds the missing checks,
see also https://github.com/eclipse-equinox/p2/issues/100