### PR TITLE
Add IRepository.contains(T) method

### DIFF
--- a/bundles/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.director;singleton:=true
-Bundle-Version: 2.6.100.qualifier
+Bundle-Version: 2.6.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.director.DirectorActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -23,7 +23,7 @@ Export-Package: org.eclipse.equinox.internal.p2.director;
  org.eclipse.equinox.p2.planner;version="2.0.0"
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.3.0,4.0.0)",
  org.eclipse.core.jobs;bundle-version="[3.3.0,4.0.0)",
- org.eclipse.equinox.p2.metadata;bundle-version="[2.0.0,3.0.0)",
+ org.eclipse.equinox.p2.metadata;bundle-version="[2.8.0,3.0.0)",
  org.sat4j.core;bundle-version="[2.3.5,3.0.0)",
  org.sat4j.pb;bundle-version="[2.3.5,3.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/QueryableArray.java
+++ b/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/QueryableArray.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corporation and others.
+ * Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -37,6 +37,11 @@ public class QueryableArray extends IndexProvider<IInstallableUnit> {
 	@Override
 	public Iterator<IInstallableUnit> everything() {
 		return dataSet.iterator();
+	}
+
+	@Override
+	public boolean contains(IInstallableUnit element) {
+		return dataSet.contains(element);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.engine;singleton:=true
-Bundle-Version: 2.8.200.qualifier
+Bundle-Version: 2.9.0.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.engine.EngineActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -50,7 +50,7 @@ Import-Package: javax.xml.parsers,
  org.eclipse.equinox.p2.metadata;version="[2.4.0,3.0.0)",
  org.eclipse.equinox.p2.metadata.expression;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.metadata.index;version="[2.0.0,3.0.0)",
- org.eclipse.equinox.p2.query;version="[2.0.0,3.0.0)",
+ org.eclipse.equinox.p2.query;version="[2.1.0,3.0.0)",
  org.eclipse.equinox.p2.repository;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.artifact;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.artifact.spi;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Profile.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Profile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2018 IBM Corporation and others.
+ * Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  * This
  * program and the accompanying materials are made available under the terms of
@@ -196,6 +196,11 @@ public class Profile extends IndexProvider<IInstallableUnit> implements IProfile
 	@Override
 	public Iterator<IInstallableUnit> everything() {
 		return ius.iterator();
+	}
+
+	@Override
+	public boolean contains(IInstallableUnit element) {
+		return ius.contains(element);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/ProfileMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/ProfileMetadataRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2009, 2017 IBM Corporation and others.
+ *  Copyright (c) 2009, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -170,6 +170,11 @@ public class ProfileMetadataRepository extends AbstractMetadataRepository {
 	@Override
 	public IQueryResult<IInstallableUnit> query(IQuery<IInstallableUnit> query, IProgressMonitor monitor) {
 		return profile.query(query, monitor);
+	}
+
+	@Override
+	public boolean contains(IInstallableUnit element) {
+		return profile.contains(element);
 	}
 
 	private static IProfile getProfile(IProvisioningAgent agent, URI location) throws ProvisionException {

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/p2/engine/ProvisioningContext.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/p2/engine/ProvisioningContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2008, 2017 IBM Corporation and others.
+ *  Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -63,6 +63,11 @@ public class ProvisioningContext {
 		@Override
 		public IQueryResult<IArtifactRepository> query(IQuery<IArtifactRepository> query, IProgressMonitor mon) {
 			return query.perform(repositories.listIterator());
+		}
+
+		@Override
+		public boolean contains(IArtifactRepository element) {
+			return repositories.contains(element);
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.p2.extensionlocation/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.extensionlocation;singleton:=true
-Bundle-Version: 1.5.100.qualifier
+Bundle-Version: 1.5.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.extensionlocation.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.extensionlocation;x-friends:="org.eclipse.equinox.p2.reconciler.dropins,org.eclipse.equinox.p2.ui,org.eclipse.equinox.p2.ui.importexport"
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.equinox.p2.metadata
+ org.eclipse.equinox.p2.metadata;bundle-version="[2.8.0,3.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.equinox.internal.p2.artifact.repository.simple,

--- a/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/ExtensionLocationMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/ExtensionLocationMetadataRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2008, 2017 IBM Corporation and others.
+ *  Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *     Code 9 - ongoing development
@@ -51,7 +51,7 @@ public class ExtensionLocationMetadataRepository extends AbstractMetadataReposit
 	}
 
 	/*
-	 * Constructor for the class. Return a new extension location repository based on the 
+	 * Constructor for the class. Return a new extension location repository based on the
 	 * given location and specified nested repo.
 	 */
 	public ExtensionLocationMetadataRepository(IProvisioningAgent agent, URI location, IMetadataRepository repository, IProgressMonitor monitor) throws ProvisionException {
@@ -110,6 +110,11 @@ public class ExtensionLocationMetadataRepository extends AbstractMetadataReposit
 	public IQueryResult<IInstallableUnit> query(IQuery<IInstallableUnit> query, IProgressMonitor monitor) {
 		ensureInitialized();
 		return metadataRepository.query(query, monitor);
+	}
+
+	@Override
+	public boolean contains(IInstallableUnit element) {
+		return metadataRepository.contains(element);
 	}
 
 	public static void validate(URI location, IProgressMonitor monitor) throws ProvisionException {

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.metadata.repository;singleton:=true
-Bundle-Version: 1.5.100.qualifier
+Bundle-Version: 1.5.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.metadata.repository;
@@ -35,7 +35,7 @@ Import-Package: javax.xml.parsers,
  org.eclipse.equinox.p2.metadata;version="[2.4.0,3.0.0)",
  org.eclipse.equinox.p2.metadata.expression;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.metadata.index;version="[2.0.0,3.0.0)",
- org.eclipse.equinox.p2.query;version="[2.0.0,3.0.0)",
+ org.eclipse.equinox.p2.query;version="[2.1.0,3.0.0)",
  org.eclipse.equinox.p2.repository;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.metadata;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.metadata.spi;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/CompositeMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/CompositeMetadataRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corporation and others.
+ * Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -151,6 +151,16 @@ public class CompositeMetadataRepository extends AbstractMetadataRepository impl
 			if (monitor != null)
 				monitor.done();
 		}
+	}
+
+	@Override
+	public boolean contains(IInstallableUnit element) {
+		for (IMetadataRepository repository : loadedRepos) {
+			if (repository.contains(element)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	//successfully loaded repo will be added to the list repositoriesToBeRemovedOnFailure if the list is not null and the repo wasn't previously loaded

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/LocalMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/LocalMetadataRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2007, 2020 IBM Corporation and others.
+ *  Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -205,6 +205,11 @@ public class LocalMetadataRepository extends AbstractMetadataRepository implemen
 	@Override
 	public IQueryResult<IInstallableUnit> query(IQuery<IInstallableUnit> query, IProgressMonitor monitor) {
 		return IndexProvider.query(this, query, monitor);
+	}
+
+	@Override
+	public boolean contains(IInstallableUnit element) {
+		return units.contains(element);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/URLMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/URLMetadataRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corporation and others.
+ * Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -105,6 +105,11 @@ public class URLMetadataRepository extends AbstractMetadataRepository implements
 	@Override
 	public synchronized IQueryResult<IInstallableUnit> query(IQuery<IInstallableUnit> query, IProgressMonitor monitor) {
 		return IndexProvider.query(this, query, monitor);
+	}
+
+	@Override
+	public boolean contains(IInstallableUnit element) {
+		return units.contains(element);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.metadata/.settings/.api_filters
+++ b/bundles/org.eclipse.equinox.p2.metadata/.settings/.api_filters
@@ -16,4 +16,12 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="src/org/eclipse/equinox/p2/query/IQueryable.java" type="org.eclipse.equinox.p2.query.IQueryable">
+        <filter id="404000815">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.query.IQueryable"/>
+                <message_argument value="contains(T)"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/bundles/org.eclipse.equinox.p2.metadata/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.metadata/META-INF/MANIFEST.MF
@@ -78,7 +78,7 @@ Export-Package: org.eclipse.equinox.internal.p2.metadata;
  org.eclipse.equinox.p2.metadata;version="2.4.0",
  org.eclipse.equinox.p2.metadata.expression;version="2.0.0",
  org.eclipse.equinox.p2.metadata.index;version="2.0.0",
- org.eclipse.equinox.p2.query;version="2.0.0"
+ org.eclipse.equinox.p2.query;version="2.1.0"
 Require-Bundle: org.eclipse.equinox.common,
  org.eclipse.equinox.p2.core;bundle-version="[2.0.0,3.0.0)"
 Import-Package: org.eclipse.osgi.service.localization;version="1.0.0",

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/CompoundQueryable.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/CompoundQueryable.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
-* Copyright (c) 2009, 2018 EclipseSource and others.
+* Copyright (c) 2009, 2023 EclipseSource and others.
 *
 * This
 * program and the accompanying materials are made available under the terms of
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.equinox.internal.p2.metadata.InstallableUnit;
 import org.eclipse.equinox.internal.p2.metadata.expression.CompoundIterator;
@@ -31,8 +32,9 @@ import org.eclipse.equinox.p2.metadata.index.IIndex;
 import org.eclipse.equinox.p2.metadata.index.IIndexProvider;
 
 /**
- * A queryable that holds a number of other IQueryables and provides
- * a mechanism for querying the entire set.
+ * A queryable that holds a number of other IQueryables and provides a mechanism
+ * for querying the entire set.
+ * 
  * @since 2.0
  */
 public final class CompoundQueryable<T> extends IndexProvider<T> {
@@ -75,7 +77,7 @@ public final class CompoundQueryable<T> extends IndexProvider<T> {
 	 */
 	@SuppressWarnings("unchecked")
 	CompoundQueryable(IQueryable<T> query1, IQueryable<T> query2) {
-		this(new IQueryable[] {query1, query2});
+		this(new IQueryable[] { query1, query2 });
 	}
 
 	@Override
@@ -98,7 +100,7 @@ public final class CompoundQueryable<T> extends IndexProvider<T> {
 			// Nobody had an index for this member
 			return null;
 
-		ArrayList<IIndex<T>> indexes = new ArrayList<>(queryables.length);
+		List<IIndex<T>> indexes = new ArrayList<>(queryables.length);
 		for (IQueryable<T> queryable : queryables) {
 			if (queryable instanceof IIndexProvider<?>) {
 				@SuppressWarnings("unchecked")
@@ -118,15 +120,25 @@ public final class CompoundQueryable<T> extends IndexProvider<T> {
 	@Override
 	public Iterator<T> everything() {
 		if (queryables.length == 0)
-			return Collections.<T> emptySet().iterator();
+			return Collections.emptyIterator();
 
 		if (queryables.length == 1)
 			return getIteratorFromQueryable(queryables[0]);
 
-		ArrayList<Iterator<T>> iterators = new ArrayList<>(queryables.length);
+		List<Iterator<T>> iterators = new ArrayList<>(queryables.length);
 		for (IQueryable<T> queryable : queryables)
 			iterators.add(getIteratorFromQueryable(queryable));
 		return new CompoundIterator<>(iterators.iterator());
+	}
+
+	@Override
+	public boolean contains(T element) {
+		for (IQueryable<T> queryable : queryables) {
+			if (queryable.contains(element)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override
@@ -164,7 +176,7 @@ public final class CompoundQueryable<T> extends IndexProvider<T> {
 		}
 
 		Iterator<T> getCapturedIterator() {
-			return capturedIterator == null ? Collections.<T> emptySet().iterator() : capturedIterator;
+			return capturedIterator == null ? Collections.emptyIterator() : capturedIterator;
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/IQueryable.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/IQueryable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2010 IBM Corporation and others.
+ * Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,23 +16,25 @@ package org.eclipse.equinox.p2.query;
 import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
- * An IQueryable contains objects, and is able to perform queries on those objects.
+ * An IQueryable contains objects, and is able to perform queries on those
+ * objects.
  * <p>
  * This interface may be implemented by clients.
+ * 
  * @since 2.0
  */
 public interface IQueryable<T> {
 	/**
-	 * Performs a query, passing any objects that satisfy the
-	 * query to the provided collector.
+	 * Performs a query, passing any objects that satisfy the query to the provided
+	 * collector.
 	 * <p>
-	 * This method is long-running; progress and cancellation are provided
-	 * by the given progress monitor. 
+	 * This method is long-running; progress and cancellation are provided by the
+	 * given progress monitor.
 	 * </p>
 	 * 
-	 * @param query The query to perform
-	 * @param monitor a progress monitor, or <code>null</code> if progress
-	 *    reporting is not desired
+	 * @param query   The query to perform
+	 * @param monitor a progress monitor, or <code>null</code> if progress reporting
+	 *                is not desired
 	 * @return The collector argument
 	 */
 	public IQueryResult<T> query(IQuery<T> query, IProgressMonitor monitor);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/IQueryable.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/IQueryable.java
@@ -10,10 +10,16 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Add IQueryable.contains(T) method and implement overrides where suitable 
  *******************************************************************************/
 package org.eclipse.equinox.p2.query;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.equinox.p2.metadata.expression.ExpressionUtil;
+import org.eclipse.equinox.p2.metadata.expression.IExpression;
 
 /**
  * An IQueryable contains objects, and is able to perform queries on those
@@ -38,4 +44,32 @@ public interface IQueryable<T> {
 	 * @return The collector argument
 	 */
 	public IQueryResult<T> query(IQuery<T> query, IProgressMonitor monitor);
+
+	/**
+	 * Returns true if this queryable contains the given element, else false.
+	 *
+	 * @param element the element to query for
+	 * @return true if the given element is found in this queryable
+	 * @since 2.8
+	 */
+	default boolean contains(T element) {
+		return !query(new IQuery<>() {
+
+			@Override
+			public IQueryResult<T> perform(Iterator<T> iterator) {
+				while (iterator.hasNext()) {
+					T t = iterator.next();
+					if (Objects.equals(t, element)) {
+						return new CollectionResult<>(List.of(t));
+					}
+				}
+				return new CollectionResult<>(List.of());
+			}
+
+			@Override
+			public IExpression getExpression() {
+				return ExpressionUtil.TRUE_EXPRESSION;
+			}
+		}, null).isEmpty();
+	}
 }

--- a/bundles/org.eclipse.equinox.p2.publisher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.publisher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.publisher;singleton:=true
-Bundle-Version: 1.8.100.qualifier
+Bundle-Version: 1.9.0.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.publisher.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -40,7 +40,7 @@ Import-Package: org.eclipse.equinox.app;version="1.0.0";resolution:=optional,
  org.eclipse.equinox.p2.metadata;version="[2.4.0,3.0.0)",
  org.eclipse.equinox.p2.metadata.expression;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.metadata.index;version="[2.0.0,3.0.0)",
- org.eclipse.equinox.p2.query;version="[2.0.0,3.0.0)",
+ org.eclipse.equinox.p2.query;version="[2.1.0,3.0.0)",
  org.eclipse.equinox.p2.repository;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.artifact;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.artifact.spi;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/PublisherResult.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/PublisherResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 Code 9 and others.
+ * Copyright (c) 2008, 2023 Code 9 and others.
  *
  * This
  * program and the accompanying materials are made available under the terms of
@@ -8,8 +8,8 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
- * Contributors: 
+ *
+ * Contributors:
  *   Code 9 - initial API and implementation
  *   IBM - ongoing development
  *   Cloudsmith Inc. - query indexes
@@ -139,6 +139,11 @@ public class PublisherResult extends IndexProvider<IInstallableUnit> implements 
 		iterators.add(nonRootIUs.iterator());
 		iterators.add(rootIUs.iterator());
 		return new CompoundIterator<>(iterators.iterator());
+	}
+
+	@Override
+	public boolean contains(IInstallableUnit element) {
+		return rootIUs.contains(element) || nonRootIUs.contains(element);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.repository;singleton:=true
-Bundle-Version: 2.7.100.qualifier
+Bundle-Version: 2.8.0.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -33,7 +33,7 @@ Export-Package: org.eclipse.equinox.internal.p2.persistence;
    org.eclipse.equinox.p2.ui,
    org.eclipse.equinox.p2.updatesite",
  org.eclipse.equinox.internal.provisional.p2.repository,
- org.eclipse.equinox.p2.repository;version="2.0.0",
+ org.eclipse.equinox.p2.repository;version="2.1.0",
  org.eclipse.equinox.p2.repository.artifact;version="2.3.0",
  org.eclipse.equinox.p2.repository.artifact.spi;version="2.0.0",
  org.eclipse.equinox.p2.repository.metadata;version="2.0.0",
@@ -65,7 +65,7 @@ Import-Package: javax.crypto,
  org.eclipse.equinox.p2.core.spi;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.metadata;version="[2.4.0,3.0.0)",
  org.eclipse.equinox.p2.metadata.expression;version="[2.0.0,3.0.0)",
- org.eclipse.equinox.p2.query;version="[2.0.0,3.0.0)",
+ org.eclipse.equinox.p2.query;version="[2.1.0,3.0.0)",
  org.eclipse.equinox.security.storage,
  org.eclipse.osgi.service.debug,
  org.eclipse.osgi.util;version="1.1.0",

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/ICompositeRepository.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/ICompositeRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2008, 2010 IBM Corporation and others.
+ *  Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -24,7 +24,7 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
  * from the children and acts as a single repository containing the union of all
  * child contents. When a composite repository is queried programmatically,
  * it will appear to contain all elements that currently exist in one or more
- * of its children. 
+ * of its children.
  * @param <T> The type of repository content. Typically this is either {@link IInstallableUnit}
  * or {@link IArtifactKey}.
  * @noextend This interface is not intended to be extended by clients.
@@ -37,24 +37,24 @@ public interface ICompositeRepository<T> extends IRepository<T> {
 	 * Does nothing if URI is a duplicate of an existing child repository.
 	 * @param child The child to add.
 	 */
-	public void addChild(URI child);
+	void addChild(URI child);
 
 	/**
 	 * Returns a list of URIs containing the locations of the children repositories
-	 * 
+	 *
 	 * @return a list of URIs containing the locations of the children repositories
 	 */
-	public List<URI> getChildren();
+	List<URI> getChildren();
 
 	/**
 	 * Removes all child repositories
 	 */
-	public void removeAllChildren();
+	void removeAllChildren();
 
 	/**
 	 * Removes the specified URI from the list of child repositories.
 	 * This method has no effect if the specified URI is not a child repository
 	 * @param child The child to remove
 	 */
-	public void removeChild(URI child);
+	void removeChild(URI child);
 }

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/IRepository.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/IRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2007, 2011 IBM Corporation and others.
+ *  Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -25,21 +25,21 @@ import org.eclipse.equinox.p2.query.IQueryable;
  * provisioning. This base interface defines properties common to all types
  * of repositories.
  * @param <T> The type of contents contained in this repository
- * 
+ *
  * @noimplement This interface is not intended to be implemented by clients. Instead the abstract classes implementing this interface should be used.
  * @noextend This interface is not intended to be extended by clients.
  * @since 2.0
  */
 public interface IRepository<T> extends IAdaptable, IQueryable<T> {
-	/** 
+	/**
 	 * The key for a boolean property indicating that the repository
 	 * is a system repository.  System repositories are implementation details
 	 * that are not subject to general access, hidden from the typical user, etc.
-	 * This property is never stored in the repository itself, but is instead tracked and 
+	 * This property is never stored in the repository itself, but is instead tracked and
 	 * managed by an {@link IRepositoryManager}.
 	 * @see IRepositoryManager#getRepositoryProperty(URI, String)
 	 */
-	public static final String PROP_SYSTEM = "p2.system"; //$NON-NLS-1$
+	String PROP_SYSTEM = "p2.system"; //$NON-NLS-1$
 
 	/**
 	 * The key for a boolean property indicating that repository metadata is
@@ -48,101 +48,101 @@ public interface IRepository<T> extends IAdaptable, IQueryable<T> {
 	 * uncompress when reading.
 	 * @see IRepository#getProperties()
 	 */
-	public static final String PROP_COMPRESSED = "p2.compressed"; //$NON-NLS-1$
+	String PROP_COMPRESSED = "p2.compressed"; //$NON-NLS-1$
 
 	/**
 	 * The key for a string property providing a human-readable name for the repository.
 	 * @see IRepositoryManager#getRepositoryProperty(URI, String)
 	 * @see IRepository#getProperties()
 	 */
-	public static final String PROP_NAME = "name"; //$NON-NLS-1$
+	String PROP_NAME = "name"; //$NON-NLS-1$
 
 	/**
 	 * The key for a string property providing a user-defined name for the repository.
-	 * This property is never stored in the repository itself, but is instead tracked and 
+	 * This property is never stored in the repository itself, but is instead tracked and
 	 * managed by an {@link IRepositoryManager}.
 	 * @see IRepositoryManager#getRepositoryProperty(URI, String)
 	 */
-	public static final String PROP_NICKNAME = "p2.nickname"; //$NON-NLS-1$
+	String PROP_NICKNAME = "p2.nickname"; //$NON-NLS-1$
 
 	/**
 	 * The key for a string property providing a human-readable description for the repository.
 	 * @see IRepositoryManager#getRepositoryProperty(URI, String)
 	 * @see IRepository#getProperties()
 	 */
-	public static final String PROP_DESCRIPTION = "description"; //$NON-NLS-1$
+	String PROP_DESCRIPTION = "description"; //$NON-NLS-1$
 
 	/**
 	 * The key for a string property providing the common base URL that should
 	 * be replaced with the mirror URL.
 	 * @see IRepository#getProperties()
 	 */
-	public static final String PROP_MIRRORS_BASE_URL = "p2.mirrorsBaseURL"; //$NON-NLS-1$
+	String PROP_MIRRORS_BASE_URL = "p2.mirrorsBaseURL"; //$NON-NLS-1$
 
 	/**
 	 * The key for a string property providing a URL that can return mirrors of this
 	 * repository.
 	 * @see IRepository#getProperties()
 	 */
-	public static final String PROP_MIRRORS_URL = "p2.mirrorsURL"; //$NON-NLS-1$
+	String PROP_MIRRORS_URL = "p2.mirrorsURL"; //$NON-NLS-1$
 
 	/**
 	 * The key for a string property containing the time when the repository was last modified.
 	 * @see IRepository#getProperties()
 	 */
-	public static final String PROP_TIMESTAMP = "p2.timestamp"; //$NON-NLS-1$
+	String PROP_TIMESTAMP = "p2.timestamp"; //$NON-NLS-1$
 
 	/**
 	 * The key for a string property providing the user name to an authenticated
 	 * URL.  This key is used in the secure preference store for repository data.
 	 * @see #PREFERENCE_NODE
 	 */
-	public static final String PROP_USERNAME = "username"; //$NON-NLS-1$
+	String PROP_USERNAME = "username"; //$NON-NLS-1$
 
 	/**
 	 * The key for a string property providing the password to an authenticated
 	 * URL.  This key is used in the secure preference store for repository data.
 	 * @see #PREFERENCE_NODE
 	 */
-	public static final String PROP_PASSWORD = "password"; //$NON-NLS-1$
+	String PROP_PASSWORD = "password"; //$NON-NLS-1$
 
 	/**
 	 * The node identifier for repository secure preference store.
 	 */
-	public static final String PREFERENCE_NODE = "org.eclipse.equinox.p2.repository"; //$NON-NLS-1$
+	String PREFERENCE_NODE = "org.eclipse.equinox.p2.repository"; //$NON-NLS-1$
 
 	/**
 	 * A repository type constant (value 0) representing a metadata repository.
 	 */
-	public static final int TYPE_METADATA = 0;
+	int TYPE_METADATA = 0;
 
 	/**
 	 * A repository type constant (value 1) representing an artifact repository.
 	 */
-	public static final int TYPE_ARTIFACT = 1;
+	int TYPE_ARTIFACT = 1;
 
-	/** 
+	/**
 	 * General purpose zero-valued bit mask constant. Useful whenever you need to
 	 * supply a bit mask with no bits set.
 	 */
-	public static final int NONE = 0;
+	int NONE = 0;
 
 	/**
 	 * An option flag constant (value 1) indicating an enabled repository.
 	 */
-	public static final int ENABLED = 1;
+	int ENABLED = 1;
 
 	/**
 	 * Returns the location of this repository.
 	 * @return the URI representing the repository location.
 	 */
-	public URI getLocation();
+	URI getLocation();
 
 	/**
 	 * Returns the name of the repository.
 	 * @return the name of the repository.
 	 */
-	public String getName();
+	String getName();
 
 	/**
 	 * Returns a string representing the type of the repository. Note this method
@@ -150,31 +150,31 @@ public interface IRepository<T> extends IAdaptable, IQueryable<T> {
 	 * but instead the unique fully qualified id representing the repository implementation.
 	 * @return the type of the repository.
 	 */
-	public String getType();
+	String getType();
 
 	/**
 	 * Returns a string representing the version for the repository type.
 	 * @return the version of the type of the repository.
 	 */
-	public String getVersion();
+	String getVersion();
 
 	/**
 	 * Returns a brief description of the repository.
 	 * @return the description of the repository.
 	 */
-	public String getDescription();
+	String getDescription();
 
 	/**
 	 * Returns the name of the provider of the repository.
 	 * @return the provider of this repository.
 	 */
-	public String getProvider();
+	String getProvider();
 
 	/**
 	 * Returns a read-only collection of the properties of the repository.
 	 * @return the properties of this repository.
 	 */
-	public Map<String, String> getProperties();
+	Map<String, String> getProperties();
 
 	/**
 	 * Returns the repository property with the given key, or <code>null</code>
@@ -182,13 +182,13 @@ public interface IRepository<T> extends IAdaptable, IQueryable<T> {
 	 * @param key the property key
 	 * @return the property value, or <code>null</code>
 	 */
-	public String getProperty(String key);
+	String getProperty(String key);
 
 	/**
 	 * Returns the provisioning agent that manages this repository
 	 * @return A provisioning agent.
 	 */
-	public IProvisioningAgent getProvisioningAgent();
+	IProvisioningAgent getProvisioningAgent();
 
 	/**
 	 * Returns <code>true</code> if this repository can be modified, and
@@ -196,24 +196,24 @@ public interface IRepository<T> extends IAdaptable, IQueryable<T> {
 	 * an unmodifiable repository will fail.
 	 * @return whether or not this repository can be modified
 	 */
-	public boolean isModifiable();
+	boolean isModifiable();
 
 	/**
 	 * Sets the value of the property with the given key. Returns the old property
 	 * associated with that key, if any.  Setting a value of <code>null</code> will
 	 * remove the corresponding key from the properties of this repository.
-	 * 
+	 *
 	 * @param key The property key
 	 * @param value The new property value, or <code>null</code> to remove the key
 	 * @return The old property value, or <code>null</code> if there was no old value
 	 */
-	public String setProperty(String key, String value);
+	String setProperty(String key, String value);
 
 	/**
 	 * Sets the value of the property with the given key. Returns the old property
 	 * associated with that key, if any.  Setting a value of <code>null</code> will
 	 * remove the corresponding key from the properties of this repository.
-	 * 
+	 *
 	 * @param key The property key
 	 * @param value The new property value, or <code>null</code> to remove the key
 	 * @param monitor A progress monitor use to track progress and cancel the operation.  This may
@@ -221,5 +221,5 @@ public interface IRepository<T> extends IAdaptable, IQueryable<T> {
 	 * @return The old property value, or <code>null</code> if there was no old value
 	 * @since 2.1
 	 */
-	public String setProperty(String key, String value, IProgressMonitor monitor);
+	String setProperty(String key, String value, IProgressMonitor monitor);
 }

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/IRepository.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/IRepository.java
@@ -10,6 +10,7 @@
  *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Hannes Wellmann - Add IQueryable.contains(T) method and implement overrides where suitable
  *******************************************************************************/
 package org.eclipse.equinox.p2.repository;
 
@@ -222,4 +223,16 @@ public interface IRepository<T> extends IAdaptable, IQueryable<T> {
 	 * @since 2.1
 	 */
 	String setProperty(String key, String value, IProgressMonitor monitor);
+
+	/**
+	 * Returns true if this repository contains the given element.
+	 *
+	 * @param element the element to query
+	 * @return true if the given element is already in this repository
+	 * @since 2.8
+	 */
+	@Override
+	default boolean contains(T element) {
+		return IQueryable.super.contains(element);
+	}
 }

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/artifact/IArtifactRepository.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/artifact/IArtifactRepository.java
@@ -116,6 +116,7 @@ public interface IArtifactRepository extends IRepository<IArtifactKey> {
 	 * @param key the key to query
 	 * @return true if the given key is already in this repository
 	 */
+	@Override
 	boolean contains(IArtifactKey key);
 
 	/**

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/artifact/IArtifactRepository.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/artifact/IArtifactRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2007, 2011 IBM Corporation and others.
+ *  Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -28,7 +28,7 @@ import org.eclipse.equinox.p2.repository.artifact.spi.AbstractArtifactRepository
  * A repository containing artifacts.
  * <p>
  * This interface is not intended to be implemented by clients.  Artifact repository
- * implementations must subclass {@link AbstractArtifactRepository} rather than 
+ * implementations must subclass {@link AbstractArtifactRepository} rather than
  * implementing this interface directly.
  * </p>
  * @noimplement This interface is not intended to be implemented by clients. Instead subclass {@link AbstractArtifactRepository}.
@@ -42,60 +42,58 @@ public interface IArtifactRepository extends IRepository<IArtifactKey> {
 	 * @see IRepository#getProperties()
 	 * @since 2.3
 	 */
-	public static final String PROP_RUNNABLE = "p2.runnable"; //$NON-NLS-1$
+	String PROP_RUNNABLE = "p2.runnable"; //$NON-NLS-1$
 
-	/** 
+	/**
 	 * The return code to use when a client could/should retry a failed getArtifact() operation.
 	 * For example, the repository may have additional mirrors that could be consulted.
 	 */
-	public static int CODE_RETRY = 13;
+	int CODE_RETRY = 13;
 
 	/**
 	 * Create an instance of {@link IArtifactDescriptor} based on the given key
 	 * @param key {@link IArtifactKey}
 	 * @return a new instance of IArtifactDescriptor
 	 */
-	public IArtifactDescriptor createArtifactDescriptor(IArtifactKey key);
+	IArtifactDescriptor createArtifactDescriptor(IArtifactKey key);
 
 	/**
 	 * Create an instance of {@link IArtifactKey}
 	 * @param classifier The classifier for this artifact key.
 	 * @param id The id for this artifact key.
-	 * @param version The version for this artifact key. 
+	 * @param version The version for this artifact key.
 	 * @return a new IArtifactKey
 	 */
-	public IArtifactKey createArtifactKey(String classifier, String id, Version version);
+	IArtifactKey createArtifactKey(String classifier, String id, Version version);
 
 	/**
-	 * Add the given descriptor to the set of descriptors in this repository.  This is 
-	 * a relatively low-level operation that should be used only when the actual related 
-	 * content is in this repository and the given descriptor accurately describes 
+	 * Add the given descriptor to the set of descriptors in this repository.  This is
+	 * a relatively low-level operation that should be used only when the actual related
+	 * content is in this repository and the given descriptor accurately describes
 	 * that content.
 	 * @param descriptor the descriptor to add.
 	 * @deprecated See {{@link #addDescriptor(IArtifactDescriptor, IProgressMonitor)}
 	 */
-	@Deprecated
-	public void addDescriptor(IArtifactDescriptor descriptor);
+	@Deprecated void addDescriptor(IArtifactDescriptor descriptor);
 
 	/**
-	 * Add the given descriptor to the set of descriptors in this repository.  This is 
-	 * a relatively low-level operation that should be used only when the actual related 
-	 * content is in this repository and the given descriptor accurately describes 
+	 * Add the given descriptor to the set of descriptors in this repository.  This is
+	 * a relatively low-level operation that should be used only when the actual related
+	 * content is in this repository and the given descriptor accurately describes
 	 * that content.
 	 * @param descriptor the descriptor to add.
 	 * @param monitor A progress monitor use to track progress and cancel the operation.  This may
 	 * be a long running operation if another process holds the lock on this location
 	 * @since 2.1
 	 */
-	public void addDescriptor(IArtifactDescriptor descriptor, IProgressMonitor monitor);
+	void addDescriptor(IArtifactDescriptor descriptor, IProgressMonitor monitor);
 
 	/**
 	 * Add the given artifact descriptors to this repository
 	 * @param descriptors the artifact descriptors to add
 	 * @deprecated See {{@link #addDescriptors(IArtifactDescriptor[], IProgressMonitor)}
 	 */
-	@Deprecated
-	public void addDescriptors(IArtifactDescriptor[] descriptors);
+	@Deprecated void addDescriptors(IArtifactDescriptor[] descriptors);
 
 	/**
 	 * Add the given artifact descriptors to this repository
@@ -104,46 +102,46 @@ public interface IArtifactRepository extends IRepository<IArtifactKey> {
 	 * be a long running operation if another process holds the lock on this location
 	 * @since 2.1
 	 */
-	public void addDescriptors(IArtifactDescriptor[] descriptors, IProgressMonitor monitor);
+	void addDescriptors(IArtifactDescriptor[] descriptors, IProgressMonitor monitor);
 
-	/** 
+	/**
 	 * Returns true if this repository contains the given descriptor.
 	 * @param descriptor the descriptor to query
 	 * @return true if the given descriptor is already in this repository
 	 */
-	public boolean contains(IArtifactDescriptor descriptor);
+	boolean contains(IArtifactDescriptor descriptor);
 
-	/** 
+	/**
 	 * Returns true if this repository contains the given artifact key.
 	 * @param key the key to query
 	 * @return true if the given key is already in this repository
 	 */
-	public boolean contains(IArtifactKey key);
+	boolean contains(IArtifactKey key);
 
 	/**
 	 * Writes to the given output stream the bytes represented by the artifact descriptor.
 	 * Any processing steps defined by the descriptor will be applied to the artifact bytes
 	 * before they are sent to the provided output stream.
-	 * 
+	 *
 	 * @param descriptor the descriptor to transfer
 	 * @param destination the stream to write the final artifact output to
 	 * @param monitor a progress monitor, or <code>null</code> if progress
 	 *    reporting and cancellation are not desired
 	 *  @return the result of the artifact transfer
 	 */
-	public IStatus getArtifact(IArtifactDescriptor descriptor, OutputStream destination, IProgressMonitor monitor);
+	IStatus getArtifact(IArtifactDescriptor descriptor, OutputStream destination, IProgressMonitor monitor);
 
 	/**
 	 * Writes to the given output stream the bytes represented by the artifact descriptor.
 	 * Any processing steps defined by the descriptor will <b>not</b> be applied to the artifact bytes.
-	 * 
+	 *
 	 * @param descriptor the descriptor to transfer
 	 * @param destination the stream to write the final artifact output to
 	 * @param monitor a progress monitor, or <code>null</code> if progress
 	 *    reporting and cancellation are not desired
 	 *  @return the result of the artifact transfer
 	 */
-	public IStatus getRawArtifact(IArtifactDescriptor descriptor, OutputStream destination, IProgressMonitor monitor);
+	IStatus getRawArtifact(IArtifactDescriptor descriptor, OutputStream destination, IProgressMonitor monitor);
 
 	/**
 	 * Return the set of artifact descriptors describing the ways that this repository
@@ -151,7 +149,7 @@ public interface IArtifactRepository extends IRepository<IArtifactKey> {
 	 * @param key the artifact key to lookup
 	 * @return the descriptors associated with the given key
 	 */
-	public IArtifactDescriptor[] getArtifactDescriptors(IArtifactKey key);
+	IArtifactDescriptor[] getArtifactDescriptors(IArtifactKey key);
 
 	/**
 	 * Executes the given artifact requests on this byte server.
@@ -161,12 +159,12 @@ public interface IArtifactRepository extends IRepository<IArtifactKey> {
 	 * processed successfully. Otherwise, a status indicating information,
 	 * warnings, or errors that occurred while executing the artifact requests
 	 */
-	public IStatus getArtifacts(IArtifactRequest[] requests, IProgressMonitor monitor);
+	IStatus getArtifacts(IArtifactRequest[] requests, IProgressMonitor monitor);
 
 	/**
-	 * Open an output stream to which a client can write the data for the given 
+	 * Open an output stream to which a client can write the data for the given
 	 * artifact descriptor.
-	 * @param descriptor the descriptor describing the artifact data to be written to the 
+	 * @param descriptor the descriptor describing the artifact data to be written to the
 	 * resultant stream
 	 * @return the stream to which the artifact content can be written. The returned output
 	 *  stream may implement <code>IStateful</code>.
@@ -176,20 +174,19 @@ public interface IArtifactRepository extends IRepository<IArtifactKey> {
 	 * <li>An artifact already exists at that location ({@link ProvisionException#ARTIFACT_EXISTS}).</li>
 	 * </ul>
 	 */
-	public OutputStream getOutputStream(IArtifactDescriptor descriptor) throws ProvisionException;
+	OutputStream getOutputStream(IArtifactDescriptor descriptor) throws ProvisionException;
 
 	/**
 	 * Returns a queryable that can be queried for artifact descriptors contained in this repository
 	 * @return The queryable of artifact descriptors
 	 */
-	public IQueryable<IArtifactDescriptor> descriptorQueryable();
+	IQueryable<IArtifactDescriptor> descriptorQueryable();
 
 	/**
 	 * Remove the all keys, descriptors, and contents from this repository.
 	 * @deprecated See {@link #removeAll(IProgressMonitor)}
 	 */
-	@Deprecated
-	public void removeAll();
+	@Deprecated void removeAll();
 
 	/**
 	 * Remove the all keys, descriptors, and contents from this repository.
@@ -197,41 +194,39 @@ public interface IArtifactRepository extends IRepository<IArtifactKey> {
 	 * be a long running operation if another process holds the lock on this location
 	 * @since 2.1
 	 */
-	public void removeAll(IProgressMonitor monitor);
+	void removeAll(IProgressMonitor monitor);
 
 	/**
-	 * Remove the given descriptor and its corresponding content in this repository.  
+	 * Remove the given descriptor and its corresponding content in this repository.
 	 * @param descriptor the descriptor to remove.
 	 * @deprecated See {@link #removeDescriptor(IArtifactDescriptor, IProgressMonitor)}
 	 */
-	@Deprecated
-	public void removeDescriptor(IArtifactDescriptor descriptor);
+	@Deprecated void removeDescriptor(IArtifactDescriptor descriptor);
 
 	/**
-	 * Remove the given descriptor and its corresponding content in this repository.  
+	 * Remove the given descriptor and its corresponding content in this repository.
 	 * @param descriptor the descriptor to remove.
 	 * @param monitor A progress monitor use to track progress and cancel the operation.  This may
 	 * be a long running operation if another process holds the lock on this location
 	 * @since 2.1
 	 */
-	public void removeDescriptor(IArtifactDescriptor descriptor, IProgressMonitor monitor);
+	void removeDescriptor(IArtifactDescriptor descriptor, IProgressMonitor monitor);
 
 	/**
-	 * Remove the given key and all related content and descriptors from this repository.  
+	 * Remove the given key and all related content and descriptors from this repository.
 	 * @param key the key to remove.
 	 * @deprecated See {@link #removeDescriptor(IArtifactKey, IProgressMonitor)}
 	 */
-	@Deprecated
-	public void removeDescriptor(IArtifactKey key);
+	@Deprecated void removeDescriptor(IArtifactKey key);
 
 	/**
-	 * Remove the given key and all related content and descriptors from this repository.  
+	 * Remove the given key and all related content and descriptors from this repository.
 	 * @param key the key to remove.
 	 * @param monitor A progress monitor use to track progress and cancel the operation.  This may
 	 * be a long running operation if another process holds the lock on this location
 	 * @since 2.1
 	 */
-	public void removeDescriptor(IArtifactKey key, IProgressMonitor monitor);
+	void removeDescriptor(IArtifactKey key, IProgressMonitor monitor);
 
 	/**
 	 * Remove the given list of artifact descriptors and their corresponding content
@@ -240,8 +235,7 @@ public interface IArtifactRepository extends IRepository<IArtifactKey> {
 	 * @since 2.1
 	 * @deprecated See {@link #removeDescriptors(IArtifactDescriptor[], IProgressMonitor)}
 	 */
-	@Deprecated
-	public void removeDescriptors(IArtifactDescriptor[] descriptors);
+	@Deprecated void removeDescriptors(IArtifactDescriptor[] descriptors);
 
 	/**
 	 * Remove the given list of artifact descriptors and their corresponding content
@@ -251,7 +245,7 @@ public interface IArtifactRepository extends IRepository<IArtifactKey> {
 	 * be a long running operation if another process holds the lock on this location
 	 * @since 2.1
 	 */
-	public void removeDescriptors(IArtifactDescriptor[] descriptors, IProgressMonitor monitor);
+	void removeDescriptors(IArtifactDescriptor[] descriptors, IProgressMonitor monitor);
 
 	/**
 	 * Remove the given list of keys and all related content and descriptors from this
@@ -260,8 +254,7 @@ public interface IArtifactRepository extends IRepository<IArtifactKey> {
 	 * @since 2.1
 	 * @deprecated See {@link #removeDescriptors(IArtifactKey[], IProgressMonitor)}
 	 */
-	@Deprecated
-	public void removeDescriptors(IArtifactKey[] keys);
+	@Deprecated void removeDescriptors(IArtifactKey[] keys);
 
 	/**
 	 * Remove the given list of keys and all related content and descriptors from this
@@ -271,20 +264,20 @@ public interface IArtifactRepository extends IRepository<IArtifactKey> {
 	 * be a long running operation if another process holds the lock on this location
 	 * @since 2.1
 	 */
-	public void removeDescriptors(IArtifactKey[] keys, IProgressMonitor monitor);
+	void removeDescriptors(IArtifactKey[] keys, IProgressMonitor monitor);
 
 	/**
 	 * Executes a runnable against this repository. It is up to the repository
 	 * implementor to determine what "batch process" means, for example, it may mean
 	 * that the repository index is not stored until after the runnable completes.
-	 * 
+	 *
 	 * The runnable should not execute anything in a separate thread.
-	 *  
+	 *
 	 * @param runnable The runnable to execute
 	 * @param monitor A progress monitor that will be passed to the runnable
 	 * @return The result of running the runnable. Any exceptions thrown during
 	 * the execution will be returned in the status.
 	 */
-	public IStatus executeBatch(IRunnableWithProgress runnable, IProgressMonitor monitor);
+	IStatus executeBatch(IRunnableWithProgress runnable, IProgressMonitor monitor);
 
 }

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/IMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/IMetadataRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2007, 2011 IBM Corporation and others.
+ *  Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -25,7 +25,7 @@ import org.eclipse.equinox.p2.repository.metadata.spi.AbstractMetadataRepository
  * A metadata repository stores information about a set of installable units
  * <p>
  * This interface is not intended to be implemented by clients.  Metadata repository
- * implementations must subclass {@link AbstractMetadataRepository} rather than 
+ * implementations must subclass {@link AbstractMetadataRepository} rather than
  * implementing this interface directly.
  * </p>
  * @noimplement This interface is not intended to be implemented by clients. Instead subclass {@link AbstractMetadataRepository}
@@ -33,12 +33,12 @@ import org.eclipse.equinox.p2.repository.metadata.spi.AbstractMetadataRepository
  */
 public interface IMetadataRepository extends IRepository<IInstallableUnit> {
 
-	/** 
+	/**
 	 * Add the given installable units to this repository.
-	 * 
+	 *
 	 * @param installableUnits the installable units to add
 	 */
-	public void addInstallableUnits(Collection<IInstallableUnit> installableUnits);
+	void addInstallableUnits(Collection<IInstallableUnit> installableUnits);
 
 	/**
 	 * <p>Adds references to another repository to this repository. When a repository
@@ -47,7 +47,7 @@ public interface IMetadataRepository extends IRepository<IInstallableUnit> {
 	 * <p>Note that this method does not add the <b>contents</b> of the given
 	 * repositories to this repository, but merely adds the location of other
 	 * repositories to the metadata of this repository.</p>
-	 * 
+	 *
 	 * @param references The references to add
 	 */
 	void addReferences(Collection<? extends IRepositoryReference> references);
@@ -60,31 +60,31 @@ public interface IMetadataRepository extends IRepository<IInstallableUnit> {
 
 	/**
 	 * Removes all installable units in the given collection from this repository.
-	 * 
+	 *
 	 * @param installableUnits the installable units to remove
 	 * @return <code>true</code> if any units were actually removed, and
 	 * <code>false</code> otherwise
 	 */
-	public boolean removeInstallableUnits(Collection<IInstallableUnit> installableUnits);
+	boolean removeInstallableUnits(Collection<IInstallableUnit> installableUnits);
 
 	/**
-	 * Remove all installable units from this repository.  
+	 * Remove all installable units from this repository.
 	 */
-	public void removeAll();
+	void removeAll();
 
 	/**
 	 * Executes a runnable against this repository. It is up to the repository
 	 * implementor to determine what "batch process" means, for example, it may mean
 	 * that the repository index is not stored until after the runnable completes.
-	 * 
+	 *
 	 * The runnable should not execute anything in a separate thread.
-	 *  
+	 *
 	 * @param runnable The runnable to execute
 	 * @param monitor A progress monitor that will be passed to the runnable
 	 * @return The result of running the runnable. Any exceptions thrown during
 	 * the execution will be returned in the status.
 	 */
-	public IStatus executeBatch(IRunnableWithProgress runnable, IProgressMonitor monitor);
+	IStatus executeBatch(IRunnableWithProgress runnable, IProgressMonitor monitor);
 
 	/**
 	 * Cause semantically equivalent IInstallableUnits in the receiver to be
@@ -92,10 +92,10 @@ public interface IMetadataRepository extends IRepository<IInstallableUnit> {
 	 * added to the {@link IPool} as required.
 	 * <p>
 	 * While the {@link IPool} should be retained to increase the scope of sharing when
-	 * calling {@link #compress(IPool)} on subsequent repositories, the {@link IPool} can 
+	 * calling {@link #compress(IPool)} on subsequent repositories, the {@link IPool} can
 	 * be discarded without adversely effecting the receiver.
 	 * </p>
 	 * @since 2.1
 	 */
-	public void compress(IPool<IInstallableUnit> iuPool);
+	void compress(IPool<IInstallableUnit> iuPool);
 }

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/TestMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/TestMetadataRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2007, 2017 IBM Corporation and others.
+ *  Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -15,12 +15,19 @@ package org.eclipse.equinox.p2.tests;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.Version;
-import org.eclipse.equinox.p2.query.*;
+import org.eclipse.equinox.p2.query.IQuery;
+import org.eclipse.equinox.p2.query.IQueryResult;
+import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.IRepository;
 import org.eclipse.equinox.p2.repository.IRepositoryReference;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
@@ -77,6 +84,11 @@ public class TestMetadataRepository extends AbstractMetadataRepository {
 	@Override
 	public IQueryResult query(IQuery query, IProgressMonitor monitor) {
 		return query.perform(units.iterator());
+	}
+
+	@Override
+	public boolean contains(IInstallableUnit element) {
+		return units.contains(element);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui;singleton:=true
-Bundle-Version: 2.8.100.qualifier
+Bundle-Version: 2.8.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.ProvUIActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -65,7 +65,7 @@ Import-Package: javax.xml.parsers,
  org.eclipse.equinox.p2.metadata.expression;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.operations;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.planner;version="[2.0.0,3.0.0)",
- org.eclipse.equinox.p2.query;version="[2.0.0,3.0.0)",
+ org.eclipse.equinox.p2.query;version="[2.1.0,3.0.0)",
  org.eclipse.equinox.p2.repository;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.artifact;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.artifact.spi;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/query/QueryableProfileRegistry.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/query/QueryableProfileRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2010 IBM Corporation and others.
+ * Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,8 @@
 package org.eclipse.equinox.internal.p2.ui.query;
 
 import java.util.Arrays;
+import java.util.List;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.equinox.internal.p2.ui.ProvUI;
 import org.eclipse.equinox.internal.p2.ui.ProvUIMessages;
 import org.eclipse.equinox.p2.engine.IProfile;
@@ -34,14 +34,23 @@ public class QueryableProfileRegistry implements IQueryable<IProfile> {
 		this.ui = ui;
 	}
 
+	private List<IProfile> getProfiles() {
+		return Arrays.asList(ProvUI.getProfileRegistry(ui.getSession()).getProfiles());
+	}
+
 	@Override
 	public IQueryResult<IProfile> query(IQuery<IProfile> query, IProgressMonitor monitor) {
-		IProfile[] profiles = ProvUI.getProfileRegistry(ui.getSession()).getProfiles();
-		SubMonitor sub = SubMonitor.convert(monitor, ProvUIMessages.QueryableProfileRegistry_QueryProfileProgress, profiles.length);
+		List<IProfile> profiles = getProfiles();
+		monitor.beginTask(ProvUIMessages.QueryableProfileRegistry_QueryProfileProgress, profiles.size());
 		try {
-			return query.perform(Arrays.asList(profiles).iterator());
+			return query.perform(profiles.iterator());
 		} finally {
-			sub.done();
+			monitor.done();
 		}
+	}
+
+	@Override
+	public boolean contains(IProfile profile) {
+		return getProfiles().contains(profile);
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.updatesite/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.updatesite/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.updatesite;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.updatesite.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -27,7 +27,7 @@ Import-Package: javax.xml.parsers,
  org.eclipse.equinox.p2.publisher,
  org.eclipse.equinox.p2.publisher.actions,
  org.eclipse.equinox.p2.publisher.eclipse,
- org.eclipse.equinox.p2.query;version="[2.0.0,3.0.0)",
+ org.eclipse.equinox.p2.query;version="[2.1.0,3.0.0)",
  org.eclipse.equinox.p2.repository;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.artifact;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.repository.artifact.spi;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/metadata/UpdateSiteMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/metadata/UpdateSiteMetadataRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2008, 2017 IBM Corporation and others.
+ *  Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -156,6 +156,11 @@ public class UpdateSiteMetadataRepository implements IMetadataRepository {
 	@Override
 	public IQueryResult<IInstallableUnit> query(IQuery<IInstallableUnit> query, IProgressMonitor monitor) {
 		return delegate.query(query, monitor);
+	}
+
+	@Override
+	public boolean contains(IInstallableUnit element) {
+		return delegate.contains(element);
 	}
 
 	@Override


### PR DESCRIPTION
This methods provides a more convenient and in most cases faster way to test if a repository contains an element, compared to querying the repository for it.
`IArtifactRepository` already has a contains() method so this effectively only adds it for `IMetadataRepository` and generalizes it.

The implementation is based on the query() or everthing() implementation of the corresponding class, if possible.

The first of the two commits contains the clean-ups in the the `IRepository` and `IArtifactRepository` interfaces.
