### PR TITLE
Remove unnecessary 'Bundle-ClassPath: .' MANIFEST.MF entries

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.core;singleton:=true
 Bundle-Version: 2.10.100.qualifier
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.equinox.internal.p2.core.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.director;singleton:=true
 Bundle-Version: 2.6.100.qualifier
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.equinox.internal.p2.director.DirectorActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.tests;singleton:=true
 Bundle-Version: 1.9.100.qualifier
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.equinox.p2.tests.TestActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/META-INF/MANIFEST.MF
@@ -23,6 +23,5 @@ Export-Package: org.eclipse.equinox.internal.p2.ui.discovery;x-internal:=true,
  org.eclipse.equinox.internal.p2.ui.discovery.repository;x-internal:=true,
  org.eclipse.equinox.internal.p2.ui.discovery.util;x-internal:=true,
  org.eclipse.equinox.internal.p2.ui.discovery.wizards;x-internal:=true
-Bundle-ClassPath: .
 Import-Package: org.eclipse.equinox.p2.planner;version="2.0.0"
 Automatic-Module-Name: org.eclipse.equinox.p2.ui.discovery


### PR DESCRIPTION
The default value of 'Bundle-ClassPath' is the dot which is used when the header is not specified. Therefore there is no need to specify it with that value explicitly.