### PR TITLE
Revert removal of maven.test.error/failure.ignore in Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
 					mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Pbuild-individual-bundles -Pbree-libs -Papi-check \
 						-Dcompare-version-with-baselines.skip=false \
+						-Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true \
 						-Dproject.build.sourceEncoding=UTF-8 \
 						-T1C
 					"""


### PR DESCRIPTION
This reverts parts of https://github.com/eclipse-equinox/p2/pull/143.