### PR TITLE
Check for null of org.eclipse.core.runtime.RegistryFactory.getRegistry()

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/processors/checksum/ChecksumUtilities.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/processors/checksum/ChecksumUtilities.java
@@ -96,7 +96,11 @@ public class ChecksumUtilities {
 	}
 
 	public static IConfigurationElement[] getChecksumComparatorConfigurations() {
-		return RegistryFactory.getRegistry().getConfigurationElementsFor(ARTIFACT_CHECKSUMS_POINT);
+		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry == null) {
+			return new IConfigurationElement[0];
+		}
+		return registry.getConfigurationElementsFor(ARTIFACT_CHECKSUMS_POINT);
 	}
 
 	/**
@@ -184,6 +188,7 @@ public class ChecksumUtilities {
 		return properties;
 	}
 
+	@SuppressWarnings("deprecation")
 	private static void putLegacyMd5Property(String propertyNamespace, Map<String, String> checksums, HashMap<String, String> result) {
 		String md5 = checksums.get(ChecksumHelper.MD5);
 		if (md5 != null) {

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/provisional/p2/artifact/repository/processing/ProcessingStepHandler.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/provisional/p2/artifact/repository/processing/ProcessingStepHandler.java
@@ -97,7 +97,7 @@ public class ProcessingStepHandler {
 	 * step has not yet executed. If the step has executed the returned status
 	 * indicates the success or failure of the step.
 	 * @param deep whether or not to aggregate the status of any linked steps
-	 * @return the requested status 
+	 * @return the requested status
 	 */
 	public static IStatus getStatus(OutputStream stream, boolean deep) {
 		if (!deep)
@@ -175,8 +175,7 @@ public class ProcessingStepHandler {
 	}
 
 	public ProcessingStep create(IProvisioningAgent agent, IProcessingStepDescriptor descriptor, IArtifactDescriptor context) {
-		IExtensionRegistry registry = RegistryFactory.getRegistry();
-		IExtension extension = registry.getExtension(PROCESSING_STEPS_EXTENSION_ID, descriptor.getProcessorId());
+		IExtension extension = getExtension(descriptor);
 		Exception error;
 		if (extension != null) {
 			IConfigurationElement[] config = extension.getConfigurationElements();
@@ -197,6 +196,15 @@ public class ProcessingStepHandler {
 		return result;
 	}
 
+	private IExtension getExtension(IProcessingStepDescriptor descriptor) {
+		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry == null) {
+			return null;
+		}
+		IExtension extension = registry.getExtension(PROCESSING_STEPS_EXTENSION_ID, descriptor.getProcessorId());
+		return extension;
+	}
+
 	public OutputStream createAndLink(IProvisioningAgent agent, IProcessingStepDescriptor[] descriptors, IArtifactDescriptor context, OutputStream output, IProgressMonitor monitor) {
 		if (descriptors == null)
 			return output;
@@ -213,7 +221,7 @@ public class ProcessingStepHandler {
 		}
 		if (steps.length == 0)
 			return previous;
-		// now link the artifact stream to the first stream in the new chain 
+		// now link the artifact stream to the first stream in the new chain
 		ArtifactOutputStream lastLink = getArtifactStream(previous);
 		if (lastLink != null)
 			lastLink.setFirstLink(previous);

--- a/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.engine;singleton:=true
-Bundle-Version: 2.7.500.qualifier
+Bundle-Version: 2.7.600.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.engine.EngineActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/ActionManager.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/ActionManager.java
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -42,7 +42,10 @@ public class ActionManager implements IRegistryChangeListener {
 
 	public ActionManager() {
 		this.touchpointManager = new TouchpointManager();
-		RegistryFactory.getRegistry().addRegistryChangeListener(this, EngineActivator.ID);
+		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry != null) {
+			registry.addRegistryChangeListener(this, EngineActivator.ID);
+		}
 	}
 
 	public Touchpoint getTouchpointPoint(ITouchpointType type) {
@@ -91,7 +94,12 @@ public class ActionManager implements IRegistryChangeListener {
 	private synchronized Map<String, IConfigurationElement> getActionMap() {
 		if (actionMap != null)
 			return actionMap;
-		IExtensionPoint point = RegistryFactory.getRegistry().getExtensionPoint(EngineActivator.ID, PT_ACTIONS);
+		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry == null) {
+			// maybe later...
+			return Map.of();
+		}
+		IExtensionPoint point = registry.getExtensionPoint(EngineActivator.ID, PT_ACTIONS);
 		IExtension[] extensions = point.getExtensions();
 		actionMap = new HashMap<>(extensions.length);
 		for (IExtension extension : extensions) {

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/TouchpointManager.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/TouchpointManager.java
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -90,13 +90,16 @@ public class TouchpointManager implements IRegistryChangeListener {
 		}
 	}
 
-	// TODO: Do we really want to store the touchpoints? The danger is 
+	// TODO: Do we really want to store the touchpoints? The danger is
 	//	     that if two installations are performed simultaneously, then...
 	// TODO: Figure out locking, concurrency requirements for touchpoints.
 	private Map<String, TouchpointEntry> touchpointEntries;
 
 	public TouchpointManager() {
-		RegistryFactory.getRegistry().addRegistryChangeListener(this, EngineActivator.ID);
+		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry != null) {
+			registry.addRegistryChangeListener(this, EngineActivator.ID);
+		}
 	}
 
 	/*
@@ -136,7 +139,12 @@ public class TouchpointManager implements IRegistryChangeListener {
 		if (touchpointEntries != null)
 			return touchpointEntries;
 
-		IExtensionPoint point = RegistryFactory.getRegistry().getExtensionPoint(EngineActivator.ID, PT_TOUCHPOINTS);
+		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry == null) {
+			// maybe later...
+			return Map.of();
+		}
+		IExtensionPoint point = registry.getExtensionPoint(EngineActivator.ID, PT_TOUCHPOINTS);
 		IExtension[] extensions = point.getExtensions();
 		touchpointEntries = new HashMap<>(extensions.length);
 		for (IExtension extension : extensions) {

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/CertificateChecker.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/CertificateChecker.java
@@ -496,7 +496,11 @@ public class CertificateChecker {
 		Map<ByteBuffer, Set<Bundle>> keys = new LinkedHashMap<>();
 
 		// Load from the extension registry.
-		for (IConfigurationElement extension : RegistryFactory.getRegistry()
+		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry == null) {
+			return Map.of();
+		}
+		for (IConfigurationElement extension : registry
 				.getConfigurationElementsFor(EngineActivator.ID, "pgp")) { //$NON-NLS-1$
 			if ("trustedKeys".equals(extension.getName())) { //$NON-NLS-1$
 				String pathInBundle = extension.getAttribute("path"); //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.garbagecollector/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.garbagecollector/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.garbagecollector;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.garbagecollector;x-friends:="org.eclipse.equinox.p2.touchpoint.eclipse,org.eclipse.pde.core,org.eclipse.equinox.p2.ui.sdk.scheduler"

--- a/bundles/org.eclipse.equinox.p2.garbagecollector/src/org/eclipse/equinox/internal/p2/garbagecollector/GarbageCollector.java
+++ b/bundles/org.eclipse.equinox.p2.garbagecollector/src/org/eclipse/equinox/internal/p2/garbagecollector/GarbageCollector.java
@@ -189,6 +189,9 @@ public class GarbageCollector implements SynchronousProvisioningListener, IAgent
 
 	private boolean traverseMainProfile(IProfile profile) {
 		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry == null) {
+			return false;
+		}
 		IConfigurationElement[] configElts = registry.getConfigurationElementsFor(PT_MARKSET);
 
 		//First we collect all repos and keys for the profile being GC'ed
@@ -203,6 +206,9 @@ public class GarbageCollector implements SynchronousProvisioningListener, IAgent
 
 	private void traverseRegisteredProfiles() {
 		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry == null) {
+			return;
+		}
 		IConfigurationElement[] configElts = registry.getConfigurationElementsFor(PT_MARKSET);
 		for (IConfigurationElement configElt : configElts) {
 			if (configElt == null || !(configElt.getName().equals("run"))) { //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/RepositoryAnalyzer.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/RepositoryAnalyzer.java
@@ -1,4 +1,4 @@
-/******************************************************************************* 
+/*******************************************************************************
 * Copyright (c) 2009,2010 EclipseSource and others.
  *
  * This
@@ -39,7 +39,11 @@ public class RepositoryAnalyzer {
 		MultiStatus result = new MultiStatus(Activator.ID, IStatus.OK, null, null);
 
 		SubMonitor sub = SubMonitor.convert(monitor, repositories.length * 2);
-		IConfigurationElement[] config = RegistryFactory.getRegistry().getConfigurationElementsFor(IIUAnalyzer.ID);
+		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry == null) {
+			return Status.CANCEL_STATUS;
+		}
+		IConfigurationElement[] config = registry.getConfigurationElementsFor(IIUAnalyzer.ID);
 
 		for (IMetadataRepository repository : repositories) {
 			IQueryResult<IInstallableUnit> queryResult = repository.query(QueryUtil.createIUAnyQuery(), sub);

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/repository/tools/comparator/ArtifactComparatorFactory.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/repository/tools/comparator/ArtifactComparatorFactory.java
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *     Compeople AG (Stefan Liebig) - various ongoing maintenance
@@ -15,8 +15,7 @@
  *******************************************************************************/
 package org.eclipse.equinox.p2.repository.tools.comparator;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.core.runtime.IConfigurationElement;
@@ -52,7 +51,8 @@ public class ArtifactComparatorFactory {
 	 * @throws {@link IllegalArgumentException} otherwise
 	 */
 	public static IArtifactComparator getArtifactComparator(String comparatorID) {
-		List<IConfigurationElement> extensions = Stream.of(RegistryFactory.getRegistry().getConfigurationElementsFor(COMPARATOR_POINT))
+		List<IConfigurationElement> extensions = Optional.ofNullable(RegistryFactory.getRegistry()).stream()
+				.flatMap(r -> Arrays.stream(r.getConfigurationElementsFor(COMPARATOR_POINT)))
 			.collect(Collectors.toList());
 		// exclude artifact checksum comparator, needs special care
 		extensions.removeIf(extension -> extension.getAttribute(ATTR_ID).equals(ArtifactChecksumComparator.COMPARATOR_ID));

--- a/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.repository;singleton:=true
-Bundle-Version: 2.6.300.qualifier
+Bundle-Version: 2.6.400.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/AbstractRepositoryManager.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/AbstractRepositoryManager.java
@@ -289,7 +289,7 @@ public abstract class AbstractRepositoryManager<T> implements IRepositoryManager
 			if (loaded)
 				fail(location, ProvisionException.REPOSITORY_EXISTS);
 
-			IExtension extension = RegistryFactory.getRegistry().getExtension(getRepositoryProviderExtensionPointId(), type);
+			IExtension extension = getExtension(type);
 			if (extension == null)
 				fail(location, ProvisionException.REPOSITORY_UNKNOWN_TYPE);
 			//		MetadataRepositoryFactory factory = (MetadataRepositoryFactory) createExecutableExtension(extension, EL_FACTORY);
@@ -306,6 +306,14 @@ public abstract class AbstractRepositoryManager<T> implements IRepositoryManager
 		//fire event after releasing load lock
 		broadcastChangeEvent(location, getRepositoryType(), RepositoryEvent.ADDED, true);
 		return result;
+	}
+
+	private IExtension getExtension(String type) {
+		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry == null) {
+			return null;
+		}
+		return registry.getExtension(getRepositoryProviderExtensionPointId(), type);
 	}
 
 	/**
@@ -406,12 +414,16 @@ public abstract class AbstractRepositoryManager<T> implements IRepositoryManager
 	}
 
 	protected IExtension[] findMatchingRepositoryExtensions(String suffix, String type) {
+		IExtensionRegistry registry = RegistryFactory.getRegistry();
+		if (registry == null) {
+			return new IExtension[0];
+		}
 		IConfigurationElement[] elt = null;
 		if (type != null && type.length() > 0) {
-			IExtension ext = RegistryFactory.getRegistry().getExtension(getRepositoryProviderExtensionPointId(), type);
+			IExtension ext = registry.getExtension(getRepositoryProviderExtensionPointId(), type);
 			elt = (ext != null) ? ext.getConfigurationElements() : new IConfigurationElement[0];
 		} else {
-			elt = RegistryFactory.getRegistry().getConfigurationElementsFor(getRepositoryProviderExtensionPointId());
+			elt = registry.getConfigurationElementsFor(getRepositoryProviderExtensionPointId());
 		}
 		int count = 0;
 		for (int i = 0; i < elt.length; i++) {


### PR DESCRIPTION
The API of `RegistryFactory.getRegistry()` states:

> return existing extension registry or null

but on several places there is no check for null.

This adds null checks on several places that previously would result in a NPE.

See https://github.com/eclipse-equinox/p2/issues/214