### PR TITLE
Fix NPE in KeySigningInfoFactory and slightly modernize it

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui;singleton:=true
-Bundle-Version: 2.7.700.qualifier
+Bundle-Version: 2.7.800.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.ProvUIActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/KeySigningInfoFactory.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/KeySigningInfoFactory.java
@@ -110,12 +110,10 @@ public class KeySigningInfoFactory implements IAdapterFactory {
 
 				private Map<PGPSignature, PGPPublicKey> getDetails(Bundle bundle) {
 					try {
-						File bundleFile = FileLocator.getBundleFile(bundle).getCanonicalFile();
-						Map<PGPSignature, PGPPublicKey> details = bundlePoolArtficactSigningDetails.get(bundleFile);
-						return details;
+						File bundleFile = FileLocator.getBundleFileLocation(bundle).orElseThrow().getCanonicalFile();
+						return bundlePoolArtficactSigningDetails.get(bundleFile);
 					} catch (IOException | RuntimeException e) {
-						ProvUIActivator.getDefault().getLog()
-								.log(new Status(IStatus.ERROR, ProvUIActivator.PLUGIN_ID, e.getMessage(), e));
+						ProvUIActivator.getDefault().getLog().log(Status.error(e.getMessage(), e));
 						return null;
 					}
 				}
@@ -148,8 +146,7 @@ public class KeySigningInfoFactory implements IAdapterFactory {
 			if (bundlePoolRepository == null) {
 				return Collections.emptyMap();
 			}
-			IQueryResult<IArtifactKey> allArtifactKeys = bundlePoolRepository.query(ArtifactKeyQuery.ALL_KEYS,
-					new NullProgressMonitor());
+			IQueryResult<IArtifactKey> allArtifactKeys = bundlePoolRepository.query(ArtifactKeyQuery.ALL_KEYS, null);
 			for (IArtifactKey key : allArtifactKeys) {
 				for (IArtifactDescriptor descriptor : bundlePoolRepository.getArtifactDescriptors(key)) {
 					File file = bundlePoolRepository.getArtifactFile(descriptor);
@@ -172,15 +169,13 @@ public class KeySigningInfoFactory implements IAdapterFactory {
 								}
 							}
 						} catch (IOException | PGPException | RuntimeException e) {
-							ProvUIActivator.getDefault().getLog()
-									.log(new Status(IStatus.ERROR, ProvUIActivator.PLUGIN_ID, e.getMessage(), e));
+							ProvUIActivator.getDefault().getLog().log(Status.error(e.getMessage(), e));
 						}
 					}
 				}
 			}
 		} catch (RuntimeException e) {
-			ProvUIActivator.getDefault().getLog()
-					.log(new Status(IStatus.ERROR, ProvUIActivator.PLUGIN_ID, e.getMessage(), e));
+			ProvUIActivator.getDefault().getLog().log(Status.error(e.getMessage(), e));
 		}
 		return result;
 	}

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/KeySigningInfoFactory.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/KeySigningInfoFactory.java
@@ -145,6 +145,9 @@ public class KeySigningInfoFactory implements IAdapterFactory {
 			// installation.
 			IFileArtifactRepository bundlePoolRepository = org.eclipse.equinox.internal.p2.extensionlocation.Activator
 					.getBundlePoolRepository();
+			if (bundlePoolRepository == null) {
+				return Collections.emptyMap();
+			}
 			IQueryResult<IArtifactKey> allArtifactKeys = bundlePoolRepository.query(ArtifactKeyQuery.ALL_KEYS,
 					new NullProgressMonitor());
 			for (IArtifactKey key : allArtifactKeys) {


### PR DESCRIPTION
Occasionally I see error reports about an NPE in `KeySigningInfoFactory` because the `bundlePoolRepository` is null.
Unfortunately I don't have any at hand now because I did the change a while ago but somehow did not submit it.

@merks can you tell if this change is reasonable?

And also apply some slight modernization/simplifications of the code.