### PR TITLE
Do not read data multiple times when calculating checksum

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.artifact.repository;singleton:=true
-Bundle-Version: 1.4.500.qualifier
+Bundle-Version: 1.4.600.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.artifact.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/ChecksumProducer.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/ChecksumProducer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 IBM Corporation and others.
+ * Copyright (c) 2009, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Mykola Nikishov - multiple artifact checksums
+ *     Christoph Läubrich - do not read data multiple times
  *******************************************************************************/
 
 package org.eclipse.equinox.internal.p2.repository.helpers;
@@ -27,6 +28,37 @@ import org.eclipse.osgi.util.NLS;
 public class ChecksumProducer {
 
 	private static final int BUFFER_SIZE = 4 * 1024;
+
+	private final String id;
+	private final String algorithm;
+	private final String providerName;
+
+	private MessageDigest messageDigest;
+
+	public ChecksumProducer(String id, String algorithm, String providerName) {
+		this.id = id;
+		this.algorithm = algorithm;
+		this.providerName = providerName;
+	}
+
+	public MessageDigest getMessageDigest() throws GeneralSecurityException {
+		if (messageDigest == null) {
+			messageDigest = getMessageDigest(algorithm, providerName);
+		}
+		return messageDigest;
+	}
+
+	public String getAlgorithm() {
+		return algorithm;
+	}
+
+	public String getProviderName() {
+		return providerName;
+	}
+
+	public String getId() {
+		return id;
+	}
 
 	/**
 	 * @param file should not be <code>null</code>

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/AllTests.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/AllTests.java
@@ -21,7 +21,7 @@ import org.junit.runners.Suite;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ ZipVerifierProcessorTest.class, ChecksumVerifierTest.class,
-		ChecksumUtilitiesTest.class, PGPSignatureVerifierTest.class })
+		ChecksumUtilitiesTest.class, PGPSignatureVerifierTest.class, ProduceChecksumTest.class })
 public class AllTests {
 // test suite
 }

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/ProduceChecksumTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/ProduceChecksumTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.equinox.p2.tests.artifact.processors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.equinox.internal.p2.artifact.processors.checksum.ChecksumUtilities;
+import org.junit.Test;
+
+public class ProduceChecksumTest {
+
+	@Test
+	public void testChecksums() throws IOException {
+		File tempFile = File.createTempFile("testArtifact", ".tmp");
+		tempFile.deleteOnExit();
+		try (FileOutputStream fout = new FileOutputStream(tempFile);
+				InputStream resource = getClass().getResourceAsStream("testArtifact")) {
+			resource.transferTo(fout);
+		}
+		HashMap<String, String> hashMap = new HashMap<>();
+		IStatus status = ChecksumUtilities.calculateChecksums(new File(tempFile.toURI()), hashMap,
+				Collections.emptyList());
+		assertTrue(status.toString(), status.isOK());
+		String md5sum = hashMap.get("md5");
+		assertNotNull("MD5 was not computed!", md5sum);
+		assertEquals("MD5 mismatch", "25b68bb92a7a77238bd60ad5e21bb91f", md5sum);
+		String sha256sum = hashMap.get("sha-256");
+		assertNotNull("SHA256 was not computed!", sha256sum);
+		assertEquals("SHA256 mismatch", "39d083c8c75eac51b2c4566cca299b41cc93d5b0313906f5979fbebf1104ff49", sha256sum);
+	}
+}


### PR DESCRIPTION
Currently the file is read for each checksum algorithm. While calculating checksums is fast, disk I/O is often not.

This changes the method that calculates the hashes in a way that the data is only read once but chained to each algorithm.

As discussed here: https://github.com/eclipse-equinox/p2/pull/160

I think this can actually be speedup even more by caching the digest itself, but that's a different story... 