### PR TITLE
Allow users mute "Using unsafe http transport" p2 warnings (#123)

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.repository;singleton:=true
-Bundle-Version: 2.6.100.qualifier
+Bundle-Version: 2.6.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/CacheManager.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/CacheManager.java
@@ -82,6 +82,9 @@ public class CacheManager {
 	private static final String JAR_EXTENSION = ".jar"; //$NON-NLS-1$
 	private static final String XML_EXTENSION = ".xml"; //$NON-NLS-1$
 
+	/** Allows to mute "Using unsafe http transport" warnings */
+	private static final boolean SKIP_REPOSITORY_PROTOCOL_CHECK = Boolean.getBoolean("p2.skipRepositoryProtocolCheck"); //$NON-NLS-1$
+
 	private final HashSet<String> knownPrefixes = new HashSet<>(5);
 
 	/**
@@ -270,6 +273,9 @@ public class CacheManager {
 	}
 
 	private void checkLocationIsSecure(URI repositoryLocation) {
+		if (SKIP_REPOSITORY_PROTOCOL_CHECK) {
+			return;
+		}
 		if ("http".equals(repositoryLocation.getScheme())) { //$NON-NLS-1$
 			LogHelper.log(new Status(IStatus.WARNING, Activator.ID, NLS.bind(Messages.unsafeHttp, repositoryLocation)));
 		}


### PR DESCRIPTION
Added system property -Dp2.skipRepositoryProtocolCheck=true that allows users to run
Eclipse without getting dozens of "Using unsafe http transport" p2
warnings on every p2 update task.

Fixes https://github.com/eclipse-equinox/p2/issues/123