### PR TITLE
Always choose the most secure algorithm to check integrity

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/plugin.xml
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/plugin.xml
@@ -43,17 +43,19 @@
 		<artifactChecksum
         algorithm="MD5"
         id="md5"
+        priority="-2000"
         warnInsecure="true">
 		</artifactChecksum>
 	</extension>
 	<extension
 			point="org.eclipse.equinox.p2.artifact.repository.artifactChecksums">
 		<artifactChecksum
-			algorithm="SHA-256"
-			id="sha-256">
+        algorithm="SHA-256"
+        id="sha-256"
+        priority="1000">
 		</artifactChecksum>
 	</extension>
-
+	
 	<extension
 			id="org.eclipse.equinox.p2.processing.PGPSignatureCheck"
 			point="org.eclipse.equinox.p2.artifact.repository.processingSteps">

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/schema/artifactChecksums.exsd
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/schema/artifactChecksums.exsd
@@ -84,6 +84,13 @@ Set to true if this algorithm is now considered as insecure. A warning will be l
                </documentation>
             </annotation>
          </attribute>
+         <attribute name="priority" type="string" use="default" value="0">
+            <annotation>
+               <documentation>
+                  Gives a priority of this algorithm, algorithms with higher priority are preffered if multiple ones are applicable.
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/processors/checksum/ChecksumVerifier.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/processors/checksum/ChecksumVerifier.java
@@ -34,13 +34,21 @@ final public class ChecksumVerifier extends MessageDigestProcessingStep {
 	final private String providerName;
 	final private String algorithmId;
 	private final boolean insecureAlgorithm;
+	private final int priority;
+
+	@Deprecated
+	public ChecksumVerifier(String digestAlgorithm, String providerName, String algorithmId, boolean insecure) {
+		this(digestAlgorithm, providerName, algorithmId, insecure, 0);
+	}
 
 	// public to access from tests
-	public ChecksumVerifier(String digestAlgorithm, String providerName, String algorithmId, boolean insecure) {
+	public ChecksumVerifier(String digestAlgorithm, String providerName, String algorithmId, boolean insecure,
+			int priority) {
 		this.algorithmName = digestAlgorithm;
 		this.providerName = providerName;
 		this.algorithmId = algorithmId;
 		this.insecureAlgorithm = insecure;
+		this.priority = priority;
 		basicInitialize(null);
 	}
 
@@ -95,5 +103,9 @@ final public class ChecksumVerifier extends MessageDigestProcessingStep {
 
 	public boolean isInsecureAlgorithm() {
 		return insecureAlgorithm;
+	}
+
+	public int getPriority() {
+		return priority;
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/ChecksumPriorityTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/ChecksumPriorityTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Christoph Läubrich and others
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.equinox.p2.tests.artifact.processors;
+
+import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.eclipse.equinox.internal.p2.artifact.processors.checksum.ChecksumUtilities;
+import org.eclipse.equinox.internal.p2.artifact.processors.checksum.ChecksumVerifier;
+import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
+import org.eclipse.equinox.internal.p2.metadata.OSGiVersion;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
+import org.eclipse.equinox.p2.repository.artifact.spi.ArtifactDescriptor;
+import org.junit.Test;
+
+public class ChecksumPriorityTest {
+
+	@Test
+	public void testChecksumPriorityWithFullSet() {
+		ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(
+				new ArtifactKey("", "", new OSGiVersion(1, 1, 1, "")));
+		artifactDescriptor.setProperty(IArtifactDescriptor.ARTIFACT_CHECKSUM + ".md5", "abc");
+		artifactDescriptor.setProperty(IArtifactDescriptor.ARTIFACT_CHECKSUM + ".sha-1", "abc");
+		artifactDescriptor.setProperty(IArtifactDescriptor.ARTIFACT_CHECKSUM + ".sha-256", "abc");
+		artifactDescriptor.setProperty(IArtifactDescriptor.ARTIFACT_CHECKSUM + ".sha-512", "abc");
+		assertBestChoice(artifactDescriptor, "sha-512");
+	}
+
+	@Test
+	public void testChecksumPriorityWithStandardSet() {
+		ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(
+				new ArtifactKey("", "", new OSGiVersion(1, 1, 1, "")));
+		artifactDescriptor.setProperty(IArtifactDescriptor.ARTIFACT_CHECKSUM + ".md5", "abc");
+		artifactDescriptor.setProperty(IArtifactDescriptor.ARTIFACT_CHECKSUM + ".sha-256", "abc");
+		assertBestChoice(artifactDescriptor, "sha-256");
+	}
+
+	@Test
+	public void testChecksumPriorityWithDeprecatedSet() {
+		ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(
+				new ArtifactKey("", "", new OSGiVersion(1, 1, 1, "")));
+		artifactDescriptor.setProperty(IArtifactDescriptor.ARTIFACT_CHECKSUM + ".md5", "abc");
+		artifactDescriptor.setProperty(IArtifactDescriptor.ARTIFACT_CHECKSUM + ".sha-1", "abc");
+		assertBestChoice(artifactDescriptor, "sha-1");
+	}
+
+	private static void assertBestChoice(ArtifactDescriptor artifactDescriptor, String bestAlgorithm) {
+		Collection<ChecksumVerifier> checksumVerifiers = ChecksumUtilities.getChecksumVerifiers(artifactDescriptor,
+				IArtifactDescriptor.ARTIFACT_CHECKSUM, emptySet());
+		// if we have the choice, just get the best!
+		assertEquals(
+				"more than one algorithm was choosen: " + checksumVerifiers.stream()
+						.map(ChecksumVerifier::getAlgorithmId).collect(Collectors.joining(", ")),
+				1, checksumVerifiers.size());
+		ChecksumVerifier verifier = checksumVerifiers.iterator().next();
+		assertEquals(bestAlgorithm, verifier.getAlgorithmId());
+	}
+}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/ChecksumVerifierTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/ChecksumVerifierTest.java
@@ -67,7 +67,7 @@ public class ChecksumVerifierTest {
 		IProcessingStepDescriptor processingStepDescriptor = mock(IProcessingStepDescriptor.class);
 		when(processingStepDescriptor.getData()).thenReturn(checksum);
 
-		ChecksumVerifier verifier = new ChecksumVerifier(digestAlgorithm, providerName, algorithmId, false);
+		ChecksumVerifier verifier = new ChecksumVerifier(digestAlgorithm, providerName, algorithmId, false, 0);
 
 		verifier.initialize(null, processingStepDescriptor, null);
 
@@ -87,7 +87,7 @@ public class ChecksumVerifierTest {
 		properties.put(downloadProperty, checksum);
 		when(artifactDescriptor.getProperties()).thenReturn(properties);
 
-		ChecksumVerifier verifier = new ChecksumVerifier(digestAlgorithm, providerName, algorithmId, false);
+		ChecksumVerifier verifier = new ChecksumVerifier(digestAlgorithm, providerName, algorithmId, false, 0);
 
 		verifier.initialize(null, processingStepDescriptor, artifactDescriptor);
 
@@ -107,7 +107,7 @@ public class ChecksumVerifierTest {
 		when(artifactDescriptor.getProperties()).thenReturn(properties);
 		when(artifactDescriptor.getProperty(not(eq(artifactProperty)))).thenReturn(null);
 
-		ChecksumVerifier verifier = new ChecksumVerifier(digestAlgorithm, providerName, algorithmId, false);
+		ChecksumVerifier verifier = new ChecksumVerifier(digestAlgorithm, providerName, algorithmId, false, 0);
 
 		verifier.initialize(null, processingStepDescriptor, artifactDescriptor);
 


### PR DESCRIPTION
Currently always all checksums are checked for integrity of a file, this change the behavior by introducing a ranking and only checks the best matching one.

This is another spin-off from #160 