### PR TITLE
Remove unused distinction between Plug-ins and Fragments in products

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/IProductDescriptor.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/IProductDescriptor.java
@@ -50,21 +50,15 @@ public interface IProductDescriptor {
 	/**
 	 * Returns the bundles listed in this product. Note: These bundles are only part of 
 	 * the product if {@link #useFeatures()} returns <code>false</code>.
-	 * @param includeFragments whether or not to include the fragments in the return value
 	 * @return the list of bundles in this product.
 	 */
-	public List<IVersionedId> getBundles(boolean includeFragments);
+	public List<IVersionedId> getBundles();
 
 	/**
-	 * Returns <code>true</code> when <code>getBundles(includeFragments)</code> returns a non-empty list.
+	 * Returns <code>true</code> when {@link #getBundles()} returns a non-empty
+	 * list.
 	 */
-	public boolean hasBundles(boolean includeFragments);
-
-	/**
-	 * Returns the fragments listed in the product.
-	 * @see #useFeatures()
-	 */
-	public List<IVersionedId> getFragments();
+	public boolean hasBundles();
 
 	/**
 	 * Returns the features listed in the product. Same as <code>getFeatures(INCLUDED_FEATURES)</code>. Note: These features are only part of 

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ProductAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ProductAction.java
@@ -179,17 +179,17 @@ public class ProductAction extends AbstractPublisherAction {
 		switch (product.getProductContentType()) { // add new case for each new content type included in product
 			case MIXED : // include all content types
 				list = versionElements(listElements(product.getFeatures(), ".feature.group"), IInstallableUnit.NAMESPACE_IU_ID); //$NON-NLS-1$
-				list.addAll(versionElements(listElements(product.getBundles(true), null), IInstallableUnit.NAMESPACE_IU_ID));
+				list.addAll(versionElements(listElements(product.getBundles(), null), IInstallableUnit.NAMESPACE_IU_ID));
 				break;
 			case FEATURES : // include features only
 				list = versionElements(listElements(product.getFeatures(), ".feature.group"), IInstallableUnit.NAMESPACE_IU_ID); //$NON-NLS-1$
 
-				if (product.hasBundles(true)) {
+				if (product.hasBundles()) {
 					finalStatus.add(new Status(IStatus.INFO, Activator.ID, Messages.bundlesInProductFileIgnored));
 				}
 				break;
 			case BUNDLES : // include bundles only
-				list = versionElements(listElements(product.getBundles(true), null), IInstallableUnit.NAMESPACE_IU_ID);
+				list = versionElements(listElements(product.getBundles(), null), IInstallableUnit.NAMESPACE_IU_ID);
 
 				if (product.hasFeatures()) {
 					finalStatus.add(new Status(IStatus.INFO, Activator.ID, Messages.featuresInProductFileIgnored));

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ProductFileAdvice.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ProductFileAdvice.java
@@ -227,7 +227,7 @@ public class ProductFileAdvice extends AbstractAdvice
 		if (product.useFeatures()) {
 			return;
 		}
-		List<IVersionedId> bundles = product.getBundles(true);
+		List<IVersionedId> bundles = product.getBundles();
 		Set<BundleInfo> set = new HashSet<>();
 		set.addAll(Arrays.asList(productConfigData.data.getBundles()));
 
@@ -247,7 +247,7 @@ public class ProductFileAdvice extends AbstractAdvice
 
 		// Add all the bundles here. We replace / update them later
 		// if we find configuration information
-		List<IVersionedId> bundles = product.getBundles(true);
+		List<IVersionedId> bundles = product.getBundles();
 		for (IVersionedId vid : bundles) {
 			BundleInfo bundleInfo = new BundleInfo();
 			bundleInfo.setSymbolicName(vid.getId());

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ProductFileTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ProductFileTest.java
@@ -98,12 +98,12 @@ public class ProductFileTest {
 	 */
 	@Test
 	public void testGetBundles() {
-		List<IVersionedId> bundles = productFile.getBundles(false);
-		assertEquals("1.0", 1, bundles.size());
-		assertEquals("1.1", "org.eclipse.core.runtime", bundles.get(0).getId());
-		assertEquals("1.2", Version.createOSGi(1, 0, 4), bundles.get(0).getVersion());
-		bundles = productFile.getBundles(true);
-		assertEquals("1.3", 2, bundles.size());
+		List<IVersionedId> bundles = productFile.getBundles();
+		assertEquals(2, bundles.size());
+		assertEquals("org.eclipse.core.runtime", bundles.get(0).getId());
+		assertEquals(Version.createOSGi(1, 0, 4), bundles.get(0).getVersion());
+		assertEquals("org.eclipse.swt.win32.win32.x86", bundles.get(1).getId());
+		assertEquals(Version.emptyVersion, bundles.get(1).getVersion());
 	}
 
 	/**
@@ -118,17 +118,6 @@ public class ProductFileTest {
 		assertEquals("1.1", "org.eclipse.core.runtime", info.getSymbolicName());
 		assertEquals("1.2", 2, info.getStartLevel());
 		assertTrue("1.3", info.isMarkedAsStarted());
-	}
-
-	/**
-	 * Test method for
-	 * {@link org.eclipse.equinox.internal.p2.publisher.eclipse.ProductFile#getFragments()}.
-	 */
-	@Test
-	public void testGetFragments() {
-		List<IVersionedId> fragments = productFile.getFragments();
-		assertEquals("1.0", 1, fragments.size());
-		assertEquals("1.1", "org.eclipse.swt.win32.win32.x86", fragments.get(0).getId());
 	}
 
 	/**
@@ -168,24 +157,21 @@ public class ProductFileTest {
 	public void testHasFeatures() throws Exception {
 		ProductFile featuresOnly = new ProductFile(TestData.getFile("ProductActionTest", "onlyFeatures.product").toString());
 		assertTrue(featuresOnly.hasFeatures());
-		assertFalse(featuresOnly.hasBundles(false));
-		assertFalse(featuresOnly.hasBundles(true));
+		assertFalse(featuresOnly.hasBundles());
 	}
 
 	@Test
 	public void testHasBundles() throws Exception {
 		ProductFile bundlesOnly = new ProductFile(TestData.getFile("ProductActionTest", "onlyBundles.product").toString());
 		assertFalse(bundlesOnly.hasFeatures());
-		assertTrue(bundlesOnly.hasBundles(false));
-		assertTrue(bundlesOnly.hasBundles(true));
+		assertTrue(bundlesOnly.hasBundles());
 	}
 
 	@Test
 	public void testHasFragments() throws Exception {
 		ProductFile bundlesOnly = new ProductFile(TestData.getFile("ProductActionTest", "onlyFragments.product").toString());
 		assertFalse(bundlesOnly.hasFeatures());
-		assertFalse(bundlesOnly.hasBundles(false));
-		assertTrue(bundlesOnly.hasBundles(true));
+		assertTrue(bundlesOnly.hasBundles());
 	}
 
 	/**


### PR DESCRIPTION
Remove unused distinction between Plug-ins and Fragments in `.product` files.
There is no usage of a product's fragments in P2 or PDE.
I also checked Tycho (5 but I assume it's the same for Tycho 4) and it never calls `IProductDescriptor.getFragments()` and calls `IProductDescriptor.getBundles(boolean includeFragments)` with `includeFragments=true`.

So it looks like this distinction is unused and can be removed too.

Consequently PDE support for adding a fragment attribute for fragments listed in a product file can be removed too and I will create a PR dedicated to that.

This was originally part of https://github.com/eclipse-equinox/p2/pull/368, but since the second part there needs some more adoptions in PDE I will postpone that but would like to land this for the December release.