### PR TITLE
Do not include Bouncycastle bundles in p2.core feature

### DIFF
--- a/features/org.eclipse.equinox.p2.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.core.feature/feature.xml
@@ -204,20 +204,6 @@
          unpack="false"/>
 
    <plugin
-         id="bcpg"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="bcprov"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.equinox.concurrent"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
This allows updating deps without touching features.