### PR TITLE
Add option to delete the workdir to fix GH action test result collection

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,2 @@
 -Pbuild-individual-bundles
+-Dtycho.surefire.deleteWorkDir=true


### PR DESCRIPTION
Lets see if this fixes the issue with windows build not publishing tests...