### PR TITLE
Support sha1/512 as additional checksums in P2

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/plugin.xml
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/plugin.xml
@@ -50,9 +50,27 @@
 	<extension
 			point="org.eclipse.equinox.p2.artifact.repository.artifactChecksums">
 		<artifactChecksum
+        algorithm="SHA-1"
+        id="sha-1"
+        priority="-1000"
+        publish="false"
+        warnInsecure="true">
+		</artifactChecksum>
+	</extension>
+	<extension
+			point="org.eclipse.equinox.p2.artifact.repository.artifactChecksums">
+		<artifactChecksum
         algorithm="SHA-256"
         id="sha-256"
         priority="1000">
+		</artifactChecksum>
+	</extension>
+	<extension
+			point="org.eclipse.equinox.p2.artifact.repository.artifactChecksums">
+		<artifactChecksum
+        algorithm="SHA-512"
+        id="sha-512"
+        priority="2000">
 		</artifactChecksum>
 	</extension>
 	

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/AllTests.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/AllTests.java
@@ -21,7 +21,8 @@ import org.junit.runners.Suite;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ ZipVerifierProcessorTest.class, ChecksumVerifierTest.class,
-		ChecksumUtilitiesTest.class, PGPSignatureVerifierTest.class, ProduceChecksumTest.class })
+		ChecksumUtilitiesTest.class, PGPSignatureVerifierTest.class, ProduceChecksumTest.class,
+		ChecksumPriorityTest.class })
 public class AllTests {
 // test suite
 }


### PR DESCRIPTION
SHA1 is the default signature for maven and recently support was added up to sha-512 so P2 should support this as well.