### PR TITLE
Add new method IQueryResult.stream()

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata/.settings/.api_filters
+++ b/bundles/org.eclipse.equinox.p2.metadata/.settings/.api_filters
@@ -8,4 +8,12 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/equinox/p2/query/IQueryResult.java" type="org.eclipse.equinox.p2.query.IQueryResult">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.query.IQueryResult"/>
+                <message_argument value="stream()"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/bundles/org.eclipse.equinox.p2.metadata/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.metadata/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.metadata;singleton:=true
-Bundle-Version: 2.7.100.qualifier
+Bundle-Version: 2.8.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.metadata;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/CollectionResult.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/CollectionResult.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.equinox.internal.p2.metadata.expression.QueryResult;
 
@@ -67,5 +68,10 @@ public class CollectionResult<T> implements IQueryResult<T> {
 	@Override
 	public String toString() {
 		return collection.toString();
+	}
+
+	@Override
+	public Stream<T> stream() {
+		return collection.stream();
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/CollectionResult.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/CollectionResult.java
@@ -13,16 +13,18 @@
  *******************************************************************************/
 package org.eclipse.equinox.p2.query;
 
-import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.equinox.internal.p2.metadata.expression.QueryResult;
 
 /**
- * This class allows to adapt java collections to a p2 a query result  and as such something queryable  
+ * This class allows to adapt java collections to a p2 a query result and as
+ * such something queryable
+ * 
  * @since 2.0
  */
 public class CollectionResult<T> implements IQueryResult<T> {
@@ -49,12 +51,7 @@ public class CollectionResult<T> implements IQueryResult<T> {
 
 	@Override
 	public T[] toArray(Class<T> clazz) {
-		int size = collection.size();
-		@SuppressWarnings("unchecked")
-		T[] result = (T[]) Array.newInstance(clazz, size);
-		if (size != 0)
-			collection.toArray(result);
-		return result;
+		return QueryResult.toArray(collection, clazz);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/Collector.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/Collector.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.equinox.internal.p2.metadata.Messages;
@@ -177,5 +178,10 @@ public class Collector<T> implements IQueryResult<T> {
 			return Collections.emptySet();
 		}
 		return Collections.unmodifiableSet(collected);
+	}
+
+	@Override
+	public Stream<T> stream() {
+		return collected == null ? Stream.empty() : collected.stream();
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/Collector.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/Collector.java
@@ -14,7 +14,6 @@
  *******************************************************************************/
 package org.eclipse.equinox.p2.query;
 
-import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -23,6 +22,7 @@ import java.util.Set;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.equinox.internal.p2.metadata.Messages;
+import org.eclipse.equinox.internal.p2.metadata.expression.QueryResult;
 
 /**
  * A collector is a generic visitor that collects objects passed to it, and can
@@ -49,13 +49,6 @@ public class Collector<T> implements IQueryResult<T> {
 	@SuppressWarnings("unchecked")
 	public static final <T> Collector<T> emptyCollector() {
 		return (Collector<T>) EMPTY_COLLECTOR;
-	}
-
-	/**
-	 * Creates a new collector.
-	 */
-	public Collector() {
-		super();
 	}
 
 	/**
@@ -96,8 +89,9 @@ public class Collector<T> implements IQueryResult<T> {
 	 * @return the collection being used to collect results.
 	 */
 	protected Collection<T> getCollection() {
-		if (collected == null)
+		if (collected == null) {
 			collected = new HashSet<>();
+		}
 		return collected;
 	}
 
@@ -119,7 +113,7 @@ public class Collector<T> implements IQueryResult<T> {
 	 */
 	@Override
 	public Iterator<T> iterator() {
-		return collected == null ? Collections.<T>emptyList().iterator() : collected.iterator();
+		return collected == null ? Collections.emptyIterator() : collected.iterator();
 	}
 
 	/**
@@ -140,18 +134,13 @@ public class Collector<T> implements IQueryResult<T> {
 	 */
 	@Override
 	public T[] toArray(Class<T> clazz) {
-		int size = collected == null ? 0 : collected.size();
-		@SuppressWarnings("unchecked")
-		T[] result = (T[]) Array.newInstance(clazz, size);
-		if (size != 0)
-			collected.toArray(result);
-		return result;
+		return QueryResult.toArray(collected, clazz);
 	}
 
 	/**
 	 * Returns a copy of the collected objects.
 	 * 
-	 * @return An unmodifiable collection of the collected objects
+	 * @return An modifiable collection of the collected objects
 	 */
 	@Override
 	public Set<T> toSet() {
@@ -164,8 +153,9 @@ public class Collector<T> implements IQueryResult<T> {
 	@Override
 	public IQueryResult<T> query(IQuery<T> query, IProgressMonitor monitor) {
 		IQueryResult<T> result;
-		if (monitor == null)
+		if (monitor == null) {
 			monitor = new NullProgressMonitor();
+		}
 		try {
 			monitor.beginTask(Messages.performing_subquery, 1);
 			result = query.perform(iterator());

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/IQueryResult.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/IQueryResult.java
@@ -18,17 +18,18 @@ import java.util.Iterator;
 import java.util.Set;
 
 /**
- * An IQueryResult represents the results of a query.  
+ * An IQueryResult represents the results of a query.
  * 
  * @since 2.0
  */
 public interface IQueryResult<T> extends IQueryable<T>, Iterable<T> {
 	/**
-	 * Returns whether this QueryResult  is empty.
-	 * @return <code>true</code> if this QueryResult has accepted any results,
-	 * and <code>false</code> otherwise.
+	 * Returns whether this QueryResult is empty.
+	 * 
+	 * @return <code>true</code> if this QueryResult has accepted any results, and
+	 *         <code>false</code> otherwise.
 	 */
-	public boolean isEmpty();
+	boolean isEmpty();
 
 	/**
 	 * Returns an iterator on the collected objects.
@@ -36,7 +37,7 @@ public interface IQueryResult<T> extends IQueryable<T>, Iterable<T> {
 	 * @return an iterator of the collected objects.
 	 */
 	@Override
-	public Iterator<T> iterator();
+	Iterator<T> iterator();
 
 	/**
 	 * Returns the collected objects as an array
@@ -46,18 +47,20 @@ public interface IQueryResult<T> extends IQueryable<T>, Iterable<T> {
 	 * @throws ArrayStoreException the runtime type of the specified array is
 	 *         not a super-type of the runtime type of every collected object
 	 */
-	public T[] toArray(Class<T> clazz);
+	T[] toArray(Class<T> clazz);
 
 	/**
-	 * Creates a new Set copy with the contents of this query result. The
-	 * copy can be altered without any side effects on its origin.
+	 * Creates a new Set copy with the contents of this query result. The copy can
+	 * be altered without any side effects on its origin.
+	 * 
 	 * @return A detached copy of the result.
 	 */
-	public Set<T> toSet();
+	Set<T> toSet();
 
 	/**
 	 * Returns a Set backed by this query result. The set is immutable.
+	 * 
 	 * @return A Set backed by this query result.
 	 */
-	public Set<T> toUnmodifiableSet();
+	Set<T> toUnmodifiableSet();
 }

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/IQueryResult.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/IQueryResult.java
@@ -14,8 +14,11 @@
 ******************************************************************************/
 package org.eclipse.equinox.p2.query;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * An IQueryResult represents the results of a query.
@@ -63,4 +66,18 @@ public interface IQueryResult<T> extends IQueryable<T>, Iterable<T> {
 	 * @return A Set backed by this query result.
 	 */
 	Set<T> toUnmodifiableSet();
+
+	/**
+	 * Returns a sequential {@code Stream} of the collected objects.
+	 * 
+	 * @implSpec The default implementation creates a sequential {@code Stream} from
+	 *           this query-results {@code Spliterator}. Implementations backed by a
+	 *           {@code Collection} should override this method and call
+	 *           {@link Collection#stream()}.
+	 * @since 2.8
+	 */
+	default Stream<T> stream() {
+		return StreamSupport.stream(spliterator(), false);
+	}
+
 }


### PR DESCRIPTION
This improves the interoperability of `IQueryResult` and the Java's modern Stream-API.

Additionally Clean-up `IQueryResult` and its implementations in a separate first commit.