### PR TITLE
Add IMetadataRepository.removeReferences()

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/CompositeMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/CompositeMetadataRepository.java
@@ -246,11 +246,7 @@ public class CompositeMetadataRepository extends AbstractMetadataRepository impl
 			//			return new File(spec + extension);
 			return spec;
 		}
-		if (path.endsWith("/")) //$NON-NLS-1$
-			path += CompositeMetadataRepositoryFactory.CONTENT_FILENAME;
-		else
-			path += "/" + CompositeMetadataRepositoryFactory.CONTENT_FILENAME; //$NON-NLS-1$
-		return new File(path + extension);
+		return new File(path, CompositeMetadataRepositoryFactory.CONTENT_FILENAME + extension);
 	}
 
 	public static File getActualLocation(URI location) {
@@ -263,10 +259,16 @@ public class CompositeMetadataRepository extends AbstractMetadataRepository impl
 	}
 
 	@Override
+	public synchronized boolean removeReferences(Collection<? extends IRepositoryReference> references) {
+		throw new UnsupportedOperationException("Cannot remove References to a composite repository"); //$NON-NLS-1$
+	}
+
+	@Override
 	public Collection<IRepositoryReference> getReferences() {
-		HashSet<IRepositoryReference> allRefs = new HashSet<>();
-		for (IMetadataRepository child : loadedRepos)
+		Set<IRepositoryReference> allRefs = new HashSet<>();
+		for (IMetadataRepository child : loadedRepos) {
 			allRefs.addAll(child.getReferences());
+		}
 		return allRefs;
 	}
 

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/LocalMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/LocalMetadataRepository.java
@@ -44,14 +44,14 @@ import org.eclipse.equinox.p2.repository.metadata.spi.AbstractMetadataRepository
  */
 public class LocalMetadataRepository extends AbstractMetadataRepository implements IIndexProvider<IInstallableUnit> {
 
-	static final private String CONTENT_FILENAME = "content"; //$NON-NLS-1$
-	static final private String REPOSITORY_TYPE = LocalMetadataRepository.class.getName();
-	static final private Integer REPOSITORY_VERSION = 1;
-	static final private String JAR_EXTENSION = ".jar"; //$NON-NLS-1$
-	static final private String XML_EXTENSION = ".xml"; //$NON-NLS-1$
+	private static final String CONTENT_FILENAME = "content"; //$NON-NLS-1$
+	private static final String REPOSITORY_TYPE = LocalMetadataRepository.class.getName();
+	private static final Integer REPOSITORY_VERSION = 1;
+	private static final String JAR_EXTENSION = ".jar"; //$NON-NLS-1$
+	private static final String XML_EXTENSION = ".xml"; //$NON-NLS-1$
 
 	protected IUMap units = new IUMap();
-	protected HashSet<IRepositoryReference> repositories = new HashSet<>();
+	protected final Set<IRepositoryReference> repositories = new LinkedHashSet<>();
 	private IIndex<IInstallableUnit> idIndex;
 	private IIndex<IInstallableUnit> capabilityIndex;
 	private TranslationSupport translationSupport;
@@ -114,14 +114,24 @@ public class LocalMetadataRepository extends AbstractMetadataRepository implemen
 	@Override
 	public void addReferences(Collection<? extends IRepositoryReference> references) {
 		assertModifiable();
-		// only write out the repository if we made changes
-		if (repositories.addAll(references))
-			save();
+		if (repositories.addAll(references)) {
+			save(); // only write out the repository if we made changes
+		}
+	}
+
+	@Override
+	public boolean removeReferences(Collection<? extends IRepositoryReference> references) {
+		assertModifiable();
+		if (repositories.removeAll(references)) {
+			save(); // only write out the repository if we made changes
+			return true;
+		}
+		return false;
 	}
 
 	@Override
 	public Collection<IRepositoryReference> getReferences() {
-		return Collections.unmodifiableCollection(repositories);
+		return Collections.unmodifiableSet(repositories);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/IMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/IMetadataRepository.java
@@ -59,6 +59,13 @@ public interface IMetadataRepository extends IRepository<IInstallableUnit> {
 	Collection<IRepositoryReference> getReferences();
 
 	/**
+	 * Removes from this repository the given references to other repositories.
+	 *
+	 * @since 2.8
+	 */
+	boolean removeReferences(Collection<? extends IRepositoryReference> references);
+
+	/**
 	 * Removes all installable units in the given collection from this repository.
 	 *
 	 * @param installableUnits the installable units to remove

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/spi/AbstractMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/spi/AbstractMetadataRepository.java
@@ -124,6 +124,13 @@ public abstract class AbstractMetadataRepository extends AbstractRepository<IIns
 	}
 
 	@Override
+	public boolean removeReferences(Collection<? extends IRepositoryReference> references) {
+		assertModifiable();
+		return false;
+	}
+
+
+	@Override
 	public void removeAll() {
 		assertModifiable();
 	}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/TestMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/TestMetadataRepository.java
@@ -123,6 +123,12 @@ public class TestMetadataRepository extends AbstractMetadataRepository {
 		repositories.addAll(references);
 	}
 
+	@Override
+	public synchronized boolean removeReferences(Collection<? extends IRepositoryReference> references) {
+		assertModifiable();
+		return repositories.removeAll(references);
+	}
+
 	/**
 	 * Returns a collection of {@link RepositoryReference}.
 	 */

--- a/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/metadata/UpdateSiteMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/metadata/UpdateSiteMetadataRepository.java
@@ -57,6 +57,11 @@ public class UpdateSiteMetadataRepository implements IMetadataRepository {
 	}
 
 	@Override
+	public boolean removeReferences(Collection<? extends IRepositoryReference> references) {
+		throw new UnsupportedOperationException("Repository not modifiable: " + location); //$NON-NLS-1$
+	}
+
+	@Override
 	public Collection<IRepositoryReference> getReferences() {
 		return delegate.getReferences();
 	}


### PR DESCRIPTION
In order to allow removing references to other repositories from an `IMetadataRepository`, just like one can also remove IUs, this adds an `IMetadataRepository.removeReferences(Collection)` method and implements it in all classes that also implement `IMetadataRepository.addReferences()`.

I have not yet added them, but a little test-case, at least for the most imporant implementation `LocalMetadataRepository` would probably be good.
