### PR TITLE
Remove old and wrong src.includes from features

### DIFF
--- a/features/org.eclipse.equinox.p2.core.feature/build.properties
+++ b/features/org.eclipse.equinox.p2.core.feature/build.properties
@@ -14,4 +14,3 @@
 ###############################################################################
 bin.includes = feature.xml,\
                feature.properties
-src.includes = license.html,epl-v10.html

--- a/features/org.eclipse.equinox.p2.extras.feature/build.properties
+++ b/features/org.eclipse.equinox.p2.extras.feature/build.properties
@@ -14,4 +14,3 @@
 ###############################################################################
 bin.includes = feature.xml,\
                feature.properties
-src.includes = license.html,epl-v10.html

--- a/features/org.eclipse.equinox.p2.rcp.feature/build.properties
+++ b/features/org.eclipse.equinox.p2.rcp.feature/build.properties
@@ -14,4 +14,3 @@
 ###############################################################################
 bin.includes = feature.xml,\
                feature.properties
-src.includes = license.html,epl-v10.html


### PR DESCRIPTION
These files no longer exist in the repo as they are taken by the license feature.