### PR TITLE
Support a system property for surrogate profile IU lock state

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/SurrogateProfileHandler.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/SurrogateProfileHandler.java
@@ -62,7 +62,18 @@ public class SurrogateProfileHandler implements ISurrogateProfileHandler {
 		for (IInstallableUnit iu : rootIUs) {
 			userProfile.addInstallableUnit(iu);
 			userProfile.addInstallableUnitProperties(iu, sharedProfile.getInstallableUnitProperties(iu));
-			userProfile.setInstallableUnitProperty(iu, IProfile.PROP_PROFILE_LOCKED_IU, IU_LOCKED);
+			String profileLockedIUSystemProperty = EngineActivator.getContext()
+					.getProperty(IProfile.PROP_PROFILE_LOCKED_IU);
+			if (profileLockedIUSystemProperty == null) {
+				userProfile.setInstallableUnitProperty(iu, IProfile.PROP_PROFILE_LOCKED_IU, IU_LOCKED);
+			} else {
+				String installableUnitProperty = userProfile.getInstallableUnitProperty(iu,
+						IProfile.PROP_PROFILE_LOCKED_IU);
+				int locked = installableUnitProperty == null ? IProfile.LOCK_NONE
+						: Integer.parseInt(installableUnitProperty);
+				userProfile.setInstallableUnitProperty(iu, IProfile.PROP_PROFILE_LOCKED_IU,
+						Integer.toString(locked | Integer.parseInt(profileLockedIUSystemProperty)));
+			}
 			userProfile.setInstallableUnitProperty(iu, PROP_BASE, Boolean.TRUE.toString());
 		}
 


### PR DESCRIPTION
Use the system property org.eclipse.equinox.p2.type.lock as a mask for setting that IU property lock state, e.g., setting it to 0 will leave the mask as specified in the user profile, 1 will lock it only for uninstall, and 3 is what it does by default, which is to look for uninstall and update.

Fixes https://github.com/eclipse-equinox/p2/issues/254