### PR TITLE
EquinoxFwConfigFileParser: add null check - fixes #219

### DIFF
--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.frameworkadmin.equinox;singleton:=true
-Bundle-Version: 1.2.200.qualifier
+Bundle-Version: 1.2.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Import-Package: org.eclipse.equinox.frameworkadmin;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EquinoxFwConfigFileParser.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EquinoxFwConfigFileParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corporation and others.
+ * Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -330,6 +330,8 @@ public class EquinoxFwConfigFileParser {
 	}
 
 	private File findSharedConfigIniFile(File base, String sharedConfigurationArea) {
+		if (sharedConfigurationArea == null)
+			return null;
 		if (base == null)
 			return null;
 		URL rootURL;


### PR DESCRIPTION
avoids warning "Failed creating shared configuration url for null."