### PR TITLE
Fix failing test in case the build-order is different

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests/pom.xml
@@ -37,6 +37,16 @@
 		</profile>
 	</profiles>
 
+	<dependencies>
+		<!-- The tests require the reconciler product -->
+		<dependency>
+			<groupId>org.eclipse.equinox.p2</groupId>
+			<artifactId>org.eclipse.equinox.p2.reconciler</artifactId>
+			<version>1.1.0-SNAPSHOT</version>
+			<type>pom</type>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -64,7 +74,7 @@
 					<execution>
 						<id>compare-attached-artifacts-with-release</id>
 						<configuration>
-						<!-- this bundle has intentionally corrupt zips inside that make content comparison fail, so let's skip it -->
+							<!-- this bundle has intentionally corrupt zips inside that make content comparison fail, so let's skip it -->
 							<skip>true</skip>
 						</configuration>
 					</execution>

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/reconciler/dropins/AbstractReconcilerTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/reconciler/dropins/AbstractReconcilerTest.java
@@ -274,6 +274,11 @@ public class AbstractReconcilerTest extends AbstractProvisioningTest {
 			}
 		} else {
 			file = new File(property);
+			try {
+				file = file.getCanonicalFile();
+			} catch (IOException e) {
+				// then use the non canonical one...
+			}
 		}
 		StringBuffer detailedMessage = new StringBuffer(600);
 		detailedMessage.append(" propertyToPlatformArchive was ").append(propertyToPlatformArchive == null ? " not set " : propertyToPlatformArchive).append('\n');


### PR DESCRIPTION
Currently the P2 test rely on the existence of the reconciler product, but as there is no requirement maven might have not build the product yet.

This adds a (pom) dependency to the reconciler project so maven always builds the project first.