### PR TITLE
Improve the handling of revoked PGP keys

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/CertificateChecker.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/CertificateChecker.java
@@ -222,7 +222,8 @@ public class CertificateChecker {
 					if (!verifiedKeys.isEmpty()) {
 						if (!isTrustedKeySetInitialized) {
 							isTrustedKeySetInitialized = true;
-							trustedKeySet.addAll(trustedKeys.get().all());
+								trustedKeySet.addAll(trustedKeys.get().all().stream()
+										.filter(it -> keyService.getVerifiedRevocationDate(it) == null).toList());
 						}
 						// Only record the untrusted keys if none of the keys are trusted.
 						if (verifiedKeys.stream().noneMatch(trustedKeySet::contains)) {


### PR DESCRIPTION
Adding missing change for the CertificateChecker removes from the set of trusted keys all PGP keys that are revoked.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=581452