### PR TITLE
Discover ECF provided schemes

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/Messages.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/Messages.java
@@ -38,5 +38,6 @@ class Messages extends NLS {
 	public static String DestinationNotModifiable;
 	public static String locationMustBeAbsolute;
 	public static String schemeNotSupported;
+	public static String schemeNotProvided;
 	public static String noSuchProvider;
 }

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/messages.properties
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/messages.properties
@@ -22,4 +22,5 @@ repoManAuthenticationFailedFor_0=Authentication failed for {0}
 DestinationNotModifiable=Destination repository is not modifiable: {0}
 locationMustBeAbsolute=Location must be absolute
 schemeNotSupported=Scheme not supported
+schemeNotProvided=No scheme provided
 noSuchProvider=No such provider: {0}


### PR DESCRIPTION
Currently if one tries to use a custom ecf scheme the first time the install dialog complains that the scheme is not supported. A user has first use some standard scheme (e.g. http) then ECF is loaded and the custom scheme can be used.

This enhance the repository check in a way that it discovers ECF available schemes at the first place.