### PR TITLE
Add package-info and annotations to p2.core

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/IAgentLocation.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/IAgentLocation.java
@@ -14,6 +14,7 @@
 package org.eclipse.equinox.p2.core;
 
 import java.net.URI;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * An instance of this service represents the location of a provisioning agent's
@@ -23,11 +24,12 @@ import java.net.URI;
  * @noextend This interface is not intended to be extended by clients.
  * @since 2.0
  */
+@ProviderType
 public interface IAgentLocation {
 	/**
 	 * Service name constant for the agent location service.
 	 */
-	public static final String SERVICE_NAME = IAgentLocation.class.getName();
+	String SERVICE_NAME = IAgentLocation.class.getName();
 
 	/**
 	 * Returns the location where the bundle with the given namespace
@@ -35,13 +37,13 @@ public interface IAgentLocation {
 	 * @param namespace The namespace of the bundle storing the data
 	 * @return The data location
 	 */
-	public URI getDataArea(String namespace);
+	URI getDataArea(String namespace);
 
 	/**
 	 * Returns the root {@link URI} of the agent metadata.
 	 *
 	 * @return the location of the agent metadata
 	 */
-	public URI getRootLocation();
+	URI getRootLocation();
 
 }

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/IPool.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/IPool.java
@@ -13,18 +13,24 @@
  *******************************************************************************/
 package org.eclipse.equinox.p2.core;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
- * A Pool allows semantically equivalent objects to be shared.  To be useful, objects added to the pool should implement
- * a meaningful equals() method.
+ * A Pool allows semantically equivalent objects to be shared. To be useful,
+ * objects added to the pool should implement a meaningful equals() method.
  * <p>
- * Care must be taken by users that object sharing is appropriate for their application.  It is easy
- * to "over share" objects leading to unexpected and difficult to debug behaviour.
- * </p><p>
+ * Care must be taken by users that object sharing is appropriate for their
+ * application. It is easy to "over share" objects leading to unexpected and
+ * difficult to debug behavior.
+ * </p>
+ * <p>
  * This interface is not intended to be implemented by clients.
  * </p>
+ *
  * @noimplement This interface is not intended to be implemented by clients.
  * @since 2.1
  */
+@ProviderType
 public interface IPool<T> {
 
 	/**
@@ -35,5 +41,5 @@ public interface IPool<T> {
 	 * @param newObject the object to add
 	 * @return a shared object that is equal to the given object or <code>null</code>
 	 */
-	public abstract T add(T newObject);
+	T add(T newObject);
 }

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/IProvisioningAgent.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/IProvisioningAgent.java
@@ -15,6 +15,7 @@
 package org.eclipse.equinox.p2.core;
 
 import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * A provisioning agent is comprised of a modular, extensible set of related services.
@@ -31,6 +32,7 @@ import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
  * @noextend This interface is not intended to be extended by clients.
  * @since 2.0
  */
+@ProviderType
 public interface IProvisioningAgent {
 	/**
 	 * Service name constant for the agent service. Note that an agent obtained directly
@@ -38,22 +40,22 @@ public interface IProvisioningAgent {
 	 * obtain an agent for a different system the {@link IProvisioningAgentProvider}
 	 * service must be used.
 	 */
-	public static final String SERVICE_NAME = IProvisioningAgent.class.getName();
+	String SERVICE_NAME = IProvisioningAgent.class.getName();
 
-	public static final String INSTALLER_AGENT = "org.eclipse.equinox.p2.installer.agent"; //$NON-NLS-1$
-	public static final String INSTALLER_PROFILEID = "org.eclipse.equinox.p2.installer.profile.id"; //$NON-NLS-1$
+	String INSTALLER_AGENT = "org.eclipse.equinox.p2.installer.agent"; //$NON-NLS-1$
+	String INSTALLER_PROFILEID = "org.eclipse.equinox.p2.installer.profile.id"; //$NON-NLS-1$
 
 	/**
 	 * When running in "shared mode", this allows to retrieve from the IProvisioningAgent the agent representing what is in the shared location aka the base
 	 * @since 2.3
 	 */
-	public static final String SHARED_BASE_AGENT = "org.eclipse.equinox.shared.base.agent"; //$NON-NLS-1$
+	String SHARED_BASE_AGENT = "org.eclipse.equinox.shared.base.agent"; //$NON-NLS-1$
 
 	/**
 	 * When running in "shared mode", this allows to retrieve from the IProvisioningAgent identified by {@link #SHARED_BASE_AGENT} the current agent
 	 * @since 2.3
 	 */
-	public static final String SHARED_CURRENT_AGENT = "org.eclipse.equinox.shared.current.agent"; //$NON-NLS-1$
+	String SHARED_CURRENT_AGENT = "org.eclipse.equinox.shared.current.agent"; //$NON-NLS-1$
 	/**
 	 * Service property identifying whether an agent is the default agent.
 	 *
@@ -65,14 +67,14 @@ public interface IProvisioningAgent {
 	 * has any other value, then the service is not the agent for the currently running system.
 	 * </p>
 	 */
-	public static final String SERVICE_CURRENT = "agent.current"; //$NON-NLS-1$
+	String SERVICE_CURRENT = "agent.current"; //$NON-NLS-1$
 
 	/**
 	 * Returns the service with the given service name, or <code>null</code>
 	 * if no such service is available in this agent.
 	 * @exception IllegalStateException if this agent has been stopped
 	 */
-	public Object getService(String serviceName);
+	Object getService(String serviceName);
 
 	/**
 	 * Returns the service with the given service name, or <code>null</code>
@@ -82,7 +84,7 @@ public interface IProvisioningAgent {
 	 * @since 2.6
 	 */
 	@SuppressWarnings("unchecked")
-	public default <T> T getService(Class<T> key) {
+	default <T> T getService(Class<T> key) {
 		return (T) getService(key.getName());
 	}
 
@@ -93,7 +95,7 @@ public interface IProvisioningAgent {
 	 * @param service The service implementation
 	 * @exception IllegalStateException if this agent has been stopped
 	 */
-	public void registerService(String serviceName, Object service);
+	void registerService(String serviceName, Object service);
 
 	/**
 	 * Stops the provisioning agent. This causes services provided by this
@@ -105,7 +107,7 @@ public interface IProvisioningAgent {
 	 * by invoking {@link IProvisioningAgentProvider#createAgent(java.net.URI)}.
 	 * </p>
 	 */
-	public void stop();
+	void stop();
 
 	/**
 	 * Unregisters a service that has previously been registered with this
@@ -115,6 +117,6 @@ public interface IProvisioningAgent {
 	 * @param serviceName The name of the service to unregister
 	 * @param service The service implementation to unregister.
 	 */
-	public void unregisterService(String serviceName, Object service);
+	void unregisterService(String serviceName, Object service);
 
 }

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/IProvisioningAgentProvider.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/IProvisioningAgentProvider.java
@@ -14,18 +14,20 @@
 package org.eclipse.equinox.p2.core;
 
 import java.net.URI;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * An OSGi service that is used to create or obtain instances of an
  * {@link IProvisioningAgent}.
  * @since 2.0
  */
+@ProviderType
 public interface IProvisioningAgentProvider {
 
 	/**
 	 * Service name constant for the agent provider service.
 	 */
-	public static final String SERVICE_NAME = IProvisioningAgentProvider.class.getName();
+	String SERVICE_NAME = IProvisioningAgentProvider.class.getName();
 
 	/**
 	 * Creates a provisioning agent who metadata is stored at the given location.
@@ -46,5 +48,5 @@ public interface IProvisioningAgentProvider {
 	 * </ul>
 	 * @see IProvisioningAgent#stop()
 	 */
-	public IProvisioningAgent createAgent(URI location) throws ProvisionException;
+	IProvisioningAgent createAgent(URI location) throws ProvisionException;
 }

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/package-info.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/package-info.java
@@ -1,0 +1,20 @@
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("2.8.0")
+/**
+ * Provides core support for interacting with a p2-based provisioning system
+ * Package Specification
+ * 
+ * This package specifies API for creating, using, and extending a provisioning
+ * system. A provisioning agent ties together a set of related services that
+ * work together to implement a provisioning system. For end users of the
+ * provisioning system, they simply instantiate or obtain an agent and get the
+ * services they require from the agent. Extenders can register a factory for
+ * adding new services to the system, or add services directly to an agent.
+ * 
+ * This package also provides some basic utility classes that are common across
+ * large parts of the system.
+ * 
+ * @since 2.0
+ */
+package org.eclipse.equinox.p2.core;
+

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/spi/IAgentService.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/spi/IAgentService.java
@@ -14,19 +14,21 @@
 package org.eclipse.equinox.p2.core.spi;
 
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.osgi.annotation.versioning.ConsumerType;
 
 /**
  * Services created by {@link IAgentServiceFactory} objects can optionally implement
  * this interface to participate in the agent lifecycle.
  * @since 2.0
  */
+@ConsumerType
 public interface IAgentService {
 	/**
 	 * This method is invoked when a service is added to an agent. This can occur
 	 * either because a client looked up the service and it was lazily instantiated by
 	 * the agent, or because the service was registered manually via {@link IProvisioningAgent#registerService(String, Object)}.
 	 */
-	public void start();
+	void start();
 
 	/**
 	 * This method is invoked when a service is removed from an agent. This can occur
@@ -36,6 +38,6 @@ public interface IAgentService {
 	 * Services must not attempt to obtain further services from their agent while
 	 * stopping, as some required services may no longer be available.
 	 */
-	public void stop();
+	void stop();
 
 }

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/spi/IAgentServiceFactory.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/spi/IAgentServiceFactory.java
@@ -14,6 +14,7 @@
 package org.eclipse.equinox.p2.core.spi;
 
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.osgi.annotation.versioning.ConsumerType;
 
 /**
  * A factory for creating a service that forms part of a provisioning agent instance.
@@ -21,16 +22,17 @@ import org.eclipse.equinox.p2.core.IProvisioningAgent;
  * can be obtained by a provisioning agent.
  * @since 2.0
  */
+@ConsumerType
 public interface IAgentServiceFactory {
 	/**
 	 * The service name for the factory service.
 	 */
-	public static final String SERVICE_NAME = IAgentServiceFactory.class.getName();
+	String SERVICE_NAME = IAgentServiceFactory.class.getName();
 
 	/**
 	 * The service property specifying the name of the service created by this factory.
 	 */
-	public static final String PROP_CREATED_SERVICE_NAME = "p2.agent.servicename"; //$NON-NLS-1$
+	String PROP_CREATED_SERVICE_NAME = "p2.agent.servicename"; //$NON-NLS-1$
 
 	/**
 	 * Instantiates a service instance for the given provisioning agent.
@@ -38,5 +40,5 @@ public interface IAgentServiceFactory {
 	 * @param agent The agent this service will belong to
 	 * @return The created service
 	 */
-	public Object createService(IProvisioningAgent agent);
+	Object createService(IProvisioningAgent agent);
 }

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/spi/package-info.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/spi/package-info.java
@@ -1,0 +1,3 @@
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("2.1.0")
+package org.eclipse.equinox.p2.core.spi;


### PR DESCRIPTION
Now PDE supports the OSGi Bundle/Version annotations, we can start to
use them in P2 to enable advanced tooling options

FYI @iloveeclipse as you wondered how this kind of stuff could be used.