### PR TITLE
CacheManager: Fix exception handling

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/CacheManager.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/CacheManager.java
@@ -113,20 +113,23 @@ public class CacheManager {
 				// it is not meaningful to continue - the credentials are for the server
 				// do not pass the exception - it gives no additional meaningful user information
 				throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, ProvisionException.REPOSITORY_FAILED_AUTHENTICATION, NLS.bind(Messages.CacheManager_AuthenticationFaileFor_0, remoteFile), null));
+			} catch (FileNotFoundException e) {
+				throw new FileNotFoundException(NLS.bind(Messages.CacheManager_Repository_not_found, remoteFile));
 			} catch (CoreException e) {
-				// give up on a timeout - if we did not get a 404 on the jar, we will just prolong the pain
-				// by (almost certainly) also timing out on the xml.
-				if (e.getStatus() != null && e.getStatus().getException() != null) {
-					Throwable ex = e.getStatus().getException();
+				IStatus status = e.getStatus();
+				if (status == null)
+					throw new ProvisionException(
+							new Status(IStatus.ERROR, Activator.ID, ProvisionException.REPOSITORY_NOT_FOUND,
+									NLS.bind(Messages.CacheManager_FailedCommunicationWithRepo_0, remoteFile), e));
+				else if (status.getException() instanceof FileNotFoundException)
+					throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID,
+							ProvisionException.REPOSITORY_NOT_FOUND, status.getMessage(), status.getException()));
+				else if (status.getException() != null) {
+					Throwable ex = status.getException();
 					if (ex.getClass() == java.net.SocketTimeoutException.class)
 						throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, ProvisionException.REPOSITORY_FAILED_READ, NLS.bind(Messages.CacheManager_FailedCommunicationWithRepo_0, remoteFile), ex));
 				}
-			} catch (OperationCanceledException e) {
-				// must pass this on
-				throw e;
-			} catch (Exception e) {
-				// not ideal, just skip the jar on error, and try the xml instead - report errors for
-				// the xml.
+				throw new ProvisionException(status);
 			}
 
 			stale = lastModifiedRemote != lastModified;

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/Messages.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/Messages.java
@@ -25,6 +25,7 @@ public class Messages extends NLS {
 	public static String CacheManager_CannotLoadNonUrlLocation;
 	public static String CacheManager_FailedCommunicationWithRepo_0;
 	public static String CacheManager_Neither_0_nor_1_found;
+	public static String CacheManager_Repository_not_found;
 
 	public static String CacheManage_ErrorRenamingCache;
 

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/messages.properties
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/messages.properties
@@ -23,6 +23,7 @@ repoMan_internalError=Internal error.
 repo_loading = Loading the repository {0}
 
 CacheManager_Neither_0_nor_1_found=Neither {0} nor {1} found.
+CacheManager_Repository_not_found=Repository not found: {0}
 CacheManager_AuthenticationFaileFor_0=Authentication failed for {0}.
 CacheManager_CannotLoadNonUrlLocation=Cannot load repository from non-URL location {0} 
 CacheManager_FailedCommunicationWithRepo_0=Communication with repository at {0} failed.


### PR DESCRIPTION
Method

    createCacheFromFile()

was introduced in

    Bug 464614 - Use XZ as compression formats of metadata files

and is more a less a simplified copy of

    createCache()

which only deals with a single URI, instead of two (with and without .jar appended).

However, the condensed exception handling was missing important branches and swallowed too many exceptions. This caused that a FileNotFoundException Was silently swallowed and the low-level Transport was asked anyways, instead of bailing out with a proper PrivisionException immediately.

The low-level Transport then, after sending another redundant HTTP request, returned a ProvisionException with improper status code (ARTIFACT_NOT_FOUND instead of REPOSITORY_NOT_FOUND).

Fixes #257.