### PR TITLE
Generalize support for dealing with insecure protocols in p2

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/Messages.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/Messages.java
@@ -90,8 +90,8 @@ public class Messages extends NLS {
 	public static String UnableToRead_0_UserCanceled;
 
 	public static String RepositoryTransport_failedReadRepo;
-	public static String RepositoryTransport_unsafeHttpBlocked;
-	public static String RepositoryTransport_unsafeHttp;
+	public static String RepositoryTransport_unsafeProtocolBlocked;
+	public static String RepositoryTransport_unsafeProtocol;
 
 	static {
 		// initialize resource bundles

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/messages.properties
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/messages.properties
@@ -80,5 +80,5 @@ connection_to_0_failed_on_1_retry_attempt_2=Connection to {0} failed on {1}. Ret
 UnableToRead_0_TooManyAttempts=Unable to read repository at: {0}. Too many failed login attempts.
 UnableToRead_0_UserCanceled=Unable to read repository at: {0}. Login canceled by user.
 RepositoryTransport_failedReadRepo=Error while reading from repository: {0}.
-RepositoryTransport_unsafeHttp=Using unsafe http transport to retrieve {0}, see CVE-2021-41033. Consider using https instead.
-RepositoryTransport_unsafeHttpBlocked=Using unsafe http transport to retrieve {0} is blocked, see CVE-2021-41033. Only https is supported. Use the system property -Dp2.httpAction=redirect to automatically redirect to https or -Dp2.httpAction=allow to permit unsafe access.
+RepositoryTransport_unsafeProtocol=Using unsafe {0} transport to retrieve {1}, see CVE-2021-41033. Consider using {0}s instead.
+RepositoryTransport_unsafeProtocolBlocked=Using unsafe {0} transport to retrieve {1} is blocked, see CVE-2021-41033. Use the system property -Dp2.{0}Rule=redirect to automatically redirect to {0}s or -Dp2.{0}Rule=allow to permit unsafe access.


### PR DESCRIPTION
Deal with both ftp and http protocol. The system property p2.{protocol}Rule can be used to configure the behavior.

https://github.com/eclipse-equinox/p2/issues/230