### PR TITLE
Replace obsolete product unit by its contained feature-units

### DIFF
--- a/org.eclipse.equinox.p2.releng/default.target
+++ b/org.eclipse.equinox.p2.releng/default.target
@@ -3,15 +3,18 @@
 <target name="p2 - default target to develop p2" sequenceNumber="1">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.platform.sdk" version="0.0.0"/>
+<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.platform.source.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.equinox.p2.user.ui.source.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.core.tests.harness" version="0.0.0"/>
 <unit id="org.eclipse.test.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/eclipse/updates/4.29-I-builds"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.bouncycastle.bcprov" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/downloads/latest-R"/>
+<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.29.0"/>
 </location>
 </locations>
-<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>


### PR DESCRIPTION
Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1235

Additionally update to new Orbit Repo and set targetJRE to match the requirement of P2 for Java-17.

I didn't test it full to build p2 against it, but it at least resolves in my workspace.