### PR TITLE
Don't set system-property skipTests=false in Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,8 +18,7 @@ pipeline {
 					sh """
 					mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Pbuild-individual-bundles -Pbree-libs -Papi-check \
-						-DskipTests=false -Dcompare-version-with-baselines.skip=false \
-						-Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true \
+						-Dcompare-version-with-baselines.skip=false \
 						-Dproject.build.sourceEncoding=UTF-8 \
 						-T1C
 					"""


### PR DESCRIPTION
Otherwise no module can enable skipTests.

@mickaelistria is there any reason (that is still relevant), that this property was set?

And remove 'maven.test.error.ignore=true' and 'maven.test.failure.ignore=true' because the build already has '--fail-at-end' set