### PR TITLE
Another round of Javadoc warnings and errors.

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/spi/package.html
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/spi/package.html
@@ -10,8 +10,7 @@ Defines  SPI for registering new implementations of metadata repositories.
 Package Specification</h2>
 <p>
 This package defines SPI for registering new implementations of metadata repositories.
-<p>
-@since 2.0
 </p>
+@since 2.0
 </body>
 </html>


### PR DESCRIPTION
As found by Java 17 javadoc tool.
Needed by
eclipse-platform/eclipse.platform.releng.aggregator#482