### PR TITLE
Add an option to disable checksum publishing

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/schema/artifactChecksums.exsd
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/schema/artifactChecksums.exsd
@@ -91,6 +91,13 @@ Set to true if this algorithm is now considered as insecure. A warning will be l
                </documentation>
             </annotation>
          </attribute>
+         <attribute name="publish" type="boolean" use="default" value="true">
+            <annotation>
+               <documentation>
+                  Controls if this checksum should be published when assembling a repository.
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/processors/checksum/ChecksumUtilities.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/processors/checksum/ChecksumUtilities.java
@@ -115,7 +115,7 @@ public class ChecksumUtilities {
 		for (IConfigurationElement checksumVerifierConfiguration : ChecksumUtilities
 				.getChecksumComparatorConfigurations()) {
 			String id = checksumVerifierConfiguration.getAttribute("id"); //$NON-NLS-1$
-			if (checksumsToSkip.contains(id))
+			if (checksumsToSkip.contains(id) || !shouldPublish(checksumVerifierConfiguration))
 				// don't calculate checksum if algo is disabled
 				continue;
 			String algorithm = checksumVerifierConfiguration.getAttribute("algorithm"); //$NON-NLS-1$
@@ -159,6 +159,14 @@ public class ChecksumUtilities {
 			status.add(new Status(IStatus.ERROR, Activator.ID, message, e));
 		}
 		return status;
+	}
+
+	private static boolean shouldPublish(IConfigurationElement checksumVerifierConfiguration) {
+		String attribute = checksumVerifierConfiguration.getAttribute("publish"); //$NON-NLS-1$
+		if (attribute == null || attribute.isBlank()) {
+			return true;
+		}
+		return Boolean.parseBoolean(attribute);
 	}
 
 	/**


### PR DESCRIPTION
Currently all registered checksums are computed and published, but in some cases it might be usefully to be able to verify a checksum but we don't want to publish it

It seems it was to ambitious to disable md5 as part of the change, so here is just the extract from
- https://github.com/eclipse-equinox/p2/pull/164

that only *allows* to disable checksums but actually do not change anything at P2 in that regard (what would better be handled in a separate change).