### PR TITLE
Revert "Use bouncycastle from Maven Central"

### DIFF
--- a/features/org.eclipse.equinox.p2.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.core.feature/feature.xml
@@ -204,14 +204,14 @@
          unpack="false"/>
 
    <plugin
-         id="bcpg"
+         id="org.bouncycastle.bcpg"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
    <plugin
-         id="bcprov"
+         id="org.bouncycastle.bcprov"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
This reverts commit 2253646b033770abf40d67823759efe1370d1863.
BouncyCastle from Central has jarsignature in with unrooted certificate,
currently causing Trust dialog to popup.
Will restore to use Maven Central when this issue is fixed.