### PR TITLE
Remove unusable o.e.equinox.p2.director.app.product

### DIFF
--- a/bundles/org.eclipse.equinox.p2.director.app/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.director.app/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.director.app;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.director.app.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.director.app/plugin.xml
+++ b/bundles/org.eclipse.equinox.p2.director.app/plugin.xml
@@ -9,9 +9,6 @@
 			<run class="org.eclipse.equinox.internal.p2.director.app.DirectorApplication"/> 
 		</application> 
 	</extension>
-	<extension id="product" point="org.eclipse.core.runtime.products">
-		<product application="org.eclipse.equinox.p2.director.app.application" name="Equinox Provisioning Director" />
-	</extension> 
 	<extension id="org.eclipse.equinox.p2.director.product" point="org.eclipse.core.runtime.products">
 		<product application="org.eclipse.equinox.p2.director" name="Equinox P2 Director" />
 	</extension> 

--- a/bundles/org.eclipse.equinox.p2.director.app/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.director.app/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.p2.director.app</artifactId>
-  <version>1.2.100-SNAPSHOT</version>
+  <version>1.2.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
The application used of the mentioned product has been removed with [Bug 308653](https://bugs.eclipse.org/bugs/show_bug.cgi?id=308653) respectively [Bug 291475](https://bugs.eclipse.org/bugs/show_bug.cgi?id=291475). Due to some back and forth removing that application it looks like the mentioned product has been forgotten to be removed eventually.