### PR TITLE
Touch bundles affected by changed bytecode generation

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.engine/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 542873 - IBuild I20181217-1800 failed due to unresolved project dependencies.
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378

--- a/bundles/org.eclipse.equinox.p2.metadata/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.metadata/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378

--- a/bundles/org.eclipse.equinox.p2.ui.sdk/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.sdk;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.sdk.ProvSDKUIActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.ui.sdk/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378

--- a/bundles/org.eclipse.equinox.p2.ui/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.ui/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378