### PR TITLE
Add IInstallableUnitQueryable interface to allow easier adaption

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/IInstallableUnitQueryable.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/IInstallableUnitQueryable.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ *  Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.p2.metadata;
+
+import org.eclipse.equinox.p2.query.IQueryable;
+
+/**
+ * A {@link IQueryable} for {@link IInstallableUnit}s, this interface is manly
+ * to allow adaption in a context where the generic {@link IQueryable} would not
+ * be applicable as the type information can not be preserved otherwise.
+ * 
+ * @since 2.8
+ *
+ */
+public interface IInstallableUnitQueryable extends IQueryable<IInstallableUnit> {
+
+}

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/IMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/IMetadataRepository.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.equinox.p2.core.IPool;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.IInstallableUnitQueryable;
 import org.eclipse.equinox.p2.repository.*;
 import org.eclipse.equinox.p2.repository.metadata.spi.AbstractMetadataRepository;
 
@@ -31,7 +32,7 @@ import org.eclipse.equinox.p2.repository.metadata.spi.AbstractMetadataRepository
  * @noimplement This interface is not intended to be implemented by clients. Instead subclass {@link AbstractMetadataRepository}
  * @since 2.0
  */
-public interface IMetadataRepository extends IRepository<IInstallableUnit> {
+public interface IMetadataRepository extends IRepository<IInstallableUnit>, IInstallableUnitQueryable {
 
 	/**
 	 * Add the given installable units to this repository.


### PR DESCRIPTION
Currently there is only the generic IQueryable<T> but this don't work well in cases where one can't pass type information for the generic e.g. when adapting an object there is no way to pass the parameter T.

This adds a new interface that lock in the type T for a IQueryable that can supply IInstallableUnits.

This is a prerequisite of https://github.com/eclipse-pde/eclipse.pde/issues/207 where I'd like to use the Adapter pattern to support other locations to supply additional Installable units.