### PR TITLE
Silence warnings in CoercingComparator

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/CoercingComparator.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/CoercingComparator.java
@@ -285,7 +285,7 @@ public abstract class CoercingComparator<T> {
 	 *                                  was impossible
 	 * @see Comparator#compare(Object, Object)
 	 */
-	@SuppressWarnings({ "unchecked" })
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static <TA extends Object, TB extends Object> int coerceAndCompare(TA o1, TB o2)
 			throws IllegalArgumentException {
 		if (o1 == null || o2 == null)
@@ -343,7 +343,7 @@ public abstract class CoercingComparator<T> {
 	 * @param value The value
 	 * @return The coercing comparator
 	 */
-	@SuppressWarnings({ "unchecked", "deprecation" })
+	@SuppressWarnings({ "unchecked", "deprecation", "removal" })
 	public static <V> CoercingComparator<V> getComparator(V value, Object v2) {
 		Class<V> vClass = (Class<V>) value.getClass();
 		CoercingComparator<?>[] carr = coercers;


### PR DESCRIPTION
Rawtypes one was removed by error while moving to Java 17 and AccessController.doPrivileged has no clear replacement and stays until JVM actually removes this one.
https://github.com/eclipse-platform/eclipse.platform/issues/385 is the general tracking issue for SecurityManager removal in the JVM