### PR TITLE
Prevent trust dialogs from being hidden behind the application window

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TrustAuthorityDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TrustAuthorityDialog.java
@@ -83,7 +83,7 @@ public class TrustAuthorityDialog extends SelectionDialog {
 	public TrustAuthorityDialog(Shell parentShell, Object input) {
 		super(parentShell);
 
-		setShellStyle(SWT.DIALOG_TRIM | SWT.MODELESS | SWT.RESIZE | SWT.MAX | getDefaultOrientation());
+		setShellStyle(SWT.DIALOG_TRIM | SWT.MODELESS | SWT.RESIZE | SWT.MAX | SWT.ON_TOP | getDefaultOrientation());
 
 		if (input instanceof TreeNode[] nodes) {
 			init(null, nodes);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TrustCertificateDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TrustCertificateDialog.java
@@ -82,7 +82,7 @@ public class TrustCertificateDialog extends SelectionDialog {
 	public TrustCertificateDialog(Shell parentShell, Object input) {
 		super(parentShell);
 
-		setShellStyle(SWT.DIALOG_TRIM | SWT.MODELESS | SWT.RESIZE | SWT.MAX | getDefaultOrientation());
+		setShellStyle(SWT.DIALOG_TRIM | SWT.MODELESS | SWT.RESIZE | SWT.MAX | SWT.ON_TOP | getDefaultOrientation());
 
 		if (input instanceof TreeNode[]) {
 			init(null, (TreeNode[]) input);


### PR DESCRIPTION
Use SWT.ON_TOP for the shell in order to keep the dialogs visible, because generally the user cannot proceed with their activity (update/install) until the dialog is completed.

A modal dialog is avoided because these dialogs are asynchronously opened from a background job, which blocks, so there is no knowing what UI activity might currently be under way.

https://github.com/eclipse-oomph/oomph/issues/11