### PR TITLE
Remove unused composite parser parameter

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/Activator.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/Activator.java
@@ -99,10 +99,6 @@ public class Activator implements BundleActivator {
 		}
 	}
 
-	public static BundleContext getContext() {
-		return context;
-	}
-
 	/**
 	 * Returns the framework log, or null if not available
 	 */

--- a/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.repository;singleton:=true
-Bundle-Version: 2.7.0.qualifier
+Bundle-Version: 2.7.100.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/persistence/CompositeParser.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/persistence/CompositeParser.java
@@ -23,7 +23,6 @@ import org.eclipse.equinox.internal.p2.core.helpers.OrderedProperties;
 import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.equinox.p2.metadata.VersionRange;
 import org.eclipse.osgi.util.NLS;
-import org.osgi.framework.BundleContext;
 import org.xml.sax.*;
 
 /*
@@ -180,7 +179,7 @@ public class CompositeParser extends XMLParser implements XMLConstants {
 		}
 	}
 
-	public CompositeParser(BundleContext context, String bundleId, String type) {
+	public CompositeParser(String bundleId, String type) {
 		super(bundleId);
 		this.repositoryType = type;
 	}

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/persistence/CompositeRepositoryIO.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/persistence/CompositeRepositoryIO.java
@@ -22,7 +22,7 @@ import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.osgi.util.NLS;
 
 /**
- * This class reads and writes repository metadata (e.g. table of contents files) 
+ * This class reads and writes repository metadata (e.g. table of contents files)
  * for composite artifact and metadata repositories.
  * <p>
  * Note: This class is not used for reading or writing the actual composite repositories.
@@ -54,7 +54,7 @@ public class CompositeRepositoryIO {
 	/**
 	 * Reads the composite repository from the given stream,
 	 * and returns the contained array of abstract composite repositories.
-	 * 
+	 *
 	 * This method performs buffering, and closes the stream when finished.
 	 */
 	public CompositeRepositoryState read(URL location, InputStream input, String type, IProgressMonitor monitor) throws ProvisionException {
@@ -62,7 +62,7 @@ public class CompositeRepositoryIO {
 		try {
 			try {
 				bufferedInput = new BufferedInputStream(input);
-				CompositeParser repositoryParser = new CompositeParser(Activator.getContext(), Activator.ID, type);
+				CompositeParser repositoryParser = new CompositeParser(Activator.ID, type);
 				repositoryParser.setErrorContext(location.toExternalForm());
 				repositoryParser.parse(input);
 				IStatus result = repositoryParser.getStatus();


### PR DESCRIPTION
The CompositeParser `BundleContext` parameter is actually unused, removing this also allows to cleanup further things that previously required static access to the Activator class.

FYI @merks do you see any issues with that?