### PR TITLE
Notify user about updates for write-protected components

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdateMessages.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdateMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2016 IBM Corporation and others.
+ * Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Christian Georgi <christian.georgi@sap.com> - Bug 432887 - Setting to show update wizard w/o notification popup
  *     Mikael Barbero (Eclipse Foundation) - Bug 498116
+ *     Vasili Gulevich (Spirent Communications) - Bug #254
  *******************************************************************************/
 
 package org.eclipse.equinox.internal.p2.ui.sdk.scheduler;
@@ -19,7 +20,7 @@ package org.eclipse.equinox.internal.p2.ui.sdk.scheduler;
 import org.eclipse.osgi.util.NLS;
 
 /**
- * Message class for provisioning UI messages.  
+ * Message class for provisioning UI messages.
  * 
  * @since 3.5
  */
@@ -42,6 +43,7 @@ public class AutomaticUpdateMessages extends NLS {
 	public static String AutomaticUpdateScheduler_240Minutes;
 	public static String AutomaticUpdateScheduler_UpdateNotInitialized;
 	public static String AutomaticUpdatesPopup_UpdatesAvailableTitle;
+	public static String AutomaticUpdatesFailPopup_ClickToReviewUpdates;
 	public static String AutomaticUpdater_AutomaticDownloadOperationName;
 	public static String AutomaticUpdater_ClickToReviewUpdates;
 	public static String AutomaticUpdater_ClickToReviewUpdatesWithProblems;

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatesFailPopup.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatesFailPopup.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Spirent Communications and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *		Vasili Gulevich (Spirent Communications) - initial implementation, Bug #254
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.ui.sdk.scheduler;
+
+import org.eclipse.jface.preference.PreferenceDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.*;
+import org.eclipse.ui.dialogs.PreferencesUtil;
+
+/**
+ * UpdatesFailPopup is an async popup dialog for notifying the user of updates
+ * that can't be installed.
+ *
+ */
+class AutomaticUpdatesFailPopup extends UpdatesPopup {
+
+	public AutomaticUpdatesFailPopup(Shell parentShell) {
+		super(parentShell, AutomaticUpdateMessages.AutomaticUpdatesFailPopup_ClickToReviewUpdates);
+	}
+
+	@Override
+	protected Composite createDialogArea(Composite parent) {
+		Composite result = super.createDialogArea(parent);
+		createConfigureSection(result);
+		return result;
+	}
+
+	private void createConfigureSection(Composite parent) {
+		Link remindLink = new Link(parent, SWT.MULTI | SWT.WRAP | SWT.RIGHT);
+		remindLink.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+			PreferenceDialog dialog = PreferencesUtil.createPreferenceDialogOn(getShell(),
+					PreferenceConstants.PREF_PAGE_AUTO_UPDATES, null, null);
+			dialog.open();
+
+		}));
+		remindLink.setText(AutomaticUpdateMessages.AutomaticUpdatesPopup_PrefLinkOnly);
+		remindLink.setLayoutData(new GridData(GridData.FILL_BOTH));
+	}
+}

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatesPopup.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatesPopup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2018 IBM Corporation and others.
+ * Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,37 +11,31 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Johannes Michler <orgler@gmail.com> - Bug 321568 -  [ui] Preference for automatic-update-reminder doesn't work in multilanguage-environments
+ *     Vasili Gulevich (Spirent Communications) - factor out UpdatesPopup
  *******************************************************************************/
 package org.eclipse.equinox.internal.p2.ui.sdk.scheduler;
 
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.dialogs.IDialogSettings;
-import org.eclipse.jface.dialogs.PopupDialog;
-import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceDialog;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.MouseListener;
 import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.*;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.progress.WorkbenchJob;
 
 /**
- * AutomaticUpdatesPopup is an async popup dialog for notifying the user of
- * updates.
+ * Async popup dialog for notifying the user of eligible updates.
  * 
  * @since 3.4
  */
-public class AutomaticUpdatesPopup extends PopupDialog {
+public class AutomaticUpdatesPopup extends UpdatesPopup {
 	public static final String[] ELAPSED_VALUES = { PreferenceConstants.PREF_REMIND_30Minutes,
 			PreferenceConstants.PREF_REMIND_60Minutes, PreferenceConstants.PREF_REMIND_240Minutes };
 	public static final String[] ELAPSED_LOCALIZED_STRINGS = {
@@ -51,49 +45,27 @@ public class AutomaticUpdatesPopup extends PopupDialog {
 	private static final long MINUTE = 60 * 1000L;
 	private static final String PREFS_HREF = "PREFS"; //$NON-NLS-1$
 	private static final String DIALOG_SETTINGS_SECTION = "AutomaticUpdatesPopup"; //$NON-NLS-1$
-	private static final int POPUP_OFFSET = 20;
 
 	IPreferenceStore prefs;
 	long remindDelay = -1L;
 	IPropertyChangeListener prefListener;
 	WorkbenchJob remindJob;
 	boolean downloaded;
-	Composite dialogArea;
 	Link remindLink;
-	MouseListener clickListener;
 
 	public AutomaticUpdatesPopup(Shell parentShell, boolean alreadyDownloaded, IPreferenceStore prefs) {
-		super(parentShell, PopupDialog.INFOPOPUPRESIZE_SHELLSTYLE | SWT.MODELESS, false, true, true, false, false,
-				AutomaticUpdateMessages.AutomaticUpdatesPopup_UpdatesAvailableTitle, null);
+		super(parentShell, alreadyDownloaded ? AutomaticUpdateMessages.AutomaticUpdatesPopup_ClickToReviewDownloaded
+				: AutomaticUpdateMessages.AutomaticUpdatesPopup_ClickToReviewNotDownloaded);
 		downloaded = alreadyDownloaded;
 		this.prefs = prefs;
 		remindDelay = computeRemindDelay();
-		clickListener = MouseListener
-				.mouseDownAdapter(e -> AutomaticUpdatePlugin.getDefault().getAutomaticUpdater().launchUpdate());
 	}
 
 	@Override
-	protected Control createDialogArea(Composite parent) {
-		dialogArea = new Composite(parent, SWT.NONE);
-		dialogArea.setLayoutData(new GridData(GridData.FILL_BOTH));
-		GridLayout layout = new GridLayout();
-		layout.numColumns = 1;
-		dialogArea.setLayout(layout);
-		dialogArea.addMouseListener(clickListener);
-
-		// The "click to update" label
-		Label infoLabel = new Label(dialogArea, SWT.NONE);
-		if (downloaded)
-			infoLabel.setText(AutomaticUpdateMessages.AutomaticUpdatesPopup_ClickToReviewDownloaded);
-		else
-			infoLabel.setText(AutomaticUpdateMessages.AutomaticUpdatesPopup_ClickToReviewNotDownloaded);
-		infoLabel.setLayoutData(new GridData(GridData.FILL_BOTH));
-		infoLabel.addMouseListener(clickListener);
-
-		createRemindSection(dialogArea);
-
-		return dialogArea;
-
+	protected Composite createDialogArea(Composite parent) {
+		Composite result = super.createDialogArea(parent);
+		createRemindSection(result);
+		return result;
 	}
 
 	private void createRemindSection(Composite parent) {
@@ -204,31 +176,6 @@ public class AutomaticUpdatesPopup extends PopupDialog {
 		}
 	}
 
-	@Override
-	protected void configureShell(Shell newShell) {
-		super.configureShell(newShell);
-		newShell.setText(AutomaticUpdateMessages.AutomaticUpdatesPopup_UpdatesAvailableTitle);
-	}
-
-	@Override
-	protected Point getInitialLocation(Point initialSize) {
-		Shell parent = getParentShell();
-		Point parentSize, parentLocation;
-
-		if (parent != null) {
-			parentSize = parent.getSize();
-			parentLocation = parent.getLocation();
-		} else {
-			Rectangle bounds = getShell().getDisplay().getBounds();
-			parentSize = new Point(bounds.width, bounds.height);
-			parentLocation = new Point(0, 0);
-		}
-		// We have to take parent location into account because SWT considers all
-		// shell locations to be in display coordinates, even if the shell is parented.
-		return new Point(parentSize.x - initialSize.x + parentLocation.x - POPUP_OFFSET,
-				parentSize.y - initialSize.y + parentLocation.y - POPUP_OFFSET);
-	}
-
 	void handlePreferenceChange(PropertyChangeEvent event) {
 		if (PreferenceConstants.PREF_REMIND_SCHEDULE.equals(event.getProperty())) {
 			// Reminders turned on
@@ -253,42 +200,6 @@ public class AutomaticUpdatesPopup extends PopupDialog {
 			computeRemindDelay();
 			scheduleRemindJob();
 		}
-	}
-
-	/*
-	 * Overridden so that clicking in the title menu area closes the dialog. Also
-	 * creates a close box menu in the title area.
-	 */
-	@Override
-	protected Control createTitleMenuArea(Composite parent) {
-		Composite titleComposite = (Composite) super.createTitleMenuArea(parent);
-		titleComposite.addMouseListener(clickListener);
-
-		ToolBar toolBar = new ToolBar(titleComposite, SWT.FLAT);
-		ToolItem closeButton = new ToolItem(toolBar, SWT.PUSH, 0);
-
-		GridDataFactory.fillDefaults().align(SWT.END, SWT.CENTER).applyTo(toolBar);
-		closeButton.setImage(
-				AutomaticUpdatePlugin.getDefault().getImageRegistry().get((AutomaticUpdatePlugin.IMG_TOOL_CLOSE)));
-		closeButton.setHotImage(
-				AutomaticUpdatePlugin.getDefault().getImageRegistry().get((AutomaticUpdatePlugin.IMG_TOOL_CLOSE_HOT)));
-		closeButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> close()));
-		// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=177183
-		toolBar.addMouseListener(MouseListener.mouseDownAdapter(e -> close()));
-		return titleComposite;
-	}
-
-	/*
-	 * Overridden to adjust the span of the title label. Reachy, reachy....
-	 */
-	@Override
-	protected Control createTitleControl(Composite parent) {
-		Control control = super.createTitleControl(parent);
-		Object data = control.getLayoutData();
-		if (data instanceof GridData) {
-			((GridData) data).horizontalSpan = 1;
-		}
-		return control;
 	}
 
 	public static String getElapsedTimeString(String elapsedTimeKey) {

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/UpdatesPopup.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/UpdatesPopup.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Spirent Communications and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *		Vasili Gulevich (Spirent Communications) - initial implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.ui.sdk.scheduler;
+
+import java.util.Objects;
+import org.eclipse.jface.dialogs.PopupDialog;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseListener;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.*;
+
+/**
+ * UpdatesPopup is an async popup dialog for notifying the user of updates.
+ * 
+ * @since 4.28
+ */
+class UpdatesPopup extends PopupDialog {
+	private static final int POPUP_OFFSET = 20;
+
+	protected Composite dialogArea;
+	private final MouseListener clickListener;
+
+	private final String message;
+
+	public UpdatesPopup(Shell parentShell, String message) {
+		super(parentShell, PopupDialog.INFOPOPUPRESIZE_SHELLSTYLE | SWT.MODELESS, false, true, true, false, false,
+				AutomaticUpdateMessages.AutomaticUpdatesPopup_UpdatesAvailableTitle, null);
+		this.message = Objects.requireNonNull(message);
+		clickListener = MouseListener
+				.mouseDownAdapter(e -> AutomaticUpdatePlugin.getDefault().getAutomaticUpdater().launchUpdate());
+	}
+
+	@Override
+	protected Composite createDialogArea(Composite parent) {
+		dialogArea = new Composite(parent, SWT.NONE);
+		dialogArea.setLayoutData(new GridData(GridData.FILL_BOTH));
+		GridLayout layout = new GridLayout();
+		layout.numColumns = 1;
+		dialogArea.setLayout(layout);
+		dialogArea.addMouseListener(clickListener);
+
+		// The "click to update" label
+		Label infoLabel = new Label(dialogArea, SWT.NONE);
+		infoLabel.setText(message);
+		infoLabel.setLayoutData(new GridData(GridData.FILL_BOTH));
+		infoLabel.addMouseListener(clickListener);
+
+		return dialogArea;
+	}
+
+	@Override
+	protected void configureShell(Shell newShell) {
+		super.configureShell(newShell);
+		newShell.setText(AutomaticUpdateMessages.AutomaticUpdatesPopup_UpdatesAvailableTitle);
+	}
+
+	@Override
+	protected Point getInitialLocation(Point initialSize) {
+		Shell parent = getParentShell();
+		Point parentSize, parentLocation;
+
+		if (parent != null) {
+			parentSize = parent.getSize();
+			parentLocation = parent.getLocation();
+		} else {
+			Rectangle bounds = getShell().getDisplay().getBounds();
+			parentSize = new Point(bounds.width, bounds.height);
+			parentLocation = new Point(0, 0);
+		}
+		// We have to take parent location into account because SWT considers all
+		// shell locations to be in display coordinates, even if the shell is parented.
+		return new Point(parentSize.x - initialSize.x + parentLocation.x - POPUP_OFFSET,
+				parentSize.y - initialSize.y + parentLocation.y - POPUP_OFFSET);
+	}
+
+	/*
+	 * Overridden so that clicking in the title menu area closes the dialog. Also
+	 * creates a close box menu in the title area.
+	 */
+	@Override
+	protected Control createTitleMenuArea(Composite parent) {
+		Composite titleComposite = (Composite) super.createTitleMenuArea(parent);
+		titleComposite.addMouseListener(clickListener);
+
+		ToolBar toolBar = new ToolBar(titleComposite, SWT.FLAT);
+		ToolItem closeButton = new ToolItem(toolBar, SWT.PUSH, 0);
+
+		GridDataFactory.fillDefaults().align(SWT.END, SWT.CENTER).applyTo(toolBar);
+		closeButton.setImage(
+				AutomaticUpdatePlugin.getDefault().getImageRegistry().get((AutomaticUpdatePlugin.IMG_TOOL_CLOSE)));
+		closeButton.setHotImage(
+				AutomaticUpdatePlugin.getDefault().getImageRegistry().get((AutomaticUpdatePlugin.IMG_TOOL_CLOSE_HOT)));
+		closeButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> close()));
+		// See https://bugs.eclipse.org/bugs/show_bug.cgi?id=177183
+		toolBar.addMouseListener(MouseListener.mouseDownAdapter(e -> close()));
+		return titleComposite;
+	}
+
+	/*
+	 * Overridden to adjust the span of the title label. Reachy, reachy....
+	 */
+	@Override
+	protected Control createTitleControl(Composite parent) {
+		Control control = super.createTitleControl(parent);
+		Object data = control.getLayoutData();
+		if (data instanceof GridData) {
+			((GridData) data).horizontalSpan = 1;
+		}
+		return control;
+	}
+
+}

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/messages.properties
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/messages.properties
@@ -28,6 +28,7 @@ AutomaticUpdateScheduler_60Minutes=Hour
 AutomaticUpdateScheduler_240Minutes= 4 Hours
 AutomaticUpdateScheduler_UpdateNotInitialized=The update checker service is not initialized
 AutomaticUpdatesPopup_UpdatesAvailableTitle=Updates Available
+AutomaticUpdatesFailPopup_ClickToReviewUpdates=Updates are available, but can't be installed.\nClick here to review them.
 AutomaticUpdater_AutomaticDownloadOperationName=Automatic updates download
 AutomaticUpdater_ClickToReviewUpdates=Updates are available.  Click here to review and install them.
 AutomaticUpdater_ClickToReviewUpdatesWithProblems=Updates are available, but there may be some compatibility problems.  Click here to review them.

--- a/org.eclipse.equinox.p2.releng/default.target
+++ b/org.eclipse.equinox.p2.releng/default.target
@@ -6,7 +6,7 @@
 <unit id="org.eclipse.platform.sdk" version="0.0.0"/>
 <unit id="org.eclipse.core.tests.harness" version="0.0.0"/>
 <unit id="org.eclipse.test.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.25-I-builds"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.28-I-builds"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.bouncycastle.bcprov" version="0.0.0"/>


### PR DESCRIPTION
Fixes #254.
Function is enabled with JVM argument `-Dorg.eclipse.equinox.p2.ui.sdk.scheduler.warnLocked=true`

### Previous behavior
Automatic update check fails silently on write-protected installations.
Explicit check for updates shows message "Insufficient access privileges to apply this update".
<img width="809" alt="Screenshot 2023-04-22 at 11 41 48" src="https://user-images.githubusercontent.com/650857/234095167-763e3ab2-438d-4d3c-a829-e75d9505eec1.png">

### New behavior
If automatic update check fails due to insufficient privileges, user is presented with a new popup:
<img width="491" alt="Screenshot 2023-04-24 at 22 01 27" src="https://user-images.githubusercontent.com/650857/234094576-fedced4b-ba64-4f99-ad92-215ab0123ef7.png">

On click, an update dialog shown, just like for explicit "Check For Updates", allowing user to see which updates can't be installed.


