### PR TITLE
Use new static IPath factories and constants

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.core;singleton:=true
-Bundle-Version: 2.10.0.qualifier
+Bundle-Version: 2.10.100.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.equinox.internal.p2.core.Activator
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/FileUtils.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/FileUtils.java
@@ -287,7 +287,7 @@ public class FileUtils {
 	 * @throws IOException
 	 */
 	public static void zip(ZipOutputStream output, File source, Set<File> exclusions, IPathComputer pathComputer) throws IOException {
-		zip(output, source, exclusions, pathComputer, new HashSet<IPath>());
+		zip(output, source, exclusions, pathComputer, new HashSet<>());
 	}
 
 	public static void zip(ZipOutputStream output, File source, Set<File> exclusions, IPathComputer pathComputer, Set<IPath> directoryEntries) throws IOException {
@@ -396,7 +396,7 @@ public class FileUtils {
 		}
 
 		if (isManifest) {
-			zipDirectoryEntry(output, new Path("META-INF"), source.lastModified(), directoryEntries); //$NON-NLS-1$
+			zipDirectoryEntry(output, IPath.fromOSString("META-INF"), source.lastModified(), directoryEntries); //$NON-NLS-1$
 		}
 	}
 
@@ -432,8 +432,8 @@ public class FileUtils {
 		return new IPathComputer() {
 			@Override
 			public IPath computePath(File source) {
-				IPath result = new Path(source.getAbsolutePath());
-				IPath rootPath = new Path(root.getAbsolutePath());
+				IPath result = IPath.fromOSString(source.getAbsolutePath());
+				IPath rootPath = IPath.fromOSString(root.getAbsolutePath());
 				result = result.removeFirstSegments(rootPath.matchingFirstSegments(result));
 				return result.setDevice(null);
 			}
@@ -472,7 +472,7 @@ public class FileUtils {
 			@Override
 			public IPath computePath(File source) {
 				if (computer == null) {
-					IPath sourcePath = new Path(source.getAbsolutePath());
+					IPath sourcePath = IPath.fromOSString(source.getAbsolutePath());
 					sourcePath = sourcePath.removeLastSegments(segmentsToKeep);
 					computer = createRootPathComputer(sourcePath.toFile());
 				}
@@ -495,7 +495,7 @@ public class FileUtils {
 		return new IPathComputer() {
 			@Override
 			public IPath computePath(File source) {
-				IPath sourcePath = new Path(source.getAbsolutePath());
+				IPath sourcePath = IPath.fromOSString(source.getAbsolutePath());
 				sourcePath = sourcePath.removeFirstSegments(Math.max(0, sourcePath.segmentCount() - segmentsToKeep));
 				return sourcePath.setDevice(null);
 			}

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
@@ -59,5 +59,5 @@ Export-Package: org.eclipse.equinox.internal.p2.publisher.compatibility;x-intern
  org.eclipse.pde.internal.build.publisher;x-friends:="org.eclipse.pde.build",
  org.eclipse.pde.internal.publishing;x-friends:="org.eclipse.pde.build",
  org.eclipse.pde.internal.swt.tools;x-internal:=true
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.5.0,4.0.0)"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.equinox.p2.publisher.eclipse

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.publisher.eclipse;singleton:=true
-Bundle-Version: 1.5.0.qualifier
+Bundle-Version: 1.5.100.qualifier
 Bundle-Activator: org.eclipse.pde.internal.publishing.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/ExecutablesDescriptor.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/ExecutablesDescriptor.java
@@ -104,7 +104,7 @@ public class ExecutablesDescriptor {
 		ExecutablesDescriptor result = new ExecutablesDescriptor(os, executable, location, null);
 		File[] files = location.listFiles();
 		for (int i = 0; files != null && i < files.length; i++) {
-			String extension = new Path(files[i].getName()).getFileExtension();
+			String extension = IPath.fromOSString(files[i].getName()).getFileExtension();
 			if (files[i].isFile() && (extension == null || extension.equals("so"))) //$NON-NLS-1$
 				result.addFile(files[i]);
 		}

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/pde/internal/build/publisher/GatheringComputer.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/pde/internal/build/publisher/GatheringComputer.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.Set;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.equinox.internal.p2.core.helpers.FileUtils.IPathComputer;
 
 public class GatheringComputer implements IPathComputer {
@@ -31,11 +30,11 @@ public class GatheringComputer implements IPathComputer {
 		IPath result = null;
 		if (prefix.startsWith(PROVIDED_PATH)) {
 			// the desired path is provided in the map
-			result = new Path(prefix.substring(10));
+			result = IPath.fromOSString(prefix.substring(10));
 		} else {
 			//else the map contains a prefix which must be stripped from the path
-			result = new Path(source.getAbsolutePath());
-			IPath rootPath = new Path(prefix);
+			result = IPath.fromOSString(source.getAbsolutePath());
+			IPath rootPath = IPath.fromOSString(prefix);
 			result = result.removeFirstSegments(rootPath.matchingFirstSegments(result));
 		}
 		return result.setDevice(null);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/AbstractProvisioningTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/AbstractProvisioningTest.java
@@ -52,10 +52,10 @@ import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.equinox.internal.p2.artifact.repository.simple.SimpleArtifactRepository;
@@ -1013,7 +1013,7 @@ public abstract class AbstractProvisioningTest extends TestCase {
 		if (base == null)
 			fail(message + " entry not found in bundle: " + entry);
 		try {
-			String osPath = new Path(FileLocator.toFileURL(base).getPath()).toOSString();
+			String osPath = IPath.fromOSString(FileLocator.toFileURL(base).getPath()).toOSString();
 			File result = new File(osPath);
 			if (!result.getCanonicalPath().equals(result.getPath()))
 				fail(message + " result path: " + result.getPath() + " does not match canonical path: " + result.getCanonicalFile().getPath());
@@ -1659,7 +1659,7 @@ public abstract class AbstractProvisioningTest extends TestCase {
 							fail(message + " descriptor mismatch");
 						if (!(expectedFile.exists() && actualFile.exists()))
 							fail(message + " file does not exist");
-						if ("jar".equals(new Path(expectedFile.getName()).getFileExtension())) {
+						if ("jar".equals(IPath.fromOSString(expectedFile.getName()).getFileExtension())) {
 							//compare jar contents
 							assertEqualJars(expectedFile, actualFile);
 						} else {

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/core/FileUtilsTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/core/FileUtilsTest.java
@@ -25,7 +25,6 @@ import java.util.zip.ZipOutputStream;
 import org.apache.tools.tar.TarEntry;
 import org.apache.tools.tar.TarOutputStream;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.equinox.internal.p2.core.helpers.FileUtils;
 import org.eclipse.equinox.internal.p2.core.helpers.FileUtils.IPathComputer;
 import org.eclipse.equinox.internal.p2.touchpoint.natives.Util;
@@ -359,7 +358,7 @@ public class FileUtilsTest extends AbstractProvisioningTest {
 
 	private void validate(IPathComputer computer, String input, String output) {
 		IPath computed = computer.computePath(new File(input));
-		IPath desired = new Path(output);
+		IPath desired = IPath.fromOSString(output);
 		assertEquals(computed, desired);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/full/AbstractEnd2EndTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/full/AbstractEnd2EndTest.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
 import org.eclipse.equinox.internal.p2.core.helpers.ServiceHelper;
@@ -287,13 +286,13 @@ public abstract class AbstractEnd2EndTest extends AbstractProvisioningTest {
 		}
 
 		if (os.equals(org.eclipse.osgi.service.environment.Constants.OS_WIN32)) {
-			IPath path = new Path(name);
+			IPath path = IPath.fromOSString(name);
 			if ("exe".equals(path.getFileExtension())) //$NON-NLS-1$
 				return name;
 			return name + ".exe"; //$NON-NLS-1$
 		}
 		if (os.equals(org.eclipse.osgi.service.environment.Constants.OS_MACOSX)) {
-			IPath path = new Path(name);
+			IPath path = IPath.fromOSString(name);
 			if ("app".equals(path.getFileExtension())) //$NON-NLS-1$
 				return name;
 			StringBuilder buffer = new StringBuilder();

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/JarURLMetadataRepositoryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/JarURLMetadataRepositoryTest.java
@@ -21,8 +21,8 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.equinox.internal.p2.core.helpers.FileUtils;
 import org.eclipse.equinox.p2.core.ProvisionException;
@@ -73,7 +73,7 @@ public class JarURLMetadataRepositoryTest extends AbstractProvisioningTest {
 	public void testZipFileRepository() throws IOException, ProvisionException, OperationCanceledException {
 		//ensure a random agent doesn't cause it to fail
 		File zip = TestData.getFile("bug369834", "f-TestBuild-group.group.group.zip");
-		URI location = URIUtil.toJarURI(zip.toURI(), new Path(""));
+		URI location = URIUtil.toJarURI(zip.toURI(), IPath.EMPTY);
 		IMetadataRepository repo = manager.loadRepository(location, null);
 		assertTrue(!repo.query(QueryUtil.createIUAnyQuery(), null).isEmpty());
 	}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/planner/Bug362692.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/planner/Bug362692.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.equinox.p2.tests.planner;
 
+import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -21,7 +22,6 @@ import java.util.Set;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.p2.engine.InstallableUnitOperand;
 import org.eclipse.equinox.p2.engine.IProvisioningPlan;
@@ -93,7 +93,7 @@ public class Bug362692 extends AbstractPlannerTest {
 		// set the metadata repositories on the provisioning context. one for the dropins and one for the shared area
 		Collection<URI> repoURLs = new ArrayList<>();
 		repoURLs.add(repo.getLocation());
-		repoURLs.add(new Path(getTestDataPath()).append("shared").toFile().toURI());
+		repoURLs.add(new File(getTestDataPath(), "shared").toURI());
 		ProvisioningContext context = getContext(repoURLs);
 		context.setExtraInstallableUnits(new ArrayList<>(toAdd));
 		IProfileChangeRequest actualChangeRequest = createProfileChangeRequest(toAdd, null, null);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/AccumulateConfigDataActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/AccumulateConfigDataActionTest.java
@@ -23,8 +23,8 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
 import org.eclipse.equinox.internal.provisional.frameworkadmin.ConfigData;
 import org.eclipse.equinox.p2.publisher.IPublisherAdvice;
@@ -72,11 +72,11 @@ public class AccumulateConfigDataActionTest extends ActionTest {
 		assertTrue(programArgs.length == 4);
 		assertTrue(programArgs[0].equalsIgnoreCase("-startup")); //$NON-NLS-1$
 
-		Path path1 = new Path(TestActivator.getTestDataFolder().getPath() + FOO);
+		IPath path1 = IPath.fromOSString(TestActivator.getTestDataFolder().getPath() + FOO);
 		assertTrue(path1.toFile().toURI().equals(new URI(programArgs[1])));
 		assertTrue(programArgs[2].equalsIgnoreCase("--launcher.library"));//$NON-NLS-1$
 
-		Path path2 = new Path(TestActivator.getTestDataFolder().getPath() + BAR);
+		IPath path2 = IPath.fromOSString(TestActivator.getTestDataFolder().getPath() + BAR);
 		assertTrue(path2.toFile().toURI().equals(new URI(programArgs[3])));
 
 		String[] vmArgs = captured.getVMArguments();

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ActionTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.StringTokenizer;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.equinox.internal.p2.core.helpers.FileUtils;
 import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
@@ -136,7 +135,7 @@ public abstract class ActionTest extends AbstractProvisioningTest {
 		return result;
 	}
 
-	protected Map<String, Object[]> getFileMap(Map<String, Object[]> map, File[] files, Path root) {
+	protected Map<String, Object[]> getFileMap(Map<String, Object[]> map, File[] files, IPath root) {
 		for (File file : files) {
 			if (file.isDirectory()) {
 				map = getFileMap(map, file.listFiles(), root);
@@ -148,7 +147,7 @@ public abstract class ActionTest extends AbstractProvisioningTest {
 					ByteArrayOutputStream content = new ByteArrayOutputStream();
 					File contentBytes = file;
 					FileUtils.copyStream(new FileInputStream(contentBytes), false, content, true);
-					IPath entryPath = new Path(file.getAbsolutePath());
+					IPath entryPath = IPath.fromOSString(file.getAbsolutePath());
 					entryPath = entryPath.removeFirstSegments(root.matchingFirstSegments(entryPath));
 					entryPath = entryPath.setDevice(null);
 					map.put(entryPath.toString(), new Object[] {contentBytes, content.toByteArray()});

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/BundlesActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/BundlesActionTest.java
@@ -40,9 +40,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.zip.ZipInputStream;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.p2.director.QueryableArray;
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
@@ -222,7 +222,7 @@ public class BundlesActionTest extends ActionTest {
 		IArtifactKey key1 = ArtifactKey.parse("osgi.bundle,test1,0.1.0");//$NON-NLS-1$
 		ZipInputStream zis = artifactRepository.getZipInputStream(key1);
 		Map<String, Object[]> fileMap = getFileMap(new HashMap<>(), new File[] { TEST_FILE1 },
-				new Path(TEST_FILE1.getAbsolutePath()));
+				IPath.fromOSString(TEST_FILE1.getAbsolutePath()));
 		TestData.assertContains(fileMap, zis, true);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/FeaturesActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/FeaturesActionTest.java
@@ -29,8 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipInputStream;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
 import org.eclipse.equinox.internal.p2.metadata.IRequiredCapability;
 import org.eclipse.equinox.p2.metadata.IArtifactKey;
@@ -339,11 +339,11 @@ public class FeaturesActionTest extends ActionTest {
 	private void verifyArtifacts() throws IOException {
 		ZipInputStream actualStream = artifactRepository.getZipInputStream(FOO_KEY);
 		Map<String, Object[]> expected = getFileMap(new HashMap<>(), new File[] { new File(root, FOO) },
-				new Path(new File(root, FOO).getAbsolutePath()));
+				IPath.fromFile(new File(root, FOO)));
 		TestData.assertContains(expected, actualStream, true);
 
 		expected = getFileMap(new HashMap<>(), new File[] { new File(root, BAR) },
-				new Path(new File(root, BAR).getAbsolutePath()));
+				IPath.fromFile(new File(root, BAR)));
 		actualStream = artifactRepository.getZipInputStream(BAR_KEY);
 		TestData.assertContains(expected, actualStream, true);
 	}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/RootFilesActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/RootFilesActionTest.java
@@ -26,8 +26,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.ZipInputStream;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.p2.core.helpers.FileUtils;
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
@@ -188,7 +188,7 @@ public class RootFilesActionTest extends ActionTest {
 			FileUtils.copyStream(new FileInputStream(contentBytes), false, content, true);
 			boolean includeRootInEntry = ((testArg & INCLUDES_ROOT) > 0);
 			String entry = includeRootInEntry ? new File(fileEntry).getPath() : new File(fileEntry).getName();
-			entry = new Path(entry).toString();
+			entry = IPath.fromOSString(entry).toString();
 			map.put(entry, new Object[] {contentBytes, content.toByteArray()});
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/reconciler/dropins/AbstractSharedBundleProductTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/reconciler/dropins/AbstractSharedBundleProductTest.java
@@ -28,7 +28,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
 import org.eclipse.equinox.internal.p2.update.Configuration;
@@ -289,7 +289,8 @@ public class AbstractSharedBundleProductTest extends AbstractReconcilerTest {
 		for (BundleInfo info : infos.values()) {
 			if (info.getSymbolicName().contains("equinox.launcher"))
 				continue;
-			File location = new File(sharedBundleLocation, new Path(info.getLocation().toString()).lastSegment());
+			File location = new File(sharedBundleLocation,
+					IPath.fromOSString(info.getLocation().toString()).lastSegment());
 			assertTrue("3.1." + location.getAbsolutePath(), location.exists());
 			info.setLocation(location.toURI());
 		}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/repository/CacheManagerTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/repository/CacheManagerTest.java
@@ -22,11 +22,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.equinox.internal.p2.repository.AuthenticationFailedException;
 import org.eclipse.equinox.internal.p2.repository.CacheManager;
@@ -64,8 +62,7 @@ public class CacheManagerTest {
 
 	@After
 	public void tearDown() throws Exception {
-		Path repositoryLocationPath = new Path(repositoryLocation.getPath());
-		deleteFileOrDirectory(repositoryLocationPath.toFile());
+		deleteFileOrDirectory(new File(repositoryLocation));
 	}
 
 	@Test
@@ -151,9 +148,9 @@ public class CacheManagerTest {
 		repository.deleteOnExit();
 		assertTrue(repository.delete());
 		assertTrue(repository.mkdirs());
-		IPath contentXmlPath = new Path(repository.getAbsolutePath()).append("content.xml"); //$NON-NLS-1$
-		assertTrue(contentXmlPath.toFile().createNewFile());
-		contentXmlFile = contentXmlPath.toFile();
+		File contentXmlPath = new File(repository, "content.xml"); //$NON-NLS-1$
+		assertTrue(contentXmlPath.createNewFile());
+		contentXmlFile = contentXmlPath;
 		return repository.toURI();
 	}
 

--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.touchpoint.eclipse;singleton:=true
-Bundle-Version: 2.4.0.qualifier
+Bundle-Version: 2.4.100.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.touchpoint.eclipse.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Export-Package: org.eclipse.equinox.internal.p2.touchpoint.eclipse;version="2.0.
  org.eclipse.equinox.internal.p2.touchpoint.eclipse.actions;version="2.0.0";x-internal:=true,
  org.eclipse.equinox.internal.p2.update;version="2.0.0";x-friends:="org.eclipse.equinox.p2.reconciler.dropins,org.eclipse.equinox.p2.extensionlocation,org.eclipse.equinox.p2.directorywatcher",
  org.eclipse.equinox.p2.touchpoint.eclipse.query;version="2.0.0"
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.5.0,4.0.0)"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.xml.parsers,

--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/touchpoint/eclipse/PublisherUtil.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/touchpoint/eclipse/PublisherUtil.java
@@ -15,7 +15,7 @@
 package org.eclipse.equinox.internal.p2.touchpoint.eclipse;
 
 import java.io.File;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.equinox.p2.metadata.*;
 import org.eclipse.equinox.p2.publisher.AdviceFileAdvice;
 import org.eclipse.equinox.p2.publisher.PublisherInfo;
@@ -25,8 +25,8 @@ import org.eclipse.osgi.service.resolver.BundleDescription;
 public class PublisherUtil {
 
 	/**
-	 * Returns an IU corresponding to the given artifact key and bundle, or <code>null</code>
-	 * if an IU could not be created.
+	 * Returns an IU corresponding to the given artifact key and bundle, or
+	 * <code>null</code> if an IU could not be created.
 	 */
 	public static IInstallableUnit createBundleIU(IArtifactKey artifactKey, File bundleFile) {
 		BundleDescription bundleDescription = BundlesAction.createBundleDescriptionIgnoringExceptions(bundleFile);
@@ -34,7 +34,8 @@ public class PublisherUtil {
 			return null;
 		PublisherInfo info = new PublisherInfo();
 		Version version = Version.create(bundleDescription.getVersion().toString());
-		AdviceFileAdvice advice = new AdviceFileAdvice(bundleDescription.getSymbolicName(), version, new Path(bundleFile.getAbsolutePath()), AdviceFileAdvice.BUNDLE_ADVICE_FILE);
+		AdviceFileAdvice advice = new AdviceFileAdvice(bundleDescription.getSymbolicName(), version,
+				IPath.fromOSString(bundleFile.getAbsolutePath()), AdviceFileAdvice.BUNDLE_ADVICE_FILE);
 		if (advice.containsAdvice())
 			info.addAdvice(advice);
 		String shape = bundleFile.isDirectory() ? IBundleShapeAdvice.DIR : IBundleShapeAdvice.JAR;


### PR DESCRIPTION
Use the new IPath factory methods introduced in https://github.com/eclipse-equinox/equinox/pull/228 in P2.

With this PR the `org.eclipse.core.runtime.Path` does not occur anymore in P2's entire code base.