### PR TITLE
Investigate Test Failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,6 @@ pipeline {
 					mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Pbree-libs -Papi-check \
 						-Dcompare-version-with-baselines.skip=false \
-						-Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true \
 						-Dproject.build.sourceEncoding=UTF-8 \
 						-T1C
 					"""

--- a/bundles/org.eclipse.equinox.p2.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests/pom.xml
@@ -37,6 +37,16 @@
 		</profile>
 	</profiles>
 
+	<dependencies>
+		<!-- The tests require the reconciler product -->
+		<dependency>
+			<groupId>org.eclipse.equinox.p2</groupId>
+			<artifactId>org.eclipse.equinox.p2.reconciler</artifactId>
+			<version>1.1.0-SNAPSHOT</version>
+			<type>pom</type>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -64,7 +74,7 @@
 					<execution>
 						<id>compare-attached-artifacts-with-release</id>
 						<configuration>
-						<!-- this bundle has intentionally corrupt zips inside that make content comparison fail, so let's skip it -->
+							<!-- this bundle has intentionally corrupt zips inside that make content comparison fail, so let's skip it -->
 							<skip>true</skip>
 						</configuration>
 					</execution>

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/reconciler/dropins/AbstractReconcilerTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/reconciler/dropins/AbstractReconcilerTest.java
@@ -274,6 +274,11 @@ public class AbstractReconcilerTest extends AbstractProvisioningTest {
 			}
 		} else {
 			file = new File(property);
+			try {
+				file = file.getCanonicalFile();
+			} catch (IOException e) {
+				// then use the non canonical one...
+			}
 		}
 		StringBuffer detailedMessage = new StringBuffer(600);
 		detailedMessage.append(" propertyToPlatformArchive was ").append(propertyToPlatformArchive == null ? " not set " : propertyToPlatformArchive).append('\n');


### PR DESCRIPTION
Currently there are a lot of failing test in GH action, this is to investigate the failures and find mitigations.

I also tried to run the test from the Eclipse SDK IDE and they fail there also because the require a `getPlatformZip` that returns a windows specific value pointing to something looking quite odd: `c:/dev/platform/zips/eclipse-platform-3.6M6-win32.zip`

I currently have not found out what this platform zip is and what it is required for, but my current theory is that these are also failing on Jenkins but never noticed because failures are ignored by maven and the Jenkins later only scans files for test assumptions....

If anyone can give some insights or like to help fixing the issue it would be welcome.