### PR TITLE
Update the matcher pattern according to new ApiTools output

### DIFF
--- a/.github/matcher.json
+++ b/.github/matcher.json
@@ -1,26 +1,14 @@
 {
   "problemMatcher": [
     {
-      "owner": "api-errors",
-      "severity": "error",
+      "owner": "api-problems",
       "pattern": [
         {
-          "regexp": "^.*on\\:\\s*\\/(.+\\.java),.*lineNumber:\\s*(\\d+).*message:\\s*(.*),\\s*messagearguments.*severity:\\s2.*sourceId:\\sAPI Tools.*\\]$",
-          "file": 1,
+          "regexp": "^\\[API\\s(\\w+)\\].*line\\s(\\d+):\\s(.+)\\(location:\\s(.+)\\)$",
+          "severity": 1,
           "line": 2,
-          "message": 3
-        }
-      ]
-    },
-    {
-      "owner": "api-warnings",
-      "severity": "warning",
-      "pattern": [
-        {
-          "regexp": "^.*on\\:\\s*\\/(.+\\.java),.*lineNumber:\\s*(\\d+).*message:\\s*(.*),\\s*messagearguments.*severity:\\s1.*sourceId:\\sAPI Tools.*\\]$",
-          "file": 1,
-          "line": 2,
-          "message": 3
+          "message": 3,
+          "file": 4
         }
       ]
     }


### PR DESCRIPTION
Thanks to
- https://github.com/eclipse-pde/eclipse.pde/pull/264

we can now greatly simplify the matcher and get full annotation support for API problems withing GH action builds:

![grafik](https://user-images.githubusercontent.com/1331477/183355340-ff4b12d6-d3ff-4b2c-993d-e0125f4fa71d.png)