### PR TITLE
ProfileChangeOperation: fix progressmonitor usage #335

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
@@ -617,7 +617,7 @@ public class SimpleArtifactRepository extends AbstractArtifactRepository impleme
 	}
 
 	protected IStatus downloadArtifact(IArtifactDescriptor descriptor, OutputStream destination, IProgressMonitor monitor) {
-		monitor = IProgressMonitor.nullSafe(monitor);
+		SubMonitor subMon = SubMonitor.convert(monitor, 2);
 		if (isFolderBased(descriptor)) {
 			File artifactFolder = getArtifactFile(descriptor);
 			if (artifactFolder == null) {
@@ -655,8 +655,8 @@ public class SimpleArtifactRepository extends AbstractArtifactRepository impleme
 		URI baseLocation = getLocation(descriptor);
 		if (baseLocation == null)
 			return new Status(IStatus.ERROR, Activator.ID, NLS.bind(Messages.no_location, descriptor));
-		URI mirrorLocation = getMirror(baseLocation, monitor);
-		IStatus status = downloadArtifact(mirrorLocation, destination, monitor);
+		URI mirrorLocation = getMirror(baseLocation, subMon.split(1));
+		IStatus status = downloadArtifact(mirrorLocation, destination, subMon.split(1));
 		IStatus result = reportStatus(descriptor, destination, status);
 		// if the original download went reasonably but the reportStatus found some issues
 		// (e..g, in the processing steps/validators) then mark the mirror as bad and return

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProfileChangeOperation.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProfileChangeOperation.java
@@ -28,7 +28,7 @@ import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
  * resolution status to be reported to a client to determine whether the operation
  * should proceed.  Each phase of the operation can be performed synchronously or in
  * the background as a job.  To perform the operation synchronously:
- * 
+ *
  *  <pre>
  *     IStatus result = op.resolveModal(monitor);
  *     if (result.isOK())
@@ -37,10 +37,10 @@ import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
  *       // interpret the result
  *     }
  *  </pre>
- *  
+ *
  *  To perform the resolution synchronously and the provisioning job in the
  *  background:
- *  
+ *
  *  <pre>
  *     IStatus status = op.resolveModal(monitor);
  *     if (status.isOK()) {
@@ -50,9 +50,9 @@ import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
  *       // interpret the result
  *     }
  *  </pre>
- *  
+ *
  *  To resolve in the background and perform the job when it is complete:
- * 
+ *
  *  <pre>
  *     ProvisioningJob job = op.getResolveJob(monitor);
  *     job.addJobChangeListener(new JobChangeAdapter() {
@@ -65,18 +65,18 @@ import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
  *       }
  *     });
  *     job.schedule();
- *     
+ *
  *  </pre>
- *  
- * In general, it is expected that clients create a new ProfileChangeOperation if 
+ *
+ * In general, it is expected that clients create a new ProfileChangeOperation if
  * the resolution result of the current operation is not satisfactory.  However,
  * subclasses may prescribe a different life cycle where appropriate.
- * 
- * When retrieving the resolution and provisioning jobs managed by this operation, 
+ *
+ * When retrieving the resolution and provisioning jobs managed by this operation,
  * a client may supply a progress monitor to be used by the job.  When the job is
- * run by the platform job manager, both the platform job manager progress indicator 
+ * run by the platform job manager, both the platform job manager progress indicator
  * and the monitor supplied by the client will be updated.
- * 
+ *
  * @noextend This class is not intended to be subclassed by clients.
  * @since 2.0
  */
@@ -93,7 +93,7 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	 * Create an operation using the provided provisioning session.
 	 * Unless otherwise specified by the client, the operation is
 	 * performed on the currently running profile.
-	 * 
+	 *
 	 * @param session the provisioning session providing the services
 	 */
 	protected ProfileChangeOperation(ProvisioningSession session) {
@@ -105,20 +105,20 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	/**
 	 * Resolve the operation in the current thread using the specified progress
 	 * monitor.  Return a status describing the result of the resolution.
-	 * 
+	 *
 	 * @param monitor the progress monitor to use
 	 * @return a status describing the resolution results
 	 */
 	public final IStatus resolveModal(IProgressMonitor monitor) {
-		if (monitor == null)
-			monitor = new NullProgressMonitor();
+		SubMonitor subMon = SubMonitor.convert(monitor, 2);
 		prepareToResolve();
-		makeResolveJob(monitor);
+		makeResolveJob(subMon.split(1));
 		if (job != null) {
-			IStatus status = job.runModal(monitor);
+			IStatus status = job.runModal(subMon.split(1));
 			if (status.getSeverity() == IStatus.CANCEL)
 				return Status.CANCEL_STATUS;
 		}
+		monitor.done();
 		// For anything other than cancellation, we examine the artifacts of the resolution and come
 		// up with an overall summary.
 		return getResolutionResult();
@@ -135,11 +135,11 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 
 	/**
 	 * Return a job that can be used to resolve this operation in the background.
-	 * 
+	 *
 	 * @param monitor a progress monitor that should be used to report the job's progress in addition
-	 * to the standard job progress reporting.  Can be <code>null</code>.  If provided, this monitor 
+	 * to the standard job progress reporting.  Can be <code>null</code>.  If provided, this monitor
 	 * will be called from a background thread.
-	 * 
+	 *
 	 * @return a job that can be scheduled to perform the provisioning operation.
 	 */
 	public final ProvisioningJob getResolveJob(IProgressMonitor monitor) {
@@ -178,11 +178,11 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 
 	/**
 	 * Compute the profile change request for this operation, adding any relevant intermediate status
-	 * to the supplied status.  
-	 * 
+	 * to the supplied status.
+	 *
 	 * @param status a multi-status to be used to add relevant status.  If a profile change request cannot
 	 * be computed for any reason, a status should be added to explain the problem.
-	 * 
+	 *
 	 * @param monitor the progress monitor to use for computing the profile change request
 	 */
 	protected abstract void computeProfileChangeRequest(MultiStatus status, IProgressMonitor monitor);
@@ -193,14 +193,14 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 
 	/**
 	 * Return an appropriate name for the resolution job.
-	 * 
+	 *
 	 * @return the resolution job name.
 	 */
 	protected abstract String getResolveJobName();
 
 	/**
 	 * Return an appropriate name for the provisioning job.
-	 * 
+	 *
 	 * @return the provisioning job name.
 	 */
 	protected abstract String getProvisioningJobName();
@@ -209,7 +209,7 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	 * Return a status indicating the result of resolving this
 	 * operation.  A <code>null</code> return indicates that
 	 * resolving has not occurred yet.
-	 * 
+	 *
 	 * @return the status of the resolution, or <code>null</code>
 	 * if resolution has not yet occurred.
 	 */
@@ -231,7 +231,7 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	/**
 	 * Return a string that can be used to describe the results of the resolution
 	 * to a client.
-	 * 
+	 *
 	 * @return a string describing the resolution details, or <code>null</code> if the
 	 * operation has not been resolved.
 	 */
@@ -250,9 +250,9 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	/**
 	 * Return a string that describes the specific resolution results
 	 * related to the supplied {@link IInstallableUnit}.
-	 * 
+	 *
 	 * @param iu the IInstallableUnit for which resolution details are requested
-	 * 
+	 *
 	 * @return a string describing the results for the installable unit, or <code>null</code> if
 	 * there are no specific results available for the installable unit.
 	 */
@@ -265,12 +265,12 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 
 	/**
 	 * Return the provisioning plan obtained by resolving the receiver.
-	 * 
+	 *
 	 * @return the provisioning plan.  This may be <code>null</code> if the operation
 	 * has not been resolved, or if a plan could not be obtained when attempting to
 	 * resolve.  If the plan is null and the operation has been resolved, then the
 	 * resolution result will explain the problem.
-	 * 
+	 *
 	 * @see #hasResolved()
 	 * @see #getResolutionResult()
 	 */
@@ -282,12 +282,12 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 
 	/**
 	 * Return the profile change request that describes the receiver.
-	 * 
+	 *
 	 * @return the profile change request.  This may be <code>null</code> if the operation
 	 * has not been resolved, or if a profile change request could not be assembled given
 	 * the operation's state.  If the profile change request is null and the operation has
 	 * been resolved, the the resolution result will explain the problem.
-	 * 
+	 *
 	 * @see #hasResolved()
 	 * @see #getResolutionResult()
 	 * @since 2.1
@@ -299,22 +299,22 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	}
 
 	/**
-	 * Return a provisioning job that can be used to perform the resolved operation.  The job is 
+	 * Return a provisioning job that can be used to perform the resolved operation.  The job is
 	 * created using the default values associated with a new job.  It is up to clients to configure
 	 * the priority of the job and set any appropriate properties, such as
-	 * {@link Job#setUser(boolean)}, 
+	 * {@link Job#setUser(boolean)},
 	 * {@link Job#setSystem(boolean)}, or {@link Job#setProperty(QualifiedName, Object)},
 	 * before scheduling it.
-	 * 
+	 *
 	 * @param monitor a progress monitor that should be used to report the job's progress in addition
-	 * to the standard job progress reporting.  Can be <code>null</code>.  If provided, this monitor 
+	 * to the standard job progress reporting.  Can be <code>null</code>.  If provided, this monitor
 	 * will be called from a background thread.
-	 * 
-	 * @return a job that can be used to perform the provisioning operation.  This may be <code>null</code> 
+	 *
+	 * @return a job that can be used to perform the provisioning operation.  This may be <code>null</code>
 	 * if the operation has not been resolved, or if a plan could not be obtained when attempting to
-	 * resolve.  If the job is null and the operation has been resolved, then the resolution result 
+	 * resolve.  If the job is null and the operation has been resolved, then the resolution result
 	 * will explain the problem.
-	 * 
+	 *
 	 * @see #hasResolved()
 	 * @see #getResolutionResult()
 	 */
@@ -337,7 +337,7 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	 * Set the provisioning context that should be used to resolve and perform the provisioning for
 	 * the operation.  This must be set before an attempt is made to resolve the operation
 	 * for it to have any effect.
-	 * 
+	 *
 	 * @param context the provisioning context.
 	 */
 	public void setProvisioningContext(ProvisioningContext context) {
@@ -349,7 +349,7 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	/**
 	 * Get the provisioning context that will be used to resolve and perform the provisioning for
 	 * the operation.
-	 * 
+	 *
 	 * @return the provisioning context
 	 */
 	public ProvisioningContext getProvisioningContext() {
@@ -367,7 +367,7 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	 * change request, provisioning plan, or resolution result.  It is possible that this
 	 * method return <code>false</code> while resolution is taking place if it is performed
 	 * in the background.
-	 * 
+	 *
 	 * @return <code>true</code> if the operation has been resolved, <code>false</code>
 	 * if it has not resolved.
 	 */

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProfileModificationJob.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProfileModificationJob.java
@@ -71,9 +71,9 @@ public class ProfileModificationJob extends ProvisioningJob implements IProfileC
 		IStatus status = Status.OK_STATUS;
 		if (task == null)
 			task = getName();
-		monitor.beginTask(task, 1000);
 		try {
-			status = getSession().performProvisioningPlan(plan, phaseSet, provisioningContext, SubMonitor.convert(monitor, 1000));
+			SubMonitor subMonitor = SubMonitor.convert(monitor, task, 1000);
+			status = getSession().performProvisioningPlan(plan, phaseSet, provisioningContext, subMonitor);
 		} finally {
 			monitor.done();
 		}

--- a/bundles/org.eclipse.equinox.p2.tests.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.tests.ui
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",

--- a/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/dialogs/UpdateWizardTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/dialogs/UpdateWizardTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.equinox.p2.tests.ui.dialogs;
 
 import java.util.ArrayList;
+import org.eclipse.core.tests.harness.FussyProgressMonitor;
 import org.eclipse.equinox.internal.p2.metadata.License;
 import org.eclipse.equinox.internal.p2.ui.ProvUI;
 import org.eclipse.equinox.internal.p2.ui.dialogs.*;
@@ -183,7 +184,9 @@ public class UpdateWizardTest extends WizardTest {
 		ArrayList<IInstallableUnit> iusInvolved = new ArrayList<>();
 		iusInvolved.add(main);
 		UpdateOperation op = getProvisioningUI().getUpdateOperation(iusInvolved, null);
-		op.resolveModal(getMonitor());
+		FussyProgressMonitor monitor = new FussyProgressMonitor();
+		op.resolveModal(monitor);
+		monitor.assertUsedUp();
 		UpdateWizard wizard = new UpdateWizard(getProvisioningUI(), op, op.getSelectedUpdates(), null);
 		ProvisioningWizardDialog dialog = new ProvisioningWizardDialog(ProvUI.getDefaultParentShell(), wizard);
 		dialog.setBlockOnOpen(false);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/AbstractProvisioningTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/AbstractProvisioningTest.java
@@ -55,9 +55,9 @@ import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.core.tests.harness.FussyProgressMonitor;
 import org.eclipse.equinox.internal.p2.artifact.repository.simple.SimpleArtifactRepository;
 import org.eclipse.equinox.internal.p2.core.helpers.ServiceHelper;
 import org.eclipse.equinox.internal.p2.core.helpers.URLUtil;
@@ -842,7 +842,7 @@ public abstract class AbstractProvisioningTest extends TestCase {
 	}
 
 	protected IProgressMonitor getMonitor() {
-		return new NullProgressMonitor();
+		return new FussyProgressMonitor();
 	}
 
 	protected IProfile getProfile(String profileId) {

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ImportWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ImportWizard.java
@@ -96,8 +96,8 @@ public class ImportWizard extends InstallWizard implements IImportWizard {
 		if (((ImportPage) mainPage).hasUnloadedRepo()) {
 			try {
 				runnableContext.run(true, true, monitor -> {
-					final SubMonitor sub = SubMonitor.convert(monitor, 1000);
-					((ImportPage) mainPage).recompute(sub.newChild(800));
+					final SubMonitor sub = SubMonitor.convert(monitor, withRemediation ? 15 : 10);
+					((ImportPage) mainPage).recompute(sub.newChild(8));
 					if (sub.isCanceled())
 						throw new InterruptedException();
 					Display.getDefault().syncExec(() -> {
@@ -127,12 +127,12 @@ public class ImportWizard extends InstallWizard implements IImportWizard {
 					});
 					if (sub.isCanceled())
 						throw new InterruptedException();
-					if (operation.resolveModal(sub.newChild(200)).getSeverity() == IStatus.CANCEL)
+					if (operation.resolveModal(sub.newChild(2)).getSeverity() == IStatus.CANCEL)
 						throw new InterruptedException();
 					if (withRemediation) {
 						IStatus status = operation.getResolutionResult();
 						if (remediationPage != null && shouldRemediate(status)) {
-							computeRemediationOperation(operation, ui, monitor);
+							computeRemediationOperation(operation, ui, sub.newChild(5));
 						}
 					}
 					Display.getDefault().asyncExec(this::planChanged);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ProvisioningOperationWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ProvisioningOperationWizard.java
@@ -27,7 +27,8 @@ import org.eclipse.equinox.internal.p2.ui.model.IUElementListRoot;
 import org.eclipse.equinox.p2.engine.IProvisioningPlan;
 import org.eclipse.equinox.p2.engine.ProvisioningContext;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
-import org.eclipse.equinox.p2.operations.*;
+import org.eclipse.equinox.p2.operations.ProfileChangeOperation;
+import org.eclipse.equinox.p2.operations.RemediationOperation;
 import org.eclipse.equinox.p2.ui.*;
 import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.wizard.*;
@@ -311,12 +312,10 @@ public abstract class ProvisioningOperationWizard extends Wizard {
 	}
 
 	public void computeRemediationOperation(ProfileChangeOperation op, ProvisioningUI ui, IProgressMonitor monitor) {
-		SubMonitor sub = SubMonitor.convert(monitor, ProvUIMessages.ProvisioningOperationWizard_Remediation_Operation,
-				RemedyConfig.getAllRemedyConfigs().length);
 		monitor.setTaskName(ProvUIMessages.ProvisioningOperationWizard_Remediation_Operation);
 		remediationOperation = new RemediationOperation(ui.getSession(), op.getProfileChangeRequest());
 		remediationOperation.resolveModal(monitor);
-		sub.done();
+		monitor.done();
 	}
 
 	/**

--- a/examples/org.eclipse.equinox.p2.examples.rcp.prestartupdate/src/org/eclipse/equinox/p2/examples/rcp/prestartupdate/P2Util.java
+++ b/examples/org.eclipse.equinox.p2.examples.rcp.prestartupdate/src/org/eclipse/equinox/p2/examples/rcp/prestartupdate/P2Util.java
@@ -47,9 +47,8 @@ public class P2Util {
 		// which installable units are being updated, use the more detailed
 		// constructors.
 		UpdateOperation operation = new UpdateOperation(session);
-		SubMonitor sub = SubMonitor.convert(monitor,
-				"Checking for application updates...", 200);
-		IStatus status = operation.resolveModal(sub.newChild(100));
+		SubMonitor sub = SubMonitor.convert(monitor, "Checking for application updates...", 2);
+		IStatus status = operation.resolveModal(sub.split(1));
 		if (status.getCode() == UpdateOperation.STATUS_NOTHING_TO_UPDATE) {
 			return status;
 		}
@@ -61,9 +60,8 @@ public class P2Util {
 			// are available if there are multiples, differentiating patches vs. updates, etc.
 			// In this example, we simply update as suggested by the operation.
 			ProvisioningJob job = operation.getProvisioningJob(null);
-			status = job.runModal(sub.newChild(100));
-			if (status.getSeverity() == IStatus.CANCEL)
-				throw new OperationCanceledException();
+			status = job.runModal(sub.split(1));
+			sub.checkCanceled();
 		}
 		return status;
 	}


### PR DESCRIPTION
passing a monitor to two callees requires it to be splitted.

https://github.com/eclipse-equinox/p2/issues/335

Also fixed forgotten monitor.done() in performProvisioningPlan and improved tests.