### PR TITLE
replacing org.apache.commons.io with org.apache.commons.commons-io

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests.reconciler.product/reconciler.product
+++ b/bundles/org.eclipse.equinox.p2.tests.reconciler.product/reconciler.product
@@ -34,7 +34,7 @@
       <plugin id="org.apache.batik.i18n"/>
       <plugin id="org.apache.batik.util"/>
       <plugin id="org.apache.commons.codec"/>
-      <plugin id="org.apache.commons.io"/>
+      <plugin id="org.apache.commons.commons-io"/>
       <plugin id="org.apache.commons.jxpath"/>
       <plugin id="org.apache.commons.logging"/>
       <plugin id="org.apache.felix.scr"/>

--- a/bundles/org.eclipse.equinox.p2.ui.admin.rcp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.admin.rcp/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.admin.rcp; singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.admin.rcp.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.ui,

--- a/bundles/org.eclipse.equinox.p2.ui.admin.rcp/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.ui.admin.rcp/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.eclipse.equinox</groupId>
   <artifactId>org.eclipse.equinox.p2.ui.admin.rcp</artifactId>
-  <version>1.3.200-SNAPSHOT</version>
+  <version>1.3.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.equinox.p2.ui.admin.rcp/rcp.product
+++ b/bundles/org.eclipse.equinox.p2.ui.admin.rcp/rcp.product
@@ -146,7 +146,7 @@ Java and all Java-based trademarks are trademarks of Sun Microsystems, Inc. in t
       <plugin id="org.apache.batik.util"/>
       <plugin id="org.apache.commons.codec"/>
       <plugin id="org.apache.commons.httpclient"/>
-      <plugin id="org.apache.commons.io"/>
+      <plugin id="org.apache.commons.commons-io"/>
       <plugin id="org.apache.commons.jxpath"/>
       <plugin id="org.apache.commons.logging"/>
       <plugin id="org.apache.felix.scr"/>

--- a/examples/org.eclipse.equinox.p2.examples.rcp.discovery/cloud.product
+++ b/examples/org.eclipse.equinox.p2.examples.rcp.discovery/cloud.product
@@ -42,7 +42,7 @@
       <plugin id="org.apache.batik.util"/>
       <plugin id="org.apache.commons.codec"/>
       <plugin id="org.apache.commons.httpclient"/>
-      <plugin id="org.apache.commons.io"/>
+      <plugin id="org.apache.commons.commons-io"/>
       <plugin id="org.apache.commons.jxpath"/>
       <plugin id="org.apache.commons.logging"/>
       <plugin id="org.apache.felix.scr"/>

--- a/examples/org.eclipse.equinox.p2.examples.rcp.sdkbundlevisibility/sdkbundlevisibility.product
+++ b/examples/org.eclipse.equinox.p2.examples.rcp.sdkbundlevisibility/sdkbundlevisibility.product
@@ -42,7 +42,7 @@
       <plugin id="org.apache.batik.util"/>
       <plugin id="org.apache.commons.codec"/>
       <plugin id="org.apache.commons.httpclient"/>
-      <plugin id="org.apache.commons.io"/>
+      <plugin id="org.apache.commons.commons-io"/>
       <plugin id="org.apache.commons.jxpath"/>
       <plugin id="org.apache.commons.logging"/>
       <plugin id="org.apache.felix.scr"/>


### PR DESCRIPTION
Tracked in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/489