### PR TITLE
Remove blank Javadoc

### DIFF
--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.frameworkadmin.equinox;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Import-Package: org.eclipse.equinox.frameworkadmin;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EquinoxBundlesState.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EquinoxBundlesState.java
@@ -51,8 +51,6 @@ public class EquinoxBundlesState implements BundlesState {
 	 * eclipse.exe will launch a fw where plugins/org.eclipse.osgi_*.*.*.*.jar is an
 	 * implementation of fw.
 	 *
-	 * @param launcherData
-	 * @param configData
 	 * @return File of fwJar to be used.
 	 */
 	static File getFwJar(LauncherData launcherData, ConfigData configData) {
@@ -238,11 +236,6 @@ public class EquinoxBundlesState implements BundlesState {
 	/**
 	 * If useFwPersistentData flag equals false, this constructor will not take a
 	 * framework persistent data into account. Otherwise, it will.
-	 *
-	 * @param context
-	 * @param fwAdmin
-	 * @param manipulator
-	 * @param useFwPersistentData
 	 */
 	EquinoxBundlesState(BundleContext context, EquinoxFwAdminImpl fwAdmin, Manipulator manipulator, PlatformAdmin admin,
 			boolean useFwPersistentData) {
@@ -260,11 +253,6 @@ public class EquinoxBundlesState implements BundlesState {
 	/**
 	 * This constructor does NOT take a framework persistent data into account. It
 	 * will create State object based on the specified platformProperties.
-	 *
-	 * @param context
-	 * @param fwAdmin
-	 * @param manipulator
-	 * @param platformProperties
 	 */
 	EquinoxBundlesState(BundleContext context, EquinoxFwAdminImpl fwAdmin, Manipulator manipulator, PlatformAdmin admin,
 			Properties platformProperties) {
@@ -286,10 +274,6 @@ public class EquinoxBundlesState implements BundlesState {
 	/**
 	 * compose new state without reading framework persistent data. The
 	 * configData.getFwDependentProps() is used for the composition.
-	 *
-	 * @param launcherData
-	 * @param configData
-	 * @param bInfos
 	 */
 	private void composeNewState(LauncherData launcherData, ConfigData configData, BundleInfo[] bInfos) {
 		this.composeNewState(launcherData, configData, configData.getProperties(), bInfos);
@@ -299,11 +283,6 @@ public class EquinoxBundlesState implements BundlesState {
 	 * compose new state without reading framework persistent data. The given
 	 * properties is used for the composition. If system bundle is not included in
 	 * the given bInfos, the fw jar launcherData contains will be used.
-	 *
-	 * @param launcherData
-	 * @param configData
-	 * @param properties
-	 * @param bInfos
 	 */
 	private void composeNewState(LauncherData launcherData, ConfigData configData, Properties properties,
 			BundleInfo[] bInfos) {
@@ -318,12 +297,7 @@ public class EquinoxBundlesState implements BundlesState {
 	/**
 	 * compose state. If it cannot compose it by somehow, false is returned.
 	 *
-	 * @param bInfos
-	 * @param props
-	 * @param fwPersistentDataLocation
 	 * @return if it cannot compose it by somehow, false is returned.
-	 * @throws IllegalArgumentException
-	 * @throws FrameworkAdminRuntimeException
 	 */
 	private boolean composeState(BundleInfo[] bInfos, Dictionary<Object, Object> props, File fwPersistentDataLocation)
 			throws IllegalArgumentException, FrameworkAdminRuntimeException {
@@ -641,8 +615,6 @@ public class EquinoxBundlesState implements BundlesState {
 
 	/**
 	 * get platforme properties from the given state.
-	 *
-	 * @param state
 	 */
 	private void setPlatformProperties(State state) {
 		@SuppressWarnings("unchecked")
@@ -662,8 +634,6 @@ public class EquinoxBundlesState implements BundlesState {
 	/**
 	 * set platfromProperties required to compose state object into
 	 * platformProperties of this state.
-	 *
-	 * @param props
 	 */
 	private void setPlatformPropertiesToState(Dictionary<Object, Object> props) {
 		Properties platformProperties = setDefaultPlatformProperties();

--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EquinoxFwConfigFileParser.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EquinoxFwConfigFileParser.java
@@ -191,10 +191,6 @@ public class EquinoxFwConfigFileParser {
 
 	/**
 	 * inputFile must be not a directory but a file.
-	 *
-	 * @param manipulator
-	 * @param inputFile
-	 * @throws IOException
 	 */
 	public void readFwConfig(Manipulator manipulator, File inputFile) throws IOException, URISyntaxException {
 		if (inputFile.isDirectory())

--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EquinoxManipulatorImpl.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EquinoxManipulatorImpl.java
@@ -47,8 +47,6 @@ public class EquinoxManipulatorImpl implements Manipulator {
 	 * directory.
 	 *
 	 * Then, reset fwConfigLocation and fwPersistentDataLocation to be matched.
-	 *
-	 * @param launcherData
 	 */
 	static void checkConsistencyOfFwConfigLocAndFwPersistentDataLoc(LauncherData launcherData) {
 		File fwConfigLocation = launcherData.getFwConfigLocation();
@@ -493,7 +491,6 @@ public class EquinoxManipulatorImpl implements Manipulator {
 	 * available ConfiguratorManipulators. 3. Choose the one that will be firstly
 	 * started among them. 4. set the object that corresponds to the chosen
 	 * ConfiguratorBundle.
-	 *
 	 */
 	@SuppressWarnings("unchecked")
 	private ConfiguratorManipulator setConfiguratorManipulator() {
@@ -564,7 +561,6 @@ public class EquinoxManipulatorImpl implements Manipulator {
 	 * FwDependentProperties and FwIndependentProperties, return true. Otherwise
 	 * false.
 	 *
-	 * @param key
 	 * @return true if it should be elimineted from FwDependentProperties and
 	 *         FwIndependentProperties,
 	 */

--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/utils/FileUtils.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/utils/FileUtils.java
@@ -137,8 +137,6 @@ public class FileUtils {
 	/**
 	 * Find the named plugin in the given bundlesDir
 	 * 
-	 * @param pluginName
-	 * @param bundlesDir
 	 * @return a URL string for the found plugin, or null
 	 */
 	// Based on org.eclipse.core.runtime.adaptor.EclipseStarter#searchFor

--- a/bundles/org.eclipse.equinox.frameworkadmin.test/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.frameworkadmin.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.frameworkadmin.test
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.equinox.frameworkadmin,

--- a/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/TestVMArg.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/TestVMArg.java
@@ -146,9 +146,6 @@ public class TestVMArg extends FwkAdminAndSimpleConfiguratorTest {
 	/**
 	 * But 282303: Have -vm ../jre as program arguments. See them vanish during the
 	 * save operation of the manipulator
-	 *
-	 * @throws FrameworkAdminRuntimeException
-	 * @throws IOException
 	 */
 	@Test
 	public void test282303() throws FrameworkAdminRuntimeException, IOException {

--- a/bundles/org.eclipse.equinox.frameworkadmin/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.frameworkadmin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.frameworkadmin;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.3.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Import-Package: org.eclipse.osgi.service.pluginconversion;version="1.0.0",

--- a/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/frameworkadmin/utils/SimpleBundlesState.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/frameworkadmin/utils/SimpleBundlesState.java
@@ -32,9 +32,6 @@ public class SimpleBundlesState implements BundlesState {
 
 	/**
 	 * Check if the specified FrameworkAdmin is available.
-	 * 
-	 * @param fwAdmin
-	 * @throws FrameworkAdminRuntimeException
 	 */
 	public static void checkAvailability(FrameworkAdmin fwAdmin) throws FrameworkAdminRuntimeException {
 		if (!fwAdmin.isActive())
@@ -44,9 +41,7 @@ public class SimpleBundlesState implements BundlesState {
 
 	/**
 	 * 
-	 * @param launcherData
 	 * @return File of fwJar to be used.
-	 * @throws IOException
 	 */
 	static File getFwJar(LauncherData launcherData) {
 		if (launcherData.getFwJar() != null)
@@ -68,10 +63,6 @@ public class SimpleBundlesState implements BundlesState {
 	/**
 	 * If the manifest of the target fw implementation has
 	 * Constants.BUNDLE_SYMBOLICNAME header, this constructor should be used.
-	 * 
-	 * @param ManipulatorAdmin
-	 * @param Manipulator
-	 * @param systemBundleSymbolicName
 	 */
 	public SimpleBundlesState(FrameworkAdmin ManipulatorAdmin, Manipulator Manipulator,
 			String systemBundleSymbolicName) {
@@ -92,11 +83,6 @@ public class SimpleBundlesState implements BundlesState {
 	 * If the manifest of the target fw implementation has not
 	 * Constants.BUNDLE_SYMBOLICNAME header but , Constants.BUNDLE_NAME and
 	 * BUNDLE_VERSION, this constructor should be used.
-	 * 
-	 * @param ManipulatorAdmin
-	 * @param Manipulator
-	 * @param systemBundleName
-	 * @param systemBundleVender
 	 */
 	public SimpleBundlesState(FrameworkAdmin ManipulatorAdmin, Manipulator Manipulator, String systemBundleName,
 			String systemBundleVender) {

--- a/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/provisional/frameworkadmin/BundlesState.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/provisional/frameworkadmin/BundlesState.java
@@ -76,7 +76,6 @@ public interface BundlesState {
 	 * 
 	 * XXX this method is prepared mainly for debugging. 
 	 * 
-	 * @param bInfo
 	 * @return array of Strings which tells the unsatisfied constaints.
 	 * @throws FrameworkAdminRuntimeException if this implementation doesn't support resolving state, FrameworkAdminRuntimeException with a cause of {@link FrameworkAdminRuntimeException#UNSUPPORTED_OPERATION}  will be thrown.
 	 */

--- a/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/provisional/frameworkadmin/FrameworkAdmin.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/provisional/frameworkadmin/FrameworkAdmin.java
@@ -64,7 +64,6 @@ import java.io.IOException;
  * In addition, FrameworkAdminFactory will create this object. This is used by Java programs.
  * 
  * @see FrameworkAdminFactory
- *    
  */
 public interface FrameworkAdmin {
 

--- a/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/provisional/frameworkadmin/FrameworkAdminRuntimeException.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/provisional/frameworkadmin/FrameworkAdminRuntimeException.java
@@ -23,28 +23,18 @@ public class FrameworkAdminRuntimeException extends RuntimeException {
 	private final String reason;
 	private Throwable cause;
 
-	/**
-	 * @param message
-	 */
 	public FrameworkAdminRuntimeException(String message, String reason) {
 		super(message);
 		this.reason = reason;
 		this.cause = null;
 	}
 
-	/**
-	 * @param message
-	 * @param cause
-	 */
 	public FrameworkAdminRuntimeException(String message, Throwable cause, String reason) {
 		super(message);
 		this.reason = reason;
 		this.cause = cause;
 	}
 
-	/**
-	 * @param cause
-	 */
 	public FrameworkAdminRuntimeException(Throwable cause, String reason) {
 		super(cause.getLocalizedMessage());
 		this.reason = reason;

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.artifact.repository;singleton:=true
-Bundle-Version: 1.5.200.qualifier
+Bundle-Version: 1.5.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.artifact.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/processors/checksum/ChecksumUtilities.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/processors/checksum/ChecksumUtilities.java
@@ -36,9 +36,7 @@ public class ChecksumUtilities {
 	/**
 	 * Instances of checksum verifiers applicable for the artifact descriptor
 	 *
-	 * @param descriptor
 	 * @param property either {@link IArtifactDescriptor#ARTIFACT_CHECKSUM} or {@link IArtifactDescriptor#DOWNLOAD_CHECKSUM}
-	 * @param checksumsToSkip
 	 * @return list of checksum verifiers
 	 * @throws IllegalArgumentException if property neither {@link IArtifactDescriptor#ARTIFACT_CHECKSUM} nor {@link IArtifactDescriptor#DOWNLOAD_CHECKSUM}
 	 * @see ChecksumHelper#getChecksums(IArtifactDescriptor, String)
@@ -104,7 +102,6 @@ public class ChecksumUtilities {
 	 *
 	 * @param pathOnDisk file to calculate checksums for
 	 * @param checksums calculated checksums
-	 * @param checksumsToSkip
 	 * @return status
 	 */
 	public static IStatus calculateChecksums(File pathOnDisk, Map<String, String> checksums,
@@ -171,7 +168,6 @@ public class ChecksumUtilities {
 
 	/**
 	 * @param property either {@link IArtifactDescriptor#ARTIFACT_CHECKSUM} or {@link IArtifactDescriptor#DOWNLOAD_CHECKSUM}
-	 * @param checksums
 	 */
 	public static Map<String, String> checksumsToProperties(String property, Map<String, String> checksums) {
 		HashMap<String, String> properties = new HashMap<>();

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/MirrorRequest.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/MirrorRequest.java
@@ -213,9 +213,6 @@ public class MirrorRequest extends ArtifactRequest {
 	/**
 	 * Keep retrying the source repository until it reports back that it will be impossible
 	 * to get the artifact from it.
-	 * @param destinationDescriptor
-	 * @param sourceDescriptor
-	 * @param monitor
 	 * @return the status of the transfer operation
 	 */
 	protected IStatus transfer(IArtifactDescriptor destinationDescriptor, IArtifactDescriptor sourceDescriptor, IProgressMonitor monitor) {
@@ -332,7 +329,6 @@ public class MirrorRequest extends ArtifactRequest {
 	/**
 	 * Extract the root cause. The root cause is the first severe non-MultiStatus status
 	 * containing an exception when searching depth first otherwise null.
-	 * @param status
 	 * @return root cause
 	 */
 	private static IStatus extractRootCause(IStatus status) {

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/MirrorSelector.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/MirrorSelector.java
@@ -43,7 +43,6 @@ import org.xml.sax.SAXException;
  * sorted geographically with closer mirrors first.
  * <br><br>
  * Always use {@link MirrorSelector.MirrorInfoComparator} for comparison.
- *
  */
 public class MirrorSelector {
 	private static final double LOG2 = Math.log(2);

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
@@ -1581,8 +1581,6 @@ public class SimpleArtifactRepository extends AbstractArtifactRepository impleme
 	 * Loads the repository from disk. This method will do nothing
 	 * if this instance of SimpleArtifactRepository holds the lock
 	 * because it will have loaded the repo when it acquired the lock.
-	 *
-	 * @param monitor
 	 */
 	private void load(IProgressMonitor monitor) {
 		monitor = IProgressMonitor.nullSafe(monitor);
@@ -1610,8 +1608,6 @@ public class SimpleArtifactRepository extends AbstractArtifactRepository impleme
 	 * Loads the repository from disk. If the last modified timestamp on the file <=
 	 * to our cache, then this method does nothing.  Otherwise the artifact repository
 	 * on disk is loaded, and reconciled with this instance of the artifact repository.
-	 *
-	 * @param monitor
 	 */
 	private void doLoad(IProgressMonitor monitor) {
 		monitor = IProgressMonitor.nullSafe(monitor);

--- a/bundles/org.eclipse.equinox.p2.console/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.console;singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.console.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.console/src/org/eclipse/equinox/internal/p2/console/ProvCommandProvider.java
+++ b/bundles/org.eclipse.equinox.p2.console/src/org/eclipse/equinox/internal/p2/console/ProvCommandProvider.java
@@ -244,8 +244,6 @@ public class ProvCommandProvider implements CommandProvider {
 
 	/**
 	 * Lists the installable units that match the given URL, id, and/or version.
-	 *
-	 * @param interpreter
 	 */
 	public void _provliu(CommandInterpreter interpreter) {
 		String urlString = processArgument(interpreter.nextArgument());
@@ -266,8 +264,6 @@ public class ProvCommandProvider implements CommandProvider {
 	 * boolean argument can be provided where <code>true</code> means &quot;full
 	 * query&quot; and <code>false</code> means &quote;match query&quote;. The
 	 * default is <code>false</code>.
-	 *
-	 * @param interpreter
 	 */
 	public void _provlquery(CommandInterpreter interpreter) {
 		String urlString = processArgument(interpreter.nextArgument());
@@ -297,8 +293,6 @@ public class ProvCommandProvider implements CommandProvider {
 	/**
 	 * Lists the known metadata repositories, or the contents of a given metadata
 	 * repository.
-	 *
-	 * @param interpreter
 	 */
 	public void _provlr(CommandInterpreter interpreter) {
 		String urlString = processArgument(interpreter.nextArgument());
@@ -323,8 +317,6 @@ public class ProvCommandProvider implements CommandProvider {
 	/**
 	 * Lists the group IUs in all known metadata repositories, or in the given
 	 * metadata repository.
-	 *
-	 * @param interpreter
 	 */
 	public void _provlg(CommandInterpreter interpreter) {
 		String urlString = processArgument(interpreter.nextArgument());
@@ -350,8 +342,6 @@ public class ProvCommandProvider implements CommandProvider {
 	/**
 	 * Lists the known artifact repositories, or the contents of a given artifact
 	 * repository.
-	 *
-	 * @param interpreter
 	 */
 	public void _provlar(CommandInterpreter interpreter) {
 		String urlString = processArgument(interpreter.nextArgument());
@@ -411,8 +401,6 @@ public class ProvCommandProvider implements CommandProvider {
 
 	/**
 	 * Lists the known profiles, or the contents of a given profile.
-	 *
-	 * @param interpreter
 	 */
 	public void _provlp(CommandInterpreter interpreter) {
 		String profileId = processArgument(interpreter.nextArgument());
@@ -453,8 +441,6 @@ public class ProvCommandProvider implements CommandProvider {
 	/**
 	 * Lists the profile timestamps for a given profile id, if no profile id, the
 	 * default profile is used.
-	 *
-	 * @param interpreter
 	 */
 	public void _provlpts(CommandInterpreter interpreter) {
 		String profileId = processArgument(interpreter.nextArgument());
@@ -561,8 +547,6 @@ public class ProvCommandProvider implements CommandProvider {
 	 * can be provided where <code>true</code> means &quot;full query&quot; and
 	 * <code>false</code> means &quote;match query&quote;. The default is
 	 * <code>false</code>.
-	 *
-	 * @param interpreter
 	 */
 	public void _provlpquery(CommandInterpreter interpreter) {
 		String profileId = processArgument(interpreter.nextArgument());
@@ -641,7 +625,6 @@ public class ProvCommandProvider implements CommandProvider {
 	/**
 	 * Handles the help command
 	 *
-	 * @param intp
 	 * @return description for a particular command or false if there is no command
 	 *         with the specified name
 	 */

--- a/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.core;singleton:=true
-Bundle-Version: 2.10.200.qualifier
+Bundle-Version: 2.10.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.core.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/CollectionUtils.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/CollectionUtils.java
@@ -212,7 +212,6 @@ public class CollectionUtils {
 
 	/**
 	 * Copies all elements from <code>properties</code> into a Map. The returned map might be unmodifiable
-	 * @param properties
 	 * @return The map containing all elements
 	 */
 	public static Map<String, String> toMap(Properties properties) {
@@ -226,8 +225,6 @@ public class CollectionUtils {
 
 	/**
 	 * Copies all elements from <code>properties</code> into the given <code>result</code>.
-	 * @param properties
-	 * @param result
 	 */
 	public static void putAll(Properties properties, Map<String, String> result) {
 		for (Enumeration<Object> keys = properties.keys(); keys.hasMoreElements();) {
@@ -241,7 +238,6 @@ public class CollectionUtils {
 	 * @param properties The properties to store
 	 * @param stream The stream to store to
 	 * @param comment The comment to use
-	 * @throws IOException
 	 */
 	public static void storeProperties(Map<String, String> properties, OutputStream stream, String comment) throws IOException {
 		Properties props = new Properties();

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/FileUtils.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/FileUtils.java
@@ -285,7 +285,6 @@ public class FileUtils {
 	 * @param source - the file or folder to zip
 	 * @param exclusions - set of files or folders to exclude
 	 * @param pathComputer - computer used to create the path of the files in the result.
-	 * @throws IOException
 	 */
 	public static void zip(ZipOutputStream output, File source, Set<File> exclusions, IPathComputer pathComputer) throws IOException {
 		zip(output, source, exclusions, pathComputer, new HashSet<>());

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/SecureXMLUtil.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/SecureXMLUtil.java
@@ -26,8 +26,6 @@ import org.xml.sax.*;
 public class SecureXMLUtil {
 	/**
 	 * Create a new {@link DocumentBuilderFactory}.
-	 *
-	 * @throws ParserConfigurationException
 	 */
 	public static DocumentBuilderFactory newSecureDocumentBuilderFactory() throws ParserConfigurationException {
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -40,10 +38,6 @@ public class SecureXMLUtil {
 
 	/**
 	 * Create a new {@link SAXParserFactory}.
-	 *
-	 * @throws ParserConfigurationException
-	 * @throws SAXNotSupportedException
-	 * @throws SAXNotRecognizedException
 	 */
 	public static SAXParserFactory newSecureSAXParserFactory() throws SAXNotRecognizedException, SAXNotSupportedException, ParserConfigurationException {
 		SAXParserFactory factory = SAXParserFactory.newInstance();
@@ -57,9 +51,6 @@ public class SecureXMLUtil {
 
 	/**
 	 * Create a new {@link XMLReader}.
-	 *
-	 * @throws SAXException
-	 * @throws ParserConfigurationException
 	 */
 	public static XMLReader newSecureXMLReader() throws SAXException, ParserConfigurationException {
 		SAXParserFactory factory = newSecureSAXParserFactory();

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/ServiceHelper.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/ServiceHelper.java
@@ -22,7 +22,6 @@ public class ServiceHelper {
 	 * that <b>immediately</b> ungets the service reference.  This results in a window where the
 	 * system thinks the service is not in use but indeed the caller is about to use the returned
 	 * service object.
-	 * @param context
 	 * @param clazz the service class
 	 * @return The requested service
 	 */
@@ -59,8 +58,6 @@ public class ServiceHelper {
 	 * that <b>immediately</b> ungets the service reference.  This results in a window where the
 	 * system thinks the service is not in use but indeed the caller is about to use the returned
 	 * service object.
-	 * @param context
-	 * @param name
 	 * @return The requested service
 	 */
 	public static Object getService(BundleContext context, String name) {

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/TarEntry.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/TarEntry.java
@@ -97,8 +97,6 @@ public class TarEntry implements Cloneable {
 	/**
 	 * Sets the type of the file, one of FILE, LINK, SYMLINK, CHAR_DEVICE,
 	 * BLOCK_DEVICE, or DIRECTORY.
-	 *
-	 * @param type
 	 */
 	public void setFileType(int type) {
 		this.type = type;
@@ -106,8 +104,6 @@ public class TarEntry implements Cloneable {
 
 	/**
 	 * Sets the mode of the file in UNIX permissions format.
-	 *
-	 * @param mode
 	 */
 	public void setMode(long mode) {
 		this.mode = mode;
@@ -115,8 +111,6 @@ public class TarEntry implements Cloneable {
 
 	/**
 	 * Sets the size of the file in bytes.
-	 *
-	 * @param size
 	 */
 	public void setSize(long size) {
 		this.size = size;
@@ -125,8 +119,6 @@ public class TarEntry implements Cloneable {
 	/**
 	 * Sets the modification time of the file in seconds since January
 	 * 1st 1970.
-	 *
-	 * @param time
 	 */
 	public void setTime(long time) {
 		this.time = time;

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/TarFile.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/TarFile.java
@@ -29,10 +29,6 @@ public class TarFile implements Closeable {
 
 	/**
 	 * Create a new TarFile for the given file.
-	 *
-	 * @param file
-	 * @throws TarException
-	 * @throws IOException
 	 */
 	public TarFile(File file) throws TarException, IOException {
 		this.file = file;
@@ -86,10 +82,7 @@ public class TarFile implements Closeable {
 	/**
 	 * Returns a new InputStream for the given file in the tar archive.
 	 *
-	 * @param entry
 	 * @return an input stream for the given file
-	 * @throws TarException
-	 * @throws IOException
 	 */
 	public InputStream getInputStream(TarEntry entry) throws TarException, IOException {
 		if (entryStream == null || !entryStream.skipToEntry(entry)) {

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/TarInputStream.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/TarInputStream.java
@@ -30,8 +30,6 @@ public class TarInputStream extends FilterInputStream {
 	 * Creates a new tar input stream on the given input stream.
 	 *
 	 * @param in input stream
-	 * @throws TarException
-	 * @throws IOException
 	 */
 	public TarInputStream(InputStream in) throws TarException, IOException {
 		super(in);
@@ -47,8 +45,6 @@ public class TarInputStream extends FilterInputStream {
 	 *
 	 * @param in input stream
 	 * @param entry skips to this entry in the file
-	 * @throws TarException
-	 * @throws IOException
 	 */
 	TarInputStream(InputStream in, TarEntry entry) throws TarException, IOException {
 		super(in);
@@ -59,7 +55,6 @@ public class TarInputStream extends FilterInputStream {
 	 *  The checksum of a tar file header is simply the sum of the bytes in
 	 *  the header.
 	 *
-	 * @param header
 	 * @return checksum
 	 */
 	private long headerChecksum(byte[] header) {
@@ -73,10 +68,7 @@ public class TarInputStream extends FilterInputStream {
 	/**
 	 * Skips ahead to the position of the given entry in the file.
 	 *
-	 * @param entry
 	 * @return false if the entry has already been passed
-	 * @throws TarException
-	 * @throws IOException
 	 */
 	boolean skipToEntry(TarEntry entry) throws TarException, IOException {
 		int bytestoskip = entry.filepos - bytesread;
@@ -102,7 +94,6 @@ public class TarInputStream extends FilterInputStream {
 	/**
 	 * Returns true if the header checksum is correct.
 	 *
-	 * @param header
 	 * @return true if this header has a valid checksum
 	 */
 	private boolean isValidTarHeader(byte[] header) {
@@ -147,8 +138,6 @@ public class TarInputStream extends FilterInputStream {
 	 * GNU @LongLink extensions.
 	 *
 	 * @return the next entry in the tar file
-	 * @throws TarException
-	 * @throws IOException
 	 */
 	TarEntry getNextEntryInternal() throws TarException, IOException {
 		byte[] header = new byte[512];
@@ -279,8 +268,6 @@ public class TarInputStream extends FilterInputStream {
 	 * a TarEntry object describing it.
 	 *
 	 * @return the next entry in the tar file
-	 * @throws TarException
-	 * @throws IOException
 	 */
 	public TarEntry getNextEntry() throws TarException, IOException {
 		TarEntry entry = getNextEntryInternal();

--- a/bundles/org.eclipse.equinox.p2.director.app/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.director.app/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.director.app;singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.director.app.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.director.app/src/org/eclipse/equinox/internal/p2/director/app/ILog.java
+++ b/bundles/org.eclipse.equinox.p2.director.app/src/org/eclipse/equinox/internal/p2/director/app/ILog.java
@@ -24,14 +24,11 @@ import org.eclipse.core.runtime.IStatus;
 public interface ILog {
 	/**
 	 * Send status to the standard log
-	 *
-	 * @param status
 	 */
 	void log(IStatus status);
 
 	/**
 	 *
-	 * @param message
 	 * @deprecated Use {@link ILog#printOut()} or {@link ILog#printErr()}
 	 */
 	@Deprecated
@@ -48,8 +45,6 @@ public interface ILog {
 	 * Print status on stdout or stderr.
 	 *
 	 * By default calls {@link #log}
-	 *
-	 * @param status
 	 */
 	default void printOut(String line) {
 		System.out.println(line);

--- a/bundles/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.director;singleton:=true
-Bundle-Version: 2.6.200.qualifier
+Bundle-Version: 2.6.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.director.DirectorActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Projector.java
+++ b/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Projector.java
@@ -803,7 +803,6 @@ public class Projector {
 	}
 
 	/**
-	 * @param req
 	 * @return a list of mandatory requirements if any, an empty list if req.isOptional().
 	 */
 	private List<IInstallableUnit> getApplicableMatches(IRequirement req) {

--- a/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/SimplePlanner.java
+++ b/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/SimplePlanner.java
@@ -200,8 +200,6 @@ public class SimplePlanner implements IPlanner {
 	 * TODO Find a way to emit INFO status. The issue is that all
 	 * {@link IStatus#isOK()} calls will fail.
 	 *
-	 * @param requestChanges
-	 * @param requestSideEffects
 	 * @return the {@link IStatus}
 	 */
 	private static IStatus convertChangesToStatus(Map<IInstallableUnit, RequestStatus> requestChanges,

--- a/bundles/org.eclipse.equinox.p2.discovery.compatibility/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.discovery.compatibility/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.p2.discovery.compatibility;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",

--- a/bundles/org.eclipse.equinox.p2.discovery.compatibility/src/org/eclipse/equinox/internal/p2/discovery/compatibility/util/CacheManager.java
+++ b/bundles/org.eclipse.equinox.p2.discovery.compatibility/src/org/eclipse/equinox/internal/p2/discovery/compatibility/util/CacheManager.java
@@ -134,7 +134,6 @@ public class CacheManager {
 
 	/**
 	 * Deletes the local cache file(s) for the given location
-	 * @param location
 	 */
 	void deleteCache(URI location) {
 		File cacheFile = getCache(location);

--- a/bundles/org.eclipse.equinox.p2.discovery.compatibility/src/org/eclipse/equinox/internal/p2/discovery/compatibility/util/TransportUtil.java
+++ b/bundles/org.eclipse.equinox.p2.discovery.compatibility/src/org/eclipse/equinox/internal/p2/discovery/compatibility/util/TransportUtil.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.eclipse.core.runtime.*;
 import org.eclipse.equinox.internal.p2.discovery.compatibility.Activator;
 import org.eclipse.equinox.internal.p2.discovery.compatibility.Messages;
-import org.eclipse.equinox.internal.p2.repository.AuthenticationFailedException;
 import org.eclipse.equinox.internal.p2.transport.ecf.RepositoryTransport;
 
 /**
@@ -45,26 +44,24 @@ public class TransportUtil {
 	/**
 	 * Download an HTTP-based resource
 	 * 
-	 * @param target
-	 *            the target file to which the content is saved
-	 * @param location
-	 *            the web location of the content
-	 * @param monitor
-	 *            the monitor
-	 * @throws IOException
-	 *             if a network or IO problem occurs
-	 * @throws CoreException 
+	 * @param target   the target file to which the content is saved
+	 * @param location the web location of the content
+	 * @param monitor  the monitor
+	 * @throws IOException   if a network or IO problem occurs
 	 */
-	public static void downloadResource(URI location, File target, IProgressMonitor monitor) throws IOException, CoreException {
+	public static void downloadResource(URI location, File target, IProgressMonitor monitor)
+			throws IOException, CoreException {
 		CacheManager cm = Activator.getDefault().getCacheManager();
 		File cacheFile = cm.createCache(location, monitor);
 		if (cacheFile == null) {
 			throw new CoreException(new Status(IStatus.ERROR, Activator.ID, Messages.TransportUtil_InternalError));
 		}
-		copyStream(new BufferedInputStream(new FileInputStream(cacheFile)), true, new BufferedOutputStream(new FileOutputStream(target)), true);
+		copyStream(new BufferedInputStream(new FileInputStream(cacheFile)), true,
+				new BufferedOutputStream(new FileOutputStream(target)), true);
 	}
 
-	public static int copyStream(InputStream in, boolean closeIn, OutputStream out, boolean closeOut) throws IOException {
+	public static int copyStream(InputStream in, boolean closeIn, OutputStream out, boolean closeOut)
+			throws IOException {
 		try {
 			int written = 0;
 			byte[] buffer = new byte[16 * 1024];
@@ -88,19 +85,16 @@ public class TransportUtil {
 	}
 
 	/**
-	 * Read a web-based resource at the specified location using the given processor.
+	 * Read a web-based resource at the specified location using the given
+	 * processor.
 	 * 
-	 * @param location
-	 *            the web location of the content
-	 * @param processor
-	 *            the processor that will handle content
-	 * @param monitor
-	 *            the monitor
-	 * @throws IOException
-	 *             if a network or IO problem occurs
-	 * @throws CoreException
+	 * @param location  the web location of the content
+	 * @param processor the processor that will handle content
+	 * @param monitor   the monitor
+	 * @throws IOException if a network or IO problem occurs
 	 */
-	public static void readResource(URI location, TextContentProcessor processor, IProgressMonitor monitor) throws IOException, CoreException {
+	public static void readResource(URI location, TextContentProcessor processor, IProgressMonitor monitor)
+			throws IOException, CoreException {
 		CacheManager cm = Activator.getDefault().getCacheManager();
 		File cacheFile = cm.createCache(location, monitor);
 		if (cacheFile == null) {
@@ -114,19 +108,16 @@ public class TransportUtil {
 	}
 
 	/**
-	 * Verify availability of resources at the given web locations. Normally this would be done using an HTTP HEAD.
+	 * Verify availability of resources at the given web locations. Normally this
+	 * would be done using an HTTP HEAD.
 	 * 
-	 * @param locations
-	 *            the locations of the resource to verify
-	 * @param one
-	 *            indicate if only one of the resources must exist
-	 * @param monitor
-	 *            the monitor
+	 * @param locations the locations of the resource to verify
+	 * @param one       indicate if only one of the resources must exist
+	 * @param monitor   the monitor
 	 * @return true if the resource exists
-	 * @throws CoreException
-	 * @throws AuthenticationFailedException
 	 */
-	public static boolean verifyAvailability(List<? extends URI> locations, boolean one, IProgressMonitor monitor) throws IOException, CoreException {
+	public static boolean verifyAvailability(List<? extends URI> locations, boolean one, IProgressMonitor monitor)
+			throws IOException, CoreException {
 		if (locations.isEmpty() || locations.size() > 5) {
 			throw new IllegalArgumentException();
 		}

--- a/bundles/org.eclipse.equinox.p2.extensionlocation/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.extensionlocation;singleton:=true
-Bundle-Version: 1.5.200.qualifier
+Bundle-Version: 1.5.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.extensionlocation.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/SiteListener.java
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/SiteListener.java
@@ -78,9 +78,6 @@ public class SiteListener extends DirectoryChangeListener {
 	 * synchronized in one go.  It is expected that both repos have been previously created
 	 * so simply loading them here will work and that all their properties etc have been configured
 	 * previously.
-	 * @param metadataRepository
-	 * @param artifactRepository
-	 * @param base
 	 */
 	public static synchronized void synchronizeRepositories(ExtensionLocationMetadataRepository metadataRepository, ExtensionLocationArtifactRepository artifactRepository, File base) {
 		try {

--- a/bundles/org.eclipse.equinox.p2.installer/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.installer/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.equinox.p2.installer;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.installer.InstallerActivator
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.osgi;bundle-version="[3.7.0,4.0.0)",

--- a/bundles/org.eclipse.equinox.p2.installer/src/org/eclipse/equinox/internal/p2/installer/InstallDescriptionParser.java
+++ b/bundles/org.eclipse.equinox.p2.installer/src/org/eclipse/equinox/internal/p2/installer/InstallDescriptionParser.java
@@ -161,8 +161,6 @@ public class InstallDescriptionParser {
 	 * Add all of the given properties to profile properties of the given description 
 	 * after removing the keys known to be for the installer.  This allows install descriptions 
 	 * to also set random profile properties.
-	 * @param description
-	 * @param properties
 	 */
 	private static void initializeProfileProperties(InstallDescription description, Map<String, String> properties) {
 		//any remaining properties are profile properties

--- a/bundles/org.eclipse.equinox.p2.installer/src/org/eclipse/equinox/internal/p2/installer/Messages.java
+++ b/bundles/org.eclipse.equinox.p2.installer/src/org/eclipse/equinox/internal/p2/installer/Messages.java
@@ -15,9 +15,6 @@ package org.eclipse.equinox.internal.p2.installer;
 
 import org.eclipse.osgi.util.NLS;
 
-/**
- * 
- */
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.equinox.internal.p2.installer.messages"; //$NON-NLS-1$
 	public static String Advisor_Canceled;

--- a/bundles/org.eclipse.equinox.p2.jarprocessor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.jarprocessor/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.equinox.p2.jarprocessor;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Main-Class: org.eclipse.equinox.internal.p2.jarprocessor.Main
 Export-Package: org.eclipse.equinox.internal.p2.jarprocessor;x-friends:="org.eclipse.equinox.p2.artifact.repository,org.eclipse.pde.build",

--- a/bundles/org.eclipse.equinox.p2.jarprocessor/src/org/eclipse/equinox/internal/p2/jarprocessor/Main.java
+++ b/bundles/org.eclipse.equinox.p2.jarprocessor/src/org/eclipse/equinox/internal/p2/jarprocessor/Main.java
@@ -74,9 +74,6 @@ public class Main {
 		return options;
 	}
 
-	/**
-	 * @param args
-	 */
 	public static void main(String[] args) {
 		JarProcessorExecutor.Options options = processArguments(args);
 		if (options == null)

--- a/bundles/org.eclipse.equinox.p2.jarprocessor/src/org/eclipse/equinox/internal/p2/jarprocessor/Utils.java
+++ b/bundles/org.eclipse.equinox.p2.jarprocessor/src/org/eclipse/equinox/internal/p2/jarprocessor/Utils.java
@@ -21,7 +21,6 @@ import java.util.zip.ZipException;
 
 /**
  * @author aniefer@ca.ibm.com
- *
  */
 public class Utils {
 	public static final String MARK_FILE_NAME = "META-INF/eclipse.inf"; //$NON-NLS-1$
@@ -66,11 +65,6 @@ public class Utils {
 	 * Transfers all available bytes from the given input stream to the given output
 	 * stream. Closes both streams if close == true, regardless of failure. Flushes
 	 * the destination stream if close == false
-	 * 
-	 * @param source
-	 * @param destination
-	 * @param close
-	 * @throws IOException
 	 */
 	public static void transferStreams(InputStream source, OutputStream destination, boolean close) throws IOException {
 		source = new BufferedInputStream(source);
@@ -169,7 +163,6 @@ public class Utils {
 	 * is not a jar, null is returned. If the file is a jar, but does not contain an
 	 * eclipse.inf file, an empty Properties object is returned.
 	 * 
-	 * @param jarFile
 	 * @return The eclipse.inf properties for the given jar file
 	 */
 	public static Properties getEclipseInf(File jarFile, boolean verbose) {
@@ -224,9 +217,6 @@ public class Utils {
 	 * Stores the given properties in the output stream. We store the properties in
 	 * sorted order so that the signing hash doesn't change if the properties didn't
 	 * change.
-	 * 
-	 * @param props
-	 * @param stream
 	 */
 	public static void storeProperties(Properties props, OutputStream stream) {
 		PrintStream printStream = new PrintStream(stream);

--- a/bundles/org.eclipse.equinox.p2.jarprocessor/src/org/eclipse/internal/provisional/equinox/p2/jarprocessor/IProcessStep.java
+++ b/bundles/org.eclipse.equinox.p2.jarprocessor/src/org/eclipse/internal/provisional/equinox/p2/jarprocessor/IProcessStep.java
@@ -19,7 +19,6 @@ import java.util.Properties;
 
 /**
  * @author aniefer@ca.ibm.com
- *
  */
 public interface IProcessStep {
 
@@ -27,15 +26,12 @@ public interface IProcessStep {
 	 * The effect of this processing step if the JarProcessor was to recurse on this entry.
 	 * Return null if this step will not do anything with this entry.
 	 * Return the new entryName if this step will modify this entry on recursion.
-	 * @param entryName
 	 * @return The new entry name, or <code>null</code>
 	 */
 	public String recursionEffect(String entryName);
 
 	/**
 	 * Perform some processing on the input file before the JarProcessor considers the entries for recursion.
-	 * @param input
-	 * @param workingDirectory
 	 * @param containers inf properties for containing jars, innermost jar is first on the list
 	 * @return the file containing the result of the processing
 	 */
@@ -44,8 +40,6 @@ public interface IProcessStep {
 	/**
 	 * Perform some processing on the input file after the JarProcessor returns from recursion.
 	 *
-	 * @param input
-	 * @param workingDirectory
 	 * @param containers inf properties for containing jars, innermost jar is first on the list
 	 * @return the file containing the result of the processing
 	 */
@@ -59,8 +53,6 @@ public interface IProcessStep {
 
 	/**
 	 * Adjust any properties in the eclipse.inf as appropriate for this step
-	 * @param input
-	 * @param inf
 	 * @param containers inf properties for containing jars, innermost jar is first on the list
 	 * @return <code>true</code> if the properties file was adjusted, and false othewise
 	 */

--- a/bundles/org.eclipse.equinox.p2.jarprocessor/src/org/eclipse/internal/provisional/equinox/p2/jarprocessor/JarProcessor.java
+++ b/bundles/org.eclipse.equinox.p2.jarprocessor/src/org/eclipse/internal/provisional/equinox/p2/jarprocessor/JarProcessor.java
@@ -65,7 +65,6 @@ public class JarProcessor {
 	 * @param outputJar    - the output
 	 * @param replacements - map of entryName -> new entryName
 	 * @param directory    - location to find file for new entryName
-	 * @throws IOException
 	 */
 	private void recreateJar(JarFile jar, JarOutputStream outputJar, Map<String, String> replacements, File directory,
 			Properties inf) throws IOException {

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.metadata.repository;singleton:=true
-Bundle-Version: 1.5.200.qualifier
+Bundle-Version: 1.5.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.metadata.repository;

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/MetadataRepositoryIO.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/MetadataRepositoryIO.java
@@ -85,9 +85,6 @@ public class MetadataRepositoryIO {
 		}
 	}
 
-	/**
-	 *
-	 */
 	public void write(IMetadataRepository repository, OutputStream output) throws IOException {
 		try (OutputStream bufferedOutput = new BufferedOutputStream(output)) {
 			Writer repositoryWriter = new Writer(bufferedOutput, repository.getClass());

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/SimpleMetadataRepositoryFactory.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/SimpleMetadataRepositoryFactory.java
@@ -139,7 +139,6 @@ public class SimpleMetadataRepositoryFactory extends MetadataRepositoryFactory {
 	 * @param stream the stream
 	 * @return <code>true</code> if the stream supports mark/reset and has the two
 	 *         magic bytes PK at its current position
-	 * @throws IOException
 	 */
 	private static boolean hasZipMagicHeader(InputStream stream) throws IOException {
 		if (stream.markSupported()) {

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/p2/metadata/io/IUDeserializer.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/p2/metadata/io/IUDeserializer.java
@@ -29,7 +29,6 @@ import org.xml.sax.*;
  * This class allows to deserialize {@link IInstallableUnit}s that have been serialized with {@link IUSerializer}.
  * The deserializer is able to read data that have been serialized with previous versions of the serializer.
  * @since 1.2
- *
  */
 public class IUDeserializer {
 	private IUDeserializerParser deserializer;
@@ -49,7 +48,6 @@ public class IUDeserializer {
 	 * Deserialize a set of {@link IInstallableUnit} from the input stream.
 	 * @param input the input stream to deserialize {@link IInstallableUnit}s from.
 	 * @return the collection of {@link IInstallableUnit}s read from the input stream.
-	 * @throws IOException
 	 */
 	public Collection<IInstallableUnit> read(InputStream input) throws IOException {
 		return deserializer.parse(input);

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/p2/metadata/io/IUSerializer.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/p2/metadata/io/IUSerializer.java
@@ -31,7 +31,6 @@ public class IUSerializer {
 	/**
 	 * Construct a serializer.
 	 * @param os the output stream against which the serializer will work.
-	 * @throws UnsupportedEncodingException
 	 */
 	public IUSerializer(OutputStream os) throws UnsupportedEncodingException {
 		writer = new MetadataWriter(os, null);

--- a/bundles/org.eclipse.equinox.p2.metadata/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.metadata/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.metadata;singleton:=true
-Bundle-Version: 2.8.0.qualifier
+Bundle-Version: 2.8.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.metadata;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/TranslationSupport.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/TranslationSupport.java
@@ -99,8 +99,6 @@ public class TranslationSupport {
 		this.fragmentSource = fragmentSource;
 	}
 
-	/**
-	 */
 	private List<String> buildLocaleVariants(String locale) {
 		ArrayList<String> result = new ArrayList<>(4);
 		int lastSeparator;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionFormatParser.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionFormatParser.java
@@ -27,7 +27,6 @@ import org.eclipse.osgi.util.NLS;
  *
  * The class is not intended to included in a public API. Instead VersionFormats should
  * be created using {@link VersionFormat#parse(String)}
- *
  */
 class VersionFormatParser {
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Collect.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Collect.java
@@ -17,8 +17,6 @@ import java.util.Iterator;
 import org.eclipse.equinox.p2.metadata.expression.IEvaluationContext;
 import org.eclipse.equinox.p2.metadata.expression.IExpression;
 
-/**
- */
 final class Collect extends CollectionFilter {
 	final class CollectIterator implements Iterator<Object> {
 		private final IEvaluationContext context;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/CompoundIterator.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/CompoundIterator.java
@@ -35,8 +35,6 @@ public class CompoundIterator<T> implements Iterator<T> {
 	 * of the provided <code>iterator</code>. Each element will be coerced
 	 * into an iterator and its elements in turn are returned
 	 * in succession by the compound iterator.
-	 *
-	 * @param iterator
 	 */
 	public CompoundIterator(Iterator<? extends Object> iterator) {
 		this.iteratorIterator = iterator;
@@ -60,7 +58,6 @@ public class CompoundIterator<T> implements Iterator<T> {
 	/**
 	 * Remove is not supported by this iterator so calling this method
 	 * will always yield an exception.
-	 * @throws UnsupportedOperationException
 	 */
 	@Override
 	public void remove() {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Union.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Union.java
@@ -17,8 +17,6 @@ import java.util.Iterator;
 import java.util.Set;
 import org.eclipse.equinox.p2.metadata.expression.IEvaluationContext;
 
-/**
- */
 final class Union extends Binary {
 	Union(Expression operand, Expression param) {
 		super(operand, param);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/WrappedIQuery.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/WrappedIQuery.java
@@ -31,7 +31,6 @@ public final class WrappedIQuery extends Function {
 	 * to an iterator. If it is not provided, it defaults to the variable
 	 * <code>everything</code>.
 	 * </ul>
-	 * @param operands
 	 */
 	public WrappedIQuery(Expression[] operands) {
 		super(assertLength(operands, 1, 2, KEYWORD_IQUERY));

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/MetadataFactory.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/MetadataFactory.java
@@ -63,28 +63,24 @@ public final class MetadataFactory {
 		/**
 		 * A property key (value <code>"org.eclipse.equinox.p2.type.patch"</code>) for a
 		 * boolean property indicating that an installable unit is a group.
-		 * 
 		 */
 		public static final String PROP_TYPE_GROUP = "org.eclipse.equinox.p2.type.group"; //$NON-NLS-1$
 
 		/**
 		 * A property key (value <code>"org.eclipse.equinox.p2.type.patch"</code>) for a
 		 * boolean property indicating that an installable unit is a patch.
-		 * 
 		 */
 		public static final String PROP_TYPE_PATCH = "org.eclipse.equinox.p2.type.patch"; //$NON-NLS-1$
 
 		/**
 		 * A property key (value <code>"org.eclipse.equinox.p2.type.fragment"</code>)
 		 * for a boolean property indicating that an installable unit is a fragment.
-		 * 
 		 */
 		public static final String PROP_TYPE_FRAGMENT = "org.eclipse.equinox.p2.type.fragment"; //$NON-NLS-1$
 
 		/**
 		 * A property key (value <code>"org.eclipse.equinox.p2.type.category"</code>)
 		 * for a boolean property indicating that an installable unit is a category.
-		 * 
 		 */
 		public static final String PROP_TYPE_CATEGORY = "org.eclipse.equinox.p2.type.category"; //$NON-NLS-1$
 

--- a/bundles/org.eclipse.equinox.p2.operations/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.operations/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.operations;singleton:=true
-Bundle-Version: 2.7.200.qualifier
+Bundle-Version: 2.7.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.operations;x-friends:="org.eclipse.pde.ui,org.eclipse.equinox.p2.ui",

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/Messages.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/Messages.java
@@ -18,7 +18,6 @@ import org.eclipse.osgi.util.NLS;
 
 /**
  * @since 2.0
- *
  */
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.equinox.internal.p2.operations.messages"; //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProvisioningJob.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProvisioningJob.java
@@ -178,7 +178,6 @@ public abstract class ProvisioningJob extends Job {
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
 	 * @see org.eclipse.core.runtime.jobs.Job#run(org.eclipse.core.runtime.IProgressMonitor)
-	 *
 	 */
 	@Override
 	public final IStatus run(IProgressMonitor monitor) {
@@ -202,7 +201,6 @@ public abstract class ProvisioningJob extends Job {
 	 *            the progress monitor to use for the operation
 	 *
 	 * @return a status indicating the result of the operation.
-	 *
 	 */
 	public abstract IStatus runModal(IProgressMonitor monitor);
 

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RepositoryTracker.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RepositoryTracker.java
@@ -189,7 +189,6 @@ public abstract class RepositoryTracker {
 	 * a repository manager
 	 * 
 	 * @return the repository flags
-	 * 
 	 */
 	public int getArtifactRepositoryFlags() {
 		return artifactRepositoryFlags;
@@ -200,7 +199,6 @@ public abstract class RepositoryTracker {
 	 * a repository manager
 	 * 
 	 * @param flags the repository flags
-	 * 
 	 */
 	public void setArtifactRepositoryFlags(int flags) {
 		artifactRepositoryFlags = flags;
@@ -211,7 +209,6 @@ public abstract class RepositoryTracker {
 	 * a repository manager
 	 * 
 	 * @return the repository flags
-	 * 
 	 */
 	public int getMetadataRepositoryFlags() {
 		return metadataRepositoryFlags;
@@ -222,7 +219,6 @@ public abstract class RepositoryTracker {
 	 * a repository manager
 	 * 
 	 * @param flags the repository flags
-	 * 
 	 */
 
 	public void setMetadataRepositoryFlags(int flags) {

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/UpdateOperation.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/UpdateOperation.java
@@ -322,7 +322,6 @@ public class UpdateOperation extends ProfileChangeOperation {
 	 * Overridden because our resolution job life cycle is different.  We have a job
 	 * before we've computed the profile change request, so we must ensure that we
 	 * have already computed the profile change request.
-	 *
 	 */
 	@Override
 	public boolean hasResolved() {

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.publisher.eclipse;singleton:=true
-Bundle-Version: 1.5.200.qualifier
+Bundle-Version: 1.5.300.qualifier
 Bundle-Activator: org.eclipse.pde.internal.publishing.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/BrandingIron.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/BrandingIron.java
@@ -24,9 +24,6 @@ import org.eclipse.pde.internal.publishing.Activator;
 import org.eclipse.pde.internal.publishing.Utils;
 import org.eclipse.pde.internal.swt.tools.IconExe;
 
-/**
- *
- */
 public class BrandingIron {
 	private static final String XDOC_ICON = "-Xdock:icon=../Resources/Eclipse.icns"; //$NON-NLS-1$
 	private static final String XDOC_ICON_PREFIX = "-Xdock:icon=../Resources/"; //$NON-NLS-1$
@@ -254,11 +251,6 @@ public class BrandingIron {
 	/**
 	 * Brand the splash.app Info.plist and link or copy the mac launcher. It is
 	 * assumed that the mac launcher has been branded already.
-	 * 
-	 * @param descriptor
-	 * @param initialRoot
-	 * @param target
-	 * @param iconName
 	 */
 	private void brandMacSplash(ExecutablesDescriptor descriptor, File initialRoot, File target, String iconName) {
 		String splashContents = "Resources/Splash.app/Contents"; //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/ExecutablesDescriptor.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/ExecutablesDescriptor.java
@@ -70,9 +70,6 @@ public class ExecutablesDescriptor {
 	 * Create an executable descriptor based on the given location, os and name.
 	 * This method is typically used to identify the executable related files in existing
 	 * unmanaged configurations.
-	 * @param os
-	 * @param location
-	 * @param executable
 	 * @return the created descriptor
 	 */
 	public static ExecutablesDescriptor createDescriptor(String os, String executable, File location) {

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/IProductDescriptor.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/IProductDescriptor.java
@@ -29,7 +29,6 @@ import org.eclipse.equinox.p2.repository.IRepositoryReference;
  * 
  * If getLocation returns null, then config.ini and p2 advice files cannot
  * be used (since these are both relative to the product location).
- *
  */
 public interface IProductDescriptor {
 

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/BundlesAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/BundlesAction.java
@@ -534,7 +534,6 @@ public class BundlesAction extends AbstractPublisherAction {
 	}
 
 	/**
-	 * @param id
 	 * @return the id for the iu fragment containing localized properties for the
 	 *         fragment with the given id.
 	 */

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ConfigCUsAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ConfigCUsAction.java
@@ -336,8 +336,6 @@ public class ConfigCUsAction extends AbstractPublisherAction {
 	/**
 	 * Publish the CUs related to the given set of bundles. This generally covers
 	 * the start-level and and whether or not the bundle is to be started.
-	 * 
-	 * @param configBundles
 	 */
 	protected void publishBundleCUs(IPublisherInfo publisherInfo, BundleInfo[] bundles, String configSpec,
 			IPublisherResult result, Set<String> configBundles) {

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/FeatureEntry.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/FeatureEntry.java
@@ -17,8 +17,6 @@ package org.eclipse.equinox.p2.publisher.eclipse;
 import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.equinox.p2.metadata.VersionRange;
 
-/**
- */
 public class FeatureEntry implements IPlatformEntry {
 	private final String id;
 	private String versionOrRange;

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/pde/internal/build/publisher/FeatureRootAdvice.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/pde/internal/build/publisher/FeatureRootAdvice.java
@@ -53,7 +53,6 @@ public class FeatureRootAdvice extends AbstractAdvice implements IFeatureRootAdv
 	/**
 	 * Return the GatheringComputer containing the set of rootfiles to include for the given config
 	 * Returns null if we have no advice for the given config.
-	 * @param config
 	 * @return GatheringComputer
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/pde/internal/build/publisher/GatherBundleAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/pde/internal/build/publisher/GatherBundleAction.java
@@ -31,9 +31,6 @@ public class GatherBundleAction extends BundlesAction {
 	private File manifestRoot = null;
 	private File bundleLocation = null;
 
-	/**
-	 * @param location
-	 */
 	public GatherBundleAction(File location, File manifestRoot) {
 		super(new File[] {location});
 		this.manifestRoot = manifestRoot;

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/pde/internal/swt/tools/IconExe.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/pde/internal/swt/tools/IconExe.java
@@ -1228,7 +1228,6 @@ public class IconExe {
 		 * the background pixel for the logical screen (this 
 		 * corresponds to the GIF89a Background Color Index value).
 		 * The default is -1 which means 'unspecified background'
-		 * 
 		 */
 		public int backgroundPixel;
 

--- a/bundles/org.eclipse.equinox.p2.publisher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.publisher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.publisher;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.100.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.publisher.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/AbstractPublisherAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/AbstractPublisherAction.java
@@ -555,7 +555,6 @@ public abstract class AbstractPublisherAction implements IPublisherAction {
 	 * @param exclusions     and folders to be excluded in the zip. files can be
 	 *                       null.
 	 * @param publisherInfo  the publisher info.
-	 * @param prefixComputer
 	 */
 	protected void publishArtifact(IArtifactDescriptor descriptor, File[] inclusions, File[] exclusions,
 			IPublisherInfo publisherInfo, IPathComputer prefixComputer) {
@@ -629,7 +628,6 @@ public abstract class AbstractPublisherAction implements IPublisherAction {
 	 * Loop over the known metadata repositories looking for the given IU within a
 	 * particular range
 	 *
-	 * @param publisherResult
 	 * @param iuId            the id of the IU to look for
 	 * @param versionRange    the version range to consider
 	 * @return The the IUs with the matching ids in the given range

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/Publisher.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/Publisher.java
@@ -48,7 +48,6 @@ public class Publisher {
 	 * @param append   whether or not the repository should appended or cleared
 	 * @param compress whether or not to compress the repository index
 	 * @return the discovered or created repository
-	 * @throws ProvisionException
 	 */
 	public static IMetadataRepository createMetadataRepository(IProvisioningAgent agent, URI location, String name,
 			boolean append, boolean compress) throws ProvisionException {
@@ -91,7 +90,6 @@ public class Publisher {
 	 * @param removeFromManager remove the loaded repository from the manager if it
 	 *                          wasn't already loaded
 	 * @return the loaded repository
-	 * @throws ProvisionException
 	 */
 	public static IMetadataRepository loadMetadataRepository(IProvisioningAgent agent, URI location, boolean modifiable,
 			boolean removeFromManager) throws ProvisionException {
@@ -109,7 +107,6 @@ public class Publisher {
 	 * @param name     the name of the repository
 	 * @param compress whether or not to compress the repository index
 	 * @return the discovered or created repository
-	 * @throws ProvisionException
 	 */
 	@Deprecated(forRemoval = true, since = "2.3.0")
 	public static IArtifactRepository createArtifactRepository(IProvisioningAgent agent, URI location, String name,
@@ -149,7 +146,6 @@ public class Publisher {
 	 * @param removeFromManager remove the loaded repository from the manager if it
 	 *                          wasn't already loaded
 	 * @return the loaded repository
-	 * @throws ProvisionException
 	 */
 	public static IArtifactRepository loadArtifactRepository(IProvisioningAgent agent, URI location, boolean modifiable,
 			boolean removeFromManager) throws ProvisionException {

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/RootFilesAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/RootFilesAction.java
@@ -143,7 +143,6 @@ public class RootFilesAction extends AbstractPublisherAction {
 	/**
 	 * Compiles the <class>IRootFilesAdvice</class> from the <code>info</code> into one <class>IRootFilesAdvice</class> 
 	 * and returns the result.
-	 * @param configSpec
 	 * @return a compilation of <class>IRootfilesAdvice</class> from the <code>info</code>.
 	 */
 	private IRootFilesAdvice getAdvice(String configSpec) {

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/spi/p2/publisher/LocalizationHelper.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/spi/p2/publisher/LocalizationHelper.java
@@ -23,7 +23,6 @@ import org.eclipse.equinox.internal.p2.core.helpers.CollectionUtils;
 
 /**
  * Helper functions supporting the processing of localized property files.
- *
  */
 public final class LocalizationHelper {
 

--- a/bundles/org.eclipse.equinox.p2.reconciler.dropins/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.reconciler.dropins/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.reconciler.dropins;singleton:=true
-Bundle-Version: 1.5.200.qualifier
+Bundle-Version: 1.5.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.reconciler.dropins.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.reconciler.dropins/src/org/eclipse/equinox/internal/p2/reconciler/dropins/Activator.java
+++ b/bundles/org.eclipse.equinox.p2.reconciler.dropins/src/org/eclipse/equinox/internal/p2/reconciler/dropins/Activator.java
@@ -65,9 +65,6 @@ public class Activator implements BundleActivator {
 	 * If one already exists at that location then an exception will be thrown.
 	 *
 	 * This method never returns <code>null</code>.
-	 *
-	 * @throws IllegalStateException
-	 * @throws ProvisionException
 	 */
 	public static IMetadataRepository createExtensionLocationMetadataRepository(URI location, String name, Map<String, String> properties) throws ProvisionException {
 		IProvisioningAgent agent = getAgent();
@@ -94,9 +91,6 @@ public class Activator implements BundleActivator {
 
 	/**
 	 * Helper method to load an extension location metadata repository from the given URL.
-	 *
-	 * @throws IllegalStateException
-	 * @throws ProvisionException
 	 */
 	public static IMetadataRepository loadMetadataRepository(URI location, IProgressMonitor monitor) throws ProvisionException {
 		return (IMetadataRepository) loadRepository(IMetadataRepositoryManager.class, location, monitor);
@@ -107,9 +101,6 @@ public class Activator implements BundleActivator {
 	 * If one already exists at that location then an exception will be thrown.
 	 *
 	 * This method never returns <code>null</code>.
-	 *
-	 * @throws IllegalStateException
-	 * @throws ProvisionException
 	 */
 	public static IArtifactRepository createExtensionLocationArtifactRepository(URI location, String name, Map<String, String> properties) throws ProvisionException {
 		IProvisioningAgent agent = getAgent();
@@ -132,9 +123,6 @@ public class Activator implements BundleActivator {
 
 	/**
 	 * Helper method to load an extension location metadata repository from the given URL.
-	 *
-	 * @throws IllegalStateException
-	 * @throws ProvisionException
 	 */
 	public static IArtifactRepository loadArtifactRepository(URI location, IProgressMonitor monitor) throws ProvisionException {
 		return (IArtifactRepository) loadRepository(IArtifactRepositoryManager.class, location, monitor);

--- a/bundles/org.eclipse.equinox.p2.repository.tools/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.repository.tools;singleton:=true
-Bundle-Version: 2.4.200.qualifier
+Bundle-Version: 2.4.300.qualifier
 Bundle-Activator: org.eclipse.equinox.p2.internal.repository.tools.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/ArtifactChecksumComparator.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/ArtifactChecksumComparator.java
@@ -34,7 +34,6 @@ final public class ArtifactChecksumComparator implements IArtifactComparator {
 	final private String id;
 
 	/**
-	 * @param checksumId
 	 * @param checksumName human-readable name of the checksum algorithm
 	 */
 	public ArtifactChecksumComparator(String checksumId, String checksumName) {

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/Annotation.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/Annotation.java
@@ -25,11 +25,6 @@ public class Annotation extends ClassFileStruct {
 
 	/**
 	 * Constructor for Annotation.
-	 *
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public Annotation(byte[] classFileBytes, ConstantPool constantPool, int offset) throws ClassFormatException {
 

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/AnnotationDefaultAttribute.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/AnnotationDefaultAttribute.java
@@ -19,10 +19,6 @@ public class AnnotationDefaultAttribute extends ClassFileAttribute {
 
 	/**
 	 * Constructor for AnnotationDefaultAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public AnnotationDefaultAttribute(byte[] classFileBytes, ConstantPool constantPool, int offset) throws ClassFormatException {
 		super(classFileBytes, constantPool, offset);

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/InnerClassesAttribute.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/InnerClassesAttribute.java
@@ -21,10 +21,6 @@ public class InnerClassesAttribute extends ClassFileAttribute {
 
 	/**
 	 * Constructor for InnerClassesAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public InnerClassesAttribute(byte[] classFileBytes, ConstantPool constantPool, int offset) throws ClassFormatException {
 		super(classFileBytes, constantPool, offset);

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/ParameterAnnotation.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/ParameterAnnotation.java
@@ -23,11 +23,6 @@ public class ParameterAnnotation extends ClassFileStruct {
 
 	/**
 	 * Constructor for Annotation.
-	 *
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public ParameterAnnotation(byte[] classFileBytes, ConstantPool constantPool, int offset) throws ClassFormatException {
 

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/RuntimeInvisibleAnnotationsAttribute.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/RuntimeInvisibleAnnotationsAttribute.java
@@ -21,10 +21,6 @@ public class RuntimeInvisibleAnnotationsAttribute extends ClassFileAttribute {
 
 	/**
 	 * Constructor for RuntimeInvisibleAnnotations.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public RuntimeInvisibleAnnotationsAttribute(byte[] classFileBytes, ConstantPool constantPool, int offset) throws ClassFormatException {
 		super(classFileBytes, constantPool, offset);

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/RuntimeInvisibleParameterAnnotationsAttribute.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/RuntimeInvisibleParameterAnnotationsAttribute.java
@@ -21,10 +21,6 @@ public class RuntimeInvisibleParameterAnnotationsAttribute extends ClassFileAttr
 
 	/**
 	 * Constructor for RuntimeVisibleParameterAnnotations.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public RuntimeInvisibleParameterAnnotationsAttribute(byte[] classFileBytes, ConstantPool constantPool, int offset) throws ClassFormatException {
 		super(classFileBytes, constantPool, offset);

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/RuntimeVisibleAnnotationsAttribute.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/RuntimeVisibleAnnotationsAttribute.java
@@ -21,10 +21,6 @@ public class RuntimeVisibleAnnotationsAttribute extends ClassFileAttribute {
 
 	/**
 	 * Constructor for RuntimeVisibleAnnotations.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public RuntimeVisibleAnnotationsAttribute(byte[] classFileBytes, ConstantPool constantPool, int offset) throws ClassFormatException {
 		super(classFileBytes, constantPool, offset);

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/RuntimeVisibleParameterAnnotationsAttribute.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/RuntimeVisibleParameterAnnotationsAttribute.java
@@ -21,10 +21,6 @@ public class RuntimeVisibleParameterAnnotationsAttribute extends ClassFileAttrib
 
 	/**
 	 * Constructor for RuntimeVisibleParameterAnnotations.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public RuntimeVisibleParameterAnnotationsAttribute(byte[] classFileBytes, ConstantPool constantPool, int offset) throws ClassFormatException {
 		super(classFileBytes, constantPool, offset);

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/SourceFileAttribute.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/SourceFileAttribute.java
@@ -20,10 +20,6 @@ public class SourceFileAttribute extends ClassFileAttribute {
 
 	/**
 	 * Constructor for SourceFileAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public SourceFileAttribute(byte[] classFileBytes, ConstantPool constantPool, int offset) throws ClassFormatException {
 		super(classFileBytes, constantPool, offset);

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/mirroring/Mirroring.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/mirroring/Mirroring.java
@@ -213,7 +213,6 @@ public class Mirroring {
 	 * Callers should verify the ProvisionException was thrown due to the artifact
 	 * existing in the destination before invoking this method.
 	 *
-	 * @param descriptor
 	 * @return the status of the compare
 	 */
 	private IStatus compareToDestination(IArtifactDescriptor descriptor) {

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/RepositoryAnalyzer.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/RepositoryAnalyzer.java
@@ -25,7 +25,6 @@ import org.eclipse.equinox.p2.repository.tools.analyzer.IUAnalyzer;
 
 /**
  * @since 2.0
- *
  */
 public class RepositoryAnalyzer {
 

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/XZCompressor.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/XZCompressor.java
@@ -30,7 +30,6 @@ import org.tukaani.xz.*;
  * artifacts.xml or artifacts.jar. Note that the tool does not require both the
  * a metadata repository and an artifact repository. The output will be
  * <fileName>.xml.xz, and a p2.index
- *
  */
 public class XZCompressor {
 	private static final String CONTENT_XML_XZ = "content.xml.xz"; //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/repository/tools/analyzer/IIUAnalyzer.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/repository/tools/analyzer/IIUAnalyzer.java
@@ -28,7 +28,6 @@ import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
  * this interface.
  * 
  * @since 2.0
- * 
  */
 public interface IIUAnalyzer {
 

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/repository/tools/analyzer/IUAnalyzer.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/repository/tools/analyzer/IUAnalyzer.java
@@ -24,7 +24,6 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
  * An abstract base class for the Analyzer.  Clients are encouraged to extends this 
  * class when defining IU Analysis extension points.
  * @since 2.0
- * 
  */
 public abstract class IUAnalyzer implements IIUAnalyzer {
 

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src_ant/org/eclipse/equinox/p2/internal/repository/tools/tasks/SlicingOption.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src_ant/org/eclipse/equinox/p2/internal/repository/tools/tasks/SlicingOption.java
@@ -43,9 +43,6 @@ public class SlicingOption extends Task {
 		options.includeOptionalDependencies(optional);
 	}
 
-	/**
-	 * 
-	 */
 	public void setPlatformFilter(String platformFilter) {
 		if (platformFilter == null || platformFilter.trim().equals("")) //$NON-NLS-1$
 			return;

--- a/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.repository;singleton:=true
-Bundle-Version: 2.8.0.qualifier
+Bundle-Version: 2.8.100.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/CacheManager.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/CacheManager.java
@@ -290,7 +290,6 @@ public class CacheManager {
 
 	/**
 	 * Deletes the local cache file(s) for the given repository
-	 * @param repositoryLocation
 	 */
 	void deleteCache(URI repositoryLocation) {
 		for (String prefix : knownPrefixes) {

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/Credentials.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/Credentials.java
@@ -322,7 +322,6 @@ public class Credentials {
 
 	/**
 	 * Remember the fact that the host was canceled.
-	 * @param host
 	 */
 	private static void rememberCancel(String host) {
 		Map<String, HostEntry> r = getRemembered();
@@ -333,8 +332,6 @@ public class Credentials {
 	/**
 	 * Throws LoginCancledException if the host was previously canceled, and the information
 	 * is not stale.
-	 * @param host
-	 * @throws LoginCanceledException
 	 */
 	private static void checkRememberedCancel(String host) throws LoginCanceledException {
 		Map<String, HostEntry> r = getRemembered();
@@ -356,7 +353,6 @@ public class Credentials {
 	/**
 	 * Increments the prompt count for host. If information is stale, the count is restarted
 	 * at 1.
-	 * @param host
 	 */
 	private static void incrementPromptCount(String host) {
 		Map<String, HostEntry> r = getRemembered();
@@ -374,7 +370,6 @@ public class Credentials {
 
 	/**
 	 * Returns prompt count for host, except if information is stale in which case 0 is returned.
-	 * @param host
 	 * @return number of time prompt has been performed for a host (or 0 if information is stale)
 	 */
 	private static int getPromptCount(String host) {
@@ -470,7 +465,6 @@ public class Credentials {
 
 	/**
 	 * Get default "InternalError" ProvisionException.
-	 * @param t
 	 * @return a default "InternalError"
 	 */
 	public static ProvisionException internalError(Throwable t) {

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/FileInfo.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/FileInfo.java
@@ -11,7 +11,6 @@ import java.util.Properties;
 
 /**
  * Carries information about a file transfer.
- * 
  */
 public class FileInfo {
 	public static final String PROPERTY_CONTENT_TYPE = "contentType"; //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/RepositoryPreferences.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/RepositoryPreferences.java
@@ -11,7 +11,6 @@ package org.eclipse.equinox.internal.p2.repository;
 /**
  * Holds various preferences for repository.
  * TODO: if values should be configurable, they need to be persisted and read back.
- *
  */
 public class RepositoryPreferences {
 

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/RepositoryTracing.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/RepositoryTracing.java
@@ -10,7 +10,6 @@ package org.eclipse.equinox.internal.p2.repository;
 
 /**
  * TODO: Placeholder class - should have link to p2 tracing for repository debug
- *
  */
 public class RepositoryTracing {
 

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/Transport.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/Transport.java
@@ -149,8 +149,6 @@ public abstract class Transport {
 	 * indicates that the server response is wrong, but should not be interpreted as
 	 * a file not found.
 	 *
-	 * @param toDownload
-	 * @param monitor
 	 * @throws OperationCanceledException if the operation was canceled by the user.
 	 * @return last modified date (possibly 0)
 	 */

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/ChecksumProducer.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/ChecksumProducer.java
@@ -63,7 +63,6 @@ public class ChecksumProducer {
 	/**
 	 * @param file should not be <code>null</code>
 	 * @return MD5 checksum of the file or <code>null</code> in case of NoSuchAlgorithmException
-	 * @throws IOException
 	 */
 	@Deprecated
 	// bug #509401 - still here to not break x-friends like in bug #507193
@@ -80,9 +79,6 @@ public class ChecksumProducer {
 	 * @param algorithm {@link java.security.MessageDigest#getInstance(String)}
 	 * @param providerName {@link Provider#getName()}
 	 * @return checksum of the file
-	 * @throws IOException
-	 * @throws NoSuchAlgorithmException
-	 * @throws NoSuchProviderException
 	 * @see {@link java.security.MessageDigest#getInstance(String, Provider)}
 	 */
 	public static String produce(File file, String algorithm, String providerName) throws IOException, NoSuchAlgorithmException, NoSuchProviderException {

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/LocationProperties.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/LocationProperties.java
@@ -39,7 +39,6 @@ import org.eclipse.equinox.p2.metadata.Version;
  * 
  * Where repository.factory.order is a comma separated list of strings 
  * representing repository suffix filters.
- * 
  */
 public class LocationProperties {
 
@@ -152,8 +151,6 @@ public class LocationProperties {
 	 * Returns true if an MD5 has exists for the specified factoryID.  If the specified
 	 * factoryID was not specified in the LocatoinProperty file, this method
 	 * will return false.
-	 * 
-	 * @param factoryID
 	 */
 	public boolean hasMD5Hash(String factoryID) {
 		Boolean result = md5Hashes.get("md5." + factoryID); //$NON-NLS-1$
@@ -187,7 +184,6 @@ public class LocationProperties {
 
 	/**
 	 * @param key 
-	 * @param value
 	 */
 	private void initHashMD5Hash(String key, String value) {
 		// Empty for now

--- a/bundles/org.eclipse.equinox.p2.tests.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.tests.ui
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",

--- a/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/actions/ElementUtilsTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/actions/ElementUtilsTest.java
@@ -28,7 +28,6 @@ import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 
 /**
  * @since 3.5
- *
  */
 public class ElementUtilsTest extends ProfileModificationActionTest {
 

--- a/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/actions/UninstallActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/actions/UninstallActionTest.java
@@ -20,7 +20,6 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 
 /**
  * @since 3.5
- *
  */
 public class UninstallActionTest extends ProfileModificationActionTest {
 	class TestUninstallAction extends UninstallAction {

--- a/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/actions/UpdateActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/actions/UpdateActionTest.java
@@ -20,7 +20,6 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 
 /**
  * @since 3.5
- *
  */
 public class UpdateActionTest extends ProfileModificationActionTest {
 	class TestUpdateAction extends UpdateAction {

--- a/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/operations/SizingTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/operations/SizingTest.java
@@ -20,9 +20,6 @@ import org.eclipse.equinox.p2.engine.*;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.tests.ui.AbstractProvisioningUITest;
 
-/**
- * 
- */
 public class SizingTest extends AbstractProvisioningUITest {
 	public void testEmptySizing() {
 		String profileId = "testEmptySizing";

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/AbstractProvisioningTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/AbstractProvisioningTest.java
@@ -1128,8 +1128,6 @@ public abstract class AbstractProvisioningTest extends TestCase {
 
 	/**
 	 * Asserts that the first line of text in f equals the content.
-	 * @param f
-	 * @param content
 	 */
 	public static void assertFileContent(String message, File f, String content) {
 		try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(f)))) {

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/TestData.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/TestData.java
@@ -41,10 +41,7 @@ public class TestData {
 	/**
 	 * Get an input stream from the resource testDataName within the folder
 	 * testDataFolder of the testData folder of this project.
-	 * @param testDataFolder
-	 * @param testDataName
 	 * @return input stream for the test data
-	 * @throws IOException
 	 */
 	public static InputStream get(String testDataFolder, String testDataName) throws IOException {
 		return new BufferedInputStream(TestActivator.getContext().getBundle().getEntry(TEST_DATA_ROOT_FOLDER + "/" + testDataFolder + "/" + testDataName).openStream());
@@ -53,9 +50,7 @@ public class TestData {
 	/**
 	 * Get a File from the resource testDataName within the folder
 	 * testDataFolder of the testData folder of this project.
-	 * @param testDataFolder
 	 * @return test data File
-	 * @throws IOException
 	 */
 	public static File getFile(String testDataFolder, String testDataName) throws IOException {
 		return new File(FileLocator.toFileURL(TestActivator.getContext().getBundle().getEntry(TEST_DATA_ROOT_FOLDER + "/" + testDataFolder + "/" + testDataName)).getPath());
@@ -65,10 +60,7 @@ public class TestData {
 	 * Create a temporary file for the test data. The temporary file will be deleted
 	 * when the jvm exists. If testDataName contains an extension this extension will
 	 * be used as suffix for the temporary file.
-	 * @param testDataFolder
-	 * @param testDataName
 	 * @return temporary file with test data
-	 * @throws IOException
 	 */
 	public static File getTempFile(String testDataFolder, String testDataName) throws IOException {
 		File temp = createTempFile(testDataName);
@@ -81,9 +73,7 @@ public class TestData {
 	 * Create a temporary file. This file will be deleted if the jvm exits.
 	 * If testDataName contains an extension this extension will be used as
 	 * suffix for the temporary file.
-	 * @param testDataName
 	 * @return temporary file
-	 * @throws IOException
 	 */
 	public static File createTempFile(String testDataName) throws IOException {
 		int i = testDataName.lastIndexOf('.');
@@ -94,9 +84,6 @@ public class TestData {
 
 	/**
 	 * Assert equality of files.
-	 * @param expected
-	 * @param actual
-	 * @throws IOException
 	 */
 	public static void assertEquals(File expected, File actual) throws IOException {
 		Assert.assertEquals("Files have different lengths.", expected.length(), actual.length());
@@ -105,9 +92,6 @@ public class TestData {
 
 	/**
 	 * Assert equality of input streams.
-	 * @param expected
-	 * @param actual
-	 * @throws IOException
 	 */
 	public static void assertEquals(InputStream expected, InputStream actual) throws IOException {
 		try {
@@ -130,9 +114,6 @@ public class TestData {
 
 	/**
 	 * Assert equality of zip input streams.
-	 * @param expected
-	 * @param actual
-	 * @throws IOException
 	 */
 	public static void assertEquals(ZipInputStream expected, ZipInputStream actual) throws IOException {
 		Map<String, Object[]> expectedEntries = getEntries(expected);
@@ -168,8 +149,6 @@ public class TestData {
 	 *
 	 * @param fileMap a map of files to verify in <code>input2</code> keyed by relative paths
 	 * i.e. Map<String filePath, File fileBytes>
-	 * @param input2
-	 * @throws IOException
 	 */
 	public static void assertContains(Map<String, Object[]> fileMap, ZipInputStream input2, boolean compareContent) throws IOException {
 		Map<String, Object[]> jar2 = getEntries(input2);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/ArtifactLockingTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/ArtifactLockingTest.java
@@ -119,7 +119,6 @@ public class ArtifactLockingTest extends AbstractProvisioningTest {
 	 * Creates 1 thread that does a long running execute batch. We then try to add descriptors to another
 	 * instance of the same repository. This will block.  We then cancel the progress monitor to test
 	 * that the block terminates.
-	 * @throws InterruptedException
 	 */
 	public void testCancel() throws InterruptedException {
 		final IProgressMonitor progressMonitor = new NullProgressMonitor();
@@ -215,7 +214,6 @@ public class ArtifactLockingTest extends AbstractProvisioningTest {
 	/**
 	 * This tests that two 'executeBatch' operations are not executed in
 	 * parallel, but rather, the second one waits for the first to complete.
-	 * @throws InterruptedException
 	 */
 	public void testMultipleExecuteBatch() throws InterruptedException {
 		this.lockAcquired = false;
@@ -260,7 +258,6 @@ public class ArtifactLockingTest extends AbstractProvisioningTest {
 
 	/**
 	 * This tests that we wait for the lock to come off, we then add a descriptor
-	 * @throws InterruptedException
 	 */
 	public void testWait() throws InterruptedException {
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/BatchExecuteArtifactRepositoryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/BatchExecuteArtifactRepositoryTest.java
@@ -211,11 +211,6 @@ public class BatchExecuteArtifactRepositoryTest extends AbstractProvisioningTest
 	class FailingSimpleArtifactRepository extends SimpleArtifactRepository {
 		boolean executeBatch = false;
 
-		/**
-		 * @param repositoryName
-		 * @param location
-		 * @param properties
-		 */
 		public FailingSimpleArtifactRepository(String repositoryName, URI location, Map<String, String> properties) {
 			super(getAgent(), repositoryName, location, properties);
 		}
@@ -236,11 +231,6 @@ public class BatchExecuteArtifactRepositoryTest extends AbstractProvisioningTest
 	class FailingCompositeArtifactRepository extends CompositeArtifactRepository {
 		boolean executeBatch = false;
 
-		/**
-		 * @param repositoryName
-		 * @param location
-		 * @param properties
-		 */
 		public FailingCompositeArtifactRepository(IArtifactRepositoryManager manager, String repositoryName, URI location, Map<String, String> properties) {
 			super(manager, location, repositoryName, properties);
 		}
@@ -357,11 +347,6 @@ public class BatchExecuteArtifactRepositoryTest extends AbstractProvisioningTest
 		boolean executeBatch = false;
 		public boolean didSave = false;
 
-		/**
-		 * @param repositoryName
-		 * @param location
-		 * @param properties
-		 */
 		public TrackSavignSimpleArtifactRepository(String repositoryName, URI location, Map<String, String> properties) {
 			super(getAgent(), repositoryName, location, properties);
 		}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/Bug351944.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/Bug351944.java
@@ -96,9 +96,6 @@ public class Bug351944 extends AbstractProvisioningTest {
 
 	/**
 	 * copy from {@link org.eclipse.equinox.internal.p2.engine.DownloadManager}
-	 * @param repository
-	 * @param requestsToProcess
-	 * @return
 	 */
 	private Collection<IArtifactRequest> getRequestsForRepository(IArtifactRepository repository,
 			IArtifactRequest[] requestsToProcess) {

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/MirrorRequestTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/MirrorRequestTest.java
@@ -131,7 +131,6 @@ public class MirrorRequestTest extends AbstractProvisioningTest {
 	 * <li><code>mirror-two</code>, which has an invalid optimized artifact and causes processing step to fail</li>
 	 * <li>original repository, which has a valid canonical artifact</li>
 	 * </ul>
-	 *
 	 */
 	public void testFailToCanonicalWithMirrors() {
 		OrderedMirrorSelector selector = new OrderedMirrorSelector(sourceRepository);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/MirrorSelectorTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/MirrorSelectorTest.java
@@ -310,10 +310,6 @@ public class MirrorSelectorTest {
 
 	}
 
-	/**
-	 * @param originallist
-	 * @param mirrors
-	 */
 	private void assertList(List<MirrorInfo> originallist, MirrorInfo[] mirrors) {
 		assertEquals("length", originallist.size(), mirrors.length);
 		for (int i = 0; i < originallist.size(); i++) {

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/TransferExceptionsTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/TransferExceptionsTest.java
@@ -22,7 +22,6 @@ import org.osgi.framework.BundleException;
 
 /**
  * Test supposed to be used interactively to monitor the error message output.
- *
  */
 public class TransferExceptionsTest extends AbstractProvisioningTest {
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/core/AggregateQueryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/core/AggregateQueryTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 
 /**
  * This tests both Compound and Composite queries
- *
  */
 public class AggregateQueryTest {
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/core/ProvisioningAgentTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/core/ProvisioningAgentTest.java
@@ -31,8 +31,6 @@ import org.osgi.framework.ServiceReference;
 public class ProvisioningAgentTest extends AbstractProvisioningTest {
 	/**
 	 * See bug 307151 and bug 304899.
-	 * @throws ProvisionException
-	 * @throws URISyntaxException
 	 */
 	public void testMultipleAgents() throws ProvisionException, URISyntaxException {
 		URI repoLocation = new URI("https://download.eclipse.org/eclipse/updates/latest");

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/director/DirectorApplicationTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/director/DirectorApplicationTest.java
@@ -652,7 +652,6 @@ public class DirectorApplicationTest extends AbstractProvisioningTest {
 	/**
 	 * Test the ProvisioningContext only uses the passed in repos and not all known repos.
 	 * Expect to install helloworld_1.0.0 not helloworld_1.0.1
-	 * @throws Exception
 	 */
 	public void testPassedInRepos_ProvisioningContext() throws Exception {
 		File artifactRepo1 = getTestData("13.0", "/testData/mirror/mirrorSourceRepo4");
@@ -754,7 +753,6 @@ public class DirectorApplicationTest extends AbstractProvisioningTest {
 	/**
 	 * Test the ProvisioningContext only uses the passed in repos and not all known repos.
 	 * Expect to install helloworld_1.0.0 not helloworld_1.0.1
-	 * @throws Exception
 	 */
 	public void testUninstallIgnoresPassedInRepos() throws Exception {
 		File srcRepo = getTestData("14.0", "/testData/mirror/mirrorSourceRepo4");

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/directorywatcher/RepositoryListenerTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/directorywatcher/RepositoryListenerTest.java
@@ -157,7 +157,6 @@ public class RepositoryListenerTest extends AbstractDirectoryWatcherTest {
 	 * proper OSGi manifest files so the bundle can be installed
 	 * This test has been commented out because support for non-OSGi bundles was 
 	 * removed. See bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=411892.
-	 * 
 	 */
 	public void _testPluginXMLConversion() {
 		// test plugin.xml in a JAR'd bundle

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/AllServerTests.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/AllServerTests.java
@@ -139,7 +139,6 @@ public class AllServerTests extends TestCase {
 
 	/**
 	 * Used by tests in the suite to enable that they run individually
-	 * @throws Exception
 	 */
 	public static synchronized void checkSetUp() throws Exception {
 		if (setUpCounter == 0) {
@@ -151,7 +150,6 @@ public class AllServerTests extends TestCase {
 
 	/**
 	 * Used by tests in the suite to enable that they run individually
-	 * @throws Exception
 	 */
 	public static synchronized void checkTearDown() throws Exception {
 		setUpCounter--;

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/BatchExecuteMetadataRepositoryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/BatchExecuteMetadataRepositoryTest.java
@@ -211,11 +211,6 @@ public class BatchExecuteMetadataRepositoryTest extends AbstractProvisioningTest
 	class FailingSimpleMetadataRepository extends LocalMetadataRepository {
 		boolean executeBatch = false;
 
-		/**
-		 * @param repositoryName
-		 * @param location
-		 * @param properties
-		 */
 		public FailingSimpleMetadataRepository() {
 			super(getAgent());
 		}
@@ -273,11 +268,6 @@ public class BatchExecuteMetadataRepositoryTest extends AbstractProvisioningTest
 		boolean executeBatch = false;
 		public boolean didSave = false;
 
-		/**
-		 * @param repositoryName
-		 * @param location
-		 * @param properties
-		 */
 		public TrackSavignSimpleMetadataRepository() {
 			super(getAgent());
 		}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/LocalMetadataRepositoryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/LocalMetadataRepositoryTest.java
@@ -179,8 +179,6 @@ public class LocalMetadataRepositoryTest extends AbstractProvisioningTest {
 
 	/**
 	 * Tests loading a repository that has a reference to itself as a disabled repository.
-	 * @throws MalformedURLException
-	 * @throws ProvisionException
 	 */
 	public void testLoadSelfReference() throws ProvisionException {
 		//setup a repository that has a reference to itself in disabled state

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/MetadataRepositoryManagerExceptionsTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/MetadataRepositoryManagerExceptionsTest.java
@@ -60,8 +60,6 @@ public class MetadataRepositoryManagerExceptionsTest extends AbstractProvisionin
 	/**
 	 * Adds a repository for a non existing site, should
 	 * return REPOSITORY_NOT_FOUND, since any other status code gets logged.
-	 *
-	 * @throws URISyntaxException
 	 */
 	public void testFailedConnection() throws URISyntaxException {
 		//		URI location = new URI("invalid://example");

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/MetadataRepositoryManagerTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/MetadataRepositoryManagerTest.java
@@ -134,8 +134,6 @@ public class MetadataRepositoryManagerTest extends AbstractProvisioningTest {
 	/**
 	 * Adds a repository that has a non-standard (non ECF) scheme.  This should
 	 * return REPOSITORY_NOT_FOUND, since any other status code gets logged.
-	 *
-	 * @throws URISyntaxException
 	 */
 	public void testFailedConnection() throws URISyntaxException {
 		URI location = new URI("invalid://example");

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/SPIMetadataRepositoryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/SPIMetadataRepositoryTest.java
@@ -699,8 +699,6 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 	 * This test cases creates an SPI implementation of an IU and writes it to a repository.
 	 * If the repository is Cached, it reads back the SPI implementation. If the repository is
 	 * not cached, it reads back the default (InstallableUnit) implementation.
-	 *
-	 * @throws ProvisionException
 	 */
 	public void testSPIMetadataIU() throws ProvisionException {
 		IMetadataRepositoryManager manager = getMetadataRepositoryManager();
@@ -728,8 +726,6 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 	 * This test cases creates an SPI IU and adds a default provided capability. It ensures that
 	 * you can write this type of repository and read it back again.  If you read it back, and it is cached,
 	 * you get the SPI IU, otherwise you get the default (InstallableUnit) IU.
-	 *
-	 * @throws ProvisionException
 	 */
 	public void testProvidedCapabilitywithSPI_IU() throws ProvisionException {
 		IMetadataRepositoryManager manager = getMetadataRepositoryManager();
@@ -767,8 +763,6 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 	 * This test cases creates an IU and adds an SPI  required capability. It ensures that
 	 * you can write this type of repository and read it back again.  If you read it back, and it is cached,
 	 * you get the SPI Required Capability, otherwise you get the default RequiredCapability.
-	 *
-	 * @throws ProvisionException
 	 */
 	public void testSPIRequiredCapability() throws ProvisionException {
 		IMetadataRepositoryManager manager = getMetadataRepositoryManager();
@@ -808,7 +802,6 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 	/**
 	 * This tests the .equals method in many of the metadata classes.  This test
 	 * case ensures that an SPI implementation .equals() the default one.
-	 * @throws ProvisionException
 	 */
 	public void testSPIEquals() throws ProvisionException, URISyntaxException {
 		IMetadataRepositoryManager manager = getMetadataRepositoryManager();

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/TimeoutTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/TimeoutTest.java
@@ -57,8 +57,6 @@ public class TimeoutTest extends ServerBasedTestCase {
 	 * Test that timeout occurs, that the expected exception is thrown, and with correct detail
 	 * and message.
 	 * Note that test takes at least 120 seconds to complete due to length of timeout.
-	 * @throws ProvisionException
-	 * @throws Exception
 	 */
 	public void testTimeout() throws ProvisionException, Exception {
 		System.out.print("Note that test takes at least 120 seconds before timing out\n");
@@ -92,8 +90,6 @@ public class TimeoutTest extends ServerBasedTestCase {
 	 * Test that it is possible to cancel a repository load that hangs on a HEAD request.
 	 * Note that test takes at least 10 seconds (the cancel delay time). The real timeout is
 	 * 120 seconds.
-	 * @throws ProvisionException
-	 * @throws Exception
 	 */
 	public void testTimeoutCancelation() throws ProvisionException, Exception {
 		System.out.print("Note that test takes at least 10 seconds before timing out (and >120 if it fails)\n");

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/AllTests.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/AllTests.java
@@ -18,7 +18,6 @@ import org.junit.runners.Suite;
 
 /**
  * Tests the OmniVersion implementation of Version and VersionRange.
- *
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ CommonPatternsTest.class, FormatArrayTest.class, FormatATest.class, FormatDTest.class,

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/CommonPatternsTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/CommonPatternsTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
  * - Mozilla
  * - RPM
  * - JSR277 (proposed version handling as documented Dec 30, 2008).
- *
  */
 public class CommonPatternsTest extends VersionTesting {
 	public static String TRIPLET_FORMAT_STRING = "n=0;[.n=0;[.n=0;]][dS=m;]";

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatATest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatATest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 /**
  * Tests the format(a) rule.
- *
  */
 public class FormatATest {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatArrayTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatArrayTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 /**
  * Tests format(<>) - arrays.
- *
  */
 public class FormatArrayTest {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatNTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatNTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 /**
  * Tests format(n) and format(N)
- *
  */
 public class FormatNTest {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatProcessingTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatProcessingTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 /**
  * Tests processing rules not tested elsewhere, and combinations of processing
  * rules.
- *
  */
 public class FormatProcessingTest {
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatQTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatQTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
  * {}, [], <>) which are handled as pairs, thus 'q' matches "<andrea-doria>" and
  * produces a single string segment with the text 'andrea-doria'. A non-quoted
  * sequence of characters are not matched by 'q'.
- *
  */
 public class FormatQTest {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatRTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatRTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 /**
  * Tests format(r)
- *
  */
 public class FormatRTest {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatRangeTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatRangeTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 /**
  * Tests ranges using format(xxx) version strings.
- *
  */
 public class FormatRangeTest extends VersionTesting {
 	public static String OSGI_PREFIX = "format(n[.n=0;[.n=0;[.S=[A-Za-z0-9_-];]]]):";

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatSTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatSTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
  * a string group matching any character except any following explicit/optional
  * delimiter. Use processing rules =[]; or =[^] to define the set of allowed
  * characters.
- *
  */
 public class FormatSTest {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/FormatTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 /**
  * Test of format() performing tests not covered by tests per rule.
- *
  */
 public class FormatTest {
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/IntersectionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/IntersectionTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
  * - inside
  *
  * Tests made with both inclusive and non inclusive values.
- *
  */
 public class IntersectionTest {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/MultiplicityTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/MultiplicityTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 /**
  * Tests {n.m} in different combinations and the special +?*
- *
  */
 public class MultiplicityTest {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/OSGiRangeTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/OSGiRangeTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 
 /**
  * Tests ranges of versions specified with osgi (default) version format.
- *
  */
 public class OSGiRangeTest extends VersionTesting {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/OSGiVersionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/OSGiVersionTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 /**
  * Tests versions specified with default OSGi version strings and tests OSGi compatibility
  * for versions specified using raw.
- *
  */
 public class OSGiVersionTest extends VersionTesting {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/PerformanceTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/PerformanceTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
  *
  * Aprox 10000 instances are created.
  * Comparison compares all instances against all other (i.e. about 10 milj).
- *
  */
 public class PerformanceTest {
 	static final int MUL = 24;

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/RawRangeTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/RawRangeTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 
 /**
  * Tests version ranges specified using raw.
- *
  */
 public class RawRangeTest extends VersionTesting {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/RawRangeWithOriginalTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/RawRangeWithOriginalTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
  * Tests inclusion of original version range string in raw format.
  * The tests in this class does not fully test the various "format(rules)" only that the sequence
  * "raw RANGE/format():ORIGINAL RANGE" works, and that errors at the top level are caught.
- *
  */
 public class RawRangeWithOriginalTest extends VersionTesting {
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/RawVersionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/RawVersionTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 
 /**
  * Tests the OmniVersion raw version format.
- *
  */
 public class RawVersionTest extends VersionTesting {
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/RawWithOriginalTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/RawWithOriginalTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
  * Tests inclusion of original version string in the raw format.
  * The tests in this class does not fully test the various "format(rules)" only that the sequence "raw/format():original"
  * works, and that errors at the top level are caught.
- *
  */
 public class RawWithOriginalTest extends VersionTesting {
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/VersionTesting.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/VersionTesting.java
@@ -31,14 +31,10 @@ import org.eclipse.equinox.p2.metadata.VersionRange;
 
 /**
  * Base class for version testing. Adds useful assert methods.
- *
  */
 public class VersionTesting {
 	/**
 	 * Asserts that the versionString version is included in the range.
-	 * @param message
-	 * @param range
-	 * @param versionString
 	 */
 	public void assertIncludedInRange(String message, VersionRange range, String versionString) {
 		assertTrue(message, range.isIncluded(Version.parseVersion(versionString)));
@@ -46,9 +42,6 @@ public class VersionTesting {
 
 	/**
 	 * Asserts that the versionString version is not included in the range.
-	 * @param message
-	 * @param range
-	 * @param versionString
 	 */
 	public void assertNotIncludedInRange(String message, VersionRange range, String versionString) {
 		assertFalse(message, range.isIncluded(Version.parseVersion(versionString)));
@@ -57,8 +50,6 @@ public class VersionTesting {
 	/**
 	 * A strict assertion of order.
 	 * asserts that b > a, a < b, a !=b, b != a
-	 * @param a
-	 * @param b
 	 */
 	public static void assertOrder(Object a, Object b) {
 		if (!(a instanceof Comparable && b instanceof Comparable))
@@ -105,7 +96,6 @@ public class VersionTesting {
 
 	/**
 	 * Asserts serialization of a VersionRange instance.
-	 * @param v
 	 */
 	public static void assertSerialized(VersionRange range) {
 		VersionRange serialized = getSerialized(range);
@@ -142,7 +132,6 @@ public class VersionTesting {
 
 	/**
 	 * Asserts serialization of a Version instance.
-	 * @param v
 	 */
 	public static void assertSerialized(Version v) {
 		Version serialized = getSerialized(v);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/perf/ProvisioningPerformanceTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/perf/ProvisioningPerformanceTest.java
@@ -16,9 +16,6 @@ package org.eclipse.equinox.p2.tests.perf;
 import org.eclipse.equinox.p2.metadata.*;
 import org.eclipse.equinox.p2.tests.AbstractProvisioningTest;
 
-/**
- * 
- */
 public class ProvisioningPerformanceTest extends AbstractProvisioningTest {
 
 	protected IInstallableUnit generateIU(int i) {

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ActionTest.java
@@ -108,9 +108,6 @@ public abstract class ActionTest extends AbstractProvisioningTest {
 	 * because match expressions are not safe to compare for equality.
 	 *
 	 * This must be guaranteed by all sub-class test cases
-	 *
-	 * @param actual
-	 * @param expected
 	 */
 	protected void verifyRequirement(Collection<IRequirement> actual, IRequirement expected) {
 		for (IRequirement act : actual) {

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/CategoryPublisherTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/CategoryPublisherTest.java
@@ -21,9 +21,6 @@ import org.eclipse.equinox.internal.p2.updatesite.CategoryPublisherApplication;
 import org.eclipse.equinox.p2.publisher.AbstractPublisherApplication;
 import org.eclipse.equinox.p2.tests.*;
 
-/**
- *
- */
 public class CategoryPublisherTest extends AbstractProvisioningTest {
 
 	/**

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ContextRepositoryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ContextRepositoryTest.java
@@ -20,9 +20,6 @@ import org.eclipse.equinox.p2.publisher.*;
 import org.eclipse.equinox.p2.tests.AbstractProvisioningTest;
 import org.eclipse.equinox.p2.tests.TestActivator;
 
-/**
- *
- */
 public class ContextRepositoryTest extends AbstractProvisioningTest {
 
 	/**

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/LocalUpdateSiteActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/LocalUpdateSiteActionTest.java
@@ -59,7 +59,6 @@ public class LocalUpdateSiteActionTest extends ActionTest {
 	/**
 	 * This test uses a simple site.xml (with a zipped up feature) and ensures
 	 * that the metadata to unzip the feature is available.
-	 * @throws Exception
 	 */
 	public void testUnzipTouchpointAction() throws Exception {
 		File file = TestData.getFile("updatesite/site", "");

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/repository/NTLMTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/repository/NTLMTest.java
@@ -49,8 +49,6 @@ public class NTLMTest extends AbstractTestServerClientCase {
 	/**
 	 * Test that a repeated status of 477 switches to JRE Http Client once.
 	 * TODO - test is incomplete, there is no test that switch has taken place yet.
-	 * @throws ProvisionException
-	 * @throws Exception
 	 */
 	public void test477Status() throws ProvisionException, Exception {
 		setUpRepo(super.getBaseURL() + "/status/477");

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/repository/TimeoutTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/repository/TimeoutTest.java
@@ -42,8 +42,6 @@ public class TimeoutTest extends AbstractTestServerClientCase {
 	 * Test that timeout occurs, that the expected exception is thrown, and with correct detail
 	 * and message.
 	 * Note that test takes at least 120 seconds to complete due to length of timeout.
-	 * @throws ProvisionException
-	 * @throws Exception
 	 */
 	public void doTimeout(int type) throws Exception {
 		System.out.print("Note that test takes at least 120 seconds before timing out\n");
@@ -98,8 +96,6 @@ public class TimeoutTest extends AbstractTestServerClientCase {
 	 * Test that timeout occurs, that the expected exception is thrown, and with correct detail
 	 * and message.
 	 * Note that test takes at least 120 seconds to complete due to length of timeout.
-	 * @throws ProvisionException
-	 * @throws Exception
 	 */
 	public void testInfoTimeout() throws Exception {
 		doTimeout(MODIFIED);
@@ -109,8 +105,6 @@ public class TimeoutTest extends AbstractTestServerClientCase {
 	 * Test that it is possible to cancel a repository load that hangs on a HEAD request.
 	 * Note that test takes at least 10 seconds (the cancel delay time). The real timeout is
 	 * 120 seconds.
-	 * @throws ProvisionException
-	 * @throws Exception
 	 */
 	public void testInfoTimeoutCancelation() throws Exception {
 		doTimeoutCancelation(MODIFIED);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/testserver/helper/AbstractTestServerClientCase.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/testserver/helper/AbstractTestServerClientCase.java
@@ -148,7 +148,6 @@ public class AbstractTestServerClientCase extends TestCase {
 	/**
 	 * Service that tries to login with the wrong password.
 	 * @author henrik
-	 *
 	 */
 	public class BadLoginService extends UIServices {
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/testserver/helper/TestServerController.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/testserver/helper/TestServerController.java
@@ -108,7 +108,6 @@ public class TestServerController {
 
 	/**
 	 * Used by tests in the suite to enable that they run individually
-	 * @throws Exception
 	 */
 	public static synchronized void checkSetUp() throws Exception {
 		if (setUpCounter == 0) {
@@ -120,7 +119,6 @@ public class TestServerController {
 
 	/**
 	 * Used by tests in the suite to enable that they run individually
-	 * @throws Exception
 	 */
 	public static synchronized void checkTearDown() throws Exception {
 		setUpCounter--;

--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.touchpoint.eclipse;singleton:=true
-Bundle-Version: 2.4.100.qualifier
+Bundle-Version: 2.4.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.touchpoint.eclipse.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/touchpoint/eclipse/actions/SetJvmAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/touchpoint/eclipse/actions/SetJvmAction.java
@@ -29,7 +29,6 @@ import org.eclipse.osgi.util.NLS;
 /**
  * Touchpoint action which allows the user to set the -vm parameter in the
  * eclipse.ini file.
- *
  */
 public class SetJvmAction extends ProvisioningAction {
 	public static final String ID = "setJvm"; //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/update/ConfigurationCache.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/update/ConfigurationCache.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 /**
  * TODO ensure thread safety
- *
  */
 public class ConfigurationCache {
 	private static Map<String, CacheEntry> cache = new HashMap<>();

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.touchpoint.natives;singleton:=true
-Bundle-Version: 1.5.100.qualifier
+Bundle-Version: 1.5.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.touchpoint.natives.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/IBackupStore.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/IBackupStore.java
@@ -101,8 +101,6 @@ public interface IBackupStore {
 	/**
 	 * Backs up a file, or everything under a directory.
 	 * A copy of the backup is left in the original place.
-	 * @param file
-	 * @throws IOException
 	 */
 	public void backupCopyAll(File file) throws IOException;
 }

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/NativeTouchpoint.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/NativeTouchpoint.java
@@ -270,7 +270,6 @@ public class NativeTouchpoint extends Touchpoint {
 	 * Gets the transactional state associated with a profile. A transactional state
 	 * is created if it did not exist.
 	 * 
-	 * @param profile
 	 * @return a lazily initialized backup store
 	 */
 	private static synchronized IBackupStore getBackupStore(IProfile profile) {

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/SimpleBackupStore.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/SimpleBackupStore.java
@@ -381,10 +381,6 @@ public class SimpleBackupStore implements IBackupStore {
 	 * Backs up a file, or everything under a directory.
 	 * 
 	 * A copy of the backup is left in the original place.
-	 *
-	 * @param file
-	 * 
-	 * @throws IOException
 	 */
 	@Override
 	public void backupCopyAll(File file) throws IOException {
@@ -515,8 +511,6 @@ public class SimpleBackupStore implements IBackupStore {
 	 * 
 	 * @return false if the directory is already created in the backup store, false
 	 *         if a placeholder had to be created and backed up.
-	 * 
-	 * @throws IOException
 	 */
 	private boolean copyDirToBackup(Path path) throws IOException {
 		Path buPath = toBackupPath(path);
@@ -618,8 +612,6 @@ public class SimpleBackupStore implements IBackupStore {
 	 *
 	 * @param unrestorable accumulate unrestorable paths (including the entire
 	 *                     backup store).
-	 * 
-	 * @throws IOException
 	 */
 	private void restoreBackups(Map<Path, Throwable> unrestorable) throws IOException {
 		if (!Files.exists(buStoreRoot)) {
@@ -741,8 +733,6 @@ public class SimpleBackupStore implements IBackupStore {
 	 * @param file a source file that needs to be backed up
 	 * 
 	 * @return a file to which the original content can be backed up
-	 * 
-	 * @throws IOException
 	 */
 	protected Path toBackupPath(Path path) throws IOException {
 		Path pathNormal = path.normalize();
@@ -868,10 +858,6 @@ public class SimpleBackupStore implements IBackupStore {
 
 	/**
 	 * Deletes a file, or a directory with all of it's children.
-	 * 
-	 * @param path
-	 * 
-	 * @throws IOException
 	 */
 	private static void deleteAll(Path path) throws IOException {
 		if (!Files.exists(path)) {

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CopyAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CopyAction.java
@@ -31,7 +31,6 @@ import org.eclipse.osgi.util.NLS;
  * existing file with the same name is an error. The default is false. If the
  * source is a directory, a merge copy to the target is performed. Copy will
  * copy files and directories (recursively).
- * 
  */
 public class CopyAction extends ProvisioningAction {
 	public static final String ID = "cp"; //$NON-NLS-1$
@@ -107,11 +106,6 @@ public class CopyAction extends ProvisioningAction {
 
 	/**
 	 * Merge-copy file or directory.
-	 * 
-	 * @param source
-	 * @param target
-	 * @param overwrite
-	 * @throws IOException
 	 */
 	private static File[] mergeCopy(File source, File target, boolean overwrite, IBackupStore backupStore)
 			throws IOException {
@@ -124,10 +118,6 @@ public class CopyAction extends ProvisioningAction {
 	 * Merge-copy file or directory.
 	 * 
 	 * @param copiedFiles - ArrayList where copied files are collected
-	 * @param source
-	 * @param target
-	 * @param overwrite
-	 * @throws IOException
 	 */
 	private static void xcopy(ArrayList<File> copiedFiles, File source, File target, boolean overwrite,
 			IBackupStore backupStore) throws IOException {

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/UnzipAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/UnzipAction.java
@@ -45,7 +45,6 @@ public class UnzipAction extends ProvisioningAction {
 	 * Unzip as directed by parameters.
 	 * Record what was zipped in the profile.
 	 *
-	 * @param parameters
 	 * @param restoreable - if the unzip should be backed up
 	 * @return status
 	 */

--- a/bundles/org.eclipse.equinox.p2.transport.ecf/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.transport.ecf
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ecf;bundle-version="3.1.0",
  org.eclipse.ecf.filetransfer;bundle-version="4.0.0",

--- a/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/FileInfoReader.java
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/FileInfoReader.java
@@ -32,7 +32,6 @@ import org.eclipse.osgi.util.NLS;
  * The FileInfoReader is a {@link Job} similar to {@link FileReader}, but without the support
  * from ECF (there is currently no way to wait on a BrowseRequest job, as this is internal to
  * ECF). If such support is added, this class is easily modified.
- * 
  */
 public class FileInfoReader extends Job implements IRemoteFileSystemListener {
 	private Exception exception;
@@ -203,9 +202,6 @@ public class FileInfoReader extends Job implements IRemoteFileSystemListener {
 	 * @param uri the URI being read - used for logging purposes
 	 * @param attemptCounter - the current attempt number (start with 0)
 	 * @return true if the exception is an IOException and attemptCounter < connectionRetryCount, false otherwise
-	 * @throws CoreException
-	 * @throws FileNotFoundException
-	 * @throws AuthenticationFailedException
 	 * @throws JREHttpClientRequiredException 
 	 */
 	private boolean checkException(URI uri, int attemptCounter) throws CoreException, FileNotFoundException, AuthenticationFailedException, JREHttpClientRequiredException {

--- a/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/FileReader.java
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/FileReader.java
@@ -493,9 +493,6 @@ public final class FileReader extends FileTransferJob implements IFileTransferLi
 	 * @param attemptCounter - the current attempt number (start with 0)
 	 * @return true if the exception is an IOException and attemptCounter <
 	 *         connectionRetryCount, false otherwise
-	 * @throws CoreException
-	 * @throws FileNotFoundException
-	 * @throws AuthenticationFailedException
 	 */
 	private boolean checkException(URI uri, int attemptCounter)
 			throws CoreException, FileNotFoundException, AuthenticationFailedException, JREHttpClientRequiredException {
@@ -551,8 +548,6 @@ public final class FileReader extends FileTransferJob implements IFileTransferLi
 
 	/**
 	 * Closes input and output streams
-	 * 
-	 * @param aStream
 	 */
 	public static void hardClose(Object aStream) {
 		if (aStream != null) {

--- a/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryStatus.java
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryStatus.java
@@ -27,7 +27,6 @@ import org.eclipse.osgi.util.NLS;
 
 /**
  * Utility class to transform transport errors into error messages.
- *
  */
 public class RepositoryStatus {
 

--- a/bundles/org.eclipse.equinox.p2.ui.admin.rcp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.admin.rcp/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.admin.rcp; singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.admin.rcp.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ui,

--- a/bundles/org.eclipse.equinox.p2.ui.admin.rcp/src/org/eclipse/equinox/internal/p2/ui/admin/rcp/ProvisioningRCPPerspective.java
+++ b/bundles/org.eclipse.equinox.p2.ui.admin.rcp/src/org/eclipse/equinox/internal/p2/ui/admin/rcp/ProvisioningRCPPerspective.java
@@ -19,7 +19,6 @@ import org.eclipse.ui.*;
  * Perspective which makes the standard provisioning views available.
  * 
  * @since 3.4
- * 
  */
 public class ProvisioningRCPPerspective implements IPerspectiveFactory {
 

--- a/bundles/org.eclipse.equinox.p2.ui.admin/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.admin;singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.admin.ProvAdminUIActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/ArtifactRepositoriesView.java
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/ArtifactRepositoriesView.java
@@ -29,9 +29,6 @@ public class ArtifactRepositoriesView extends RepositoriesView {
 
 	private RepositoryTracker tracker;
 
-	/**
-	 * 
-	 */
 	public ArtifactRepositoriesView() {
 		// constructor
 	}

--- a/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/InstallIUDropAdapter.java
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/InstallIUDropAdapter.java
@@ -29,7 +29,6 @@ import org.eclipse.swt.dnd.*;
  * profile.
  * 
  * @since 3.4
- * 
  */
 public class InstallIUDropAdapter extends ViewerDropAdapter {
 

--- a/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/ProfileFactory.java
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/ProfileFactory.java
@@ -28,7 +28,6 @@ import org.eclipse.osgi.service.environment.EnvironmentInfo;
  * default values.
  * 
  * @since 3.4
- *
  */
 public class ProfileFactory {
 

--- a/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/ProvisioningPerspective.java
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/ProvisioningPerspective.java
@@ -19,7 +19,6 @@ import org.eclipse.ui.*;
  * Perspective which makes the standard provisioning views available.
  * 
  * @since 3.4
- * 
  */
 public class ProvisioningPerspective implements IPerspectiveFactory {
 

--- a/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/dialogs/AddArtifactRepositoryDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/dialogs/AddArtifactRepositoryDialog.java
@@ -23,7 +23,6 @@ import org.eclipse.swt.widgets.Shell;
  * Dialog that allows an artifact repository to be defined and added.
  * 
  * @since 3.4
- * 
  */
 public class AddArtifactRepositoryDialog extends AddRepositoryDialog {
 

--- a/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/dialogs/AddMetadataRepositoryDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/dialogs/AddMetadataRepositoryDialog.java
@@ -23,7 +23,6 @@ import org.eclipse.swt.widgets.Shell;
  * Dialog that allows a metadata repository to be defined and added.
  * 
  * @since 3.4
- * 
  */
 public class AddMetadataRepositoryDialog extends AddRepositoryDialog {
 

--- a/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/dialogs/AddProfileDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/dialogs/AddProfileDialog.java
@@ -27,7 +27,6 @@ import org.eclipse.swt.widgets.*;
  * Dialog that allows a profile to be defined and added.
  * 
  * @since 3.4
- * 
  */
 public class AddProfileDialog extends StatusDialog {
 

--- a/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/dialogs/ProfileGroup.java
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/dialogs/ProfileGroup.java
@@ -35,7 +35,6 @@ import org.eclipse.swt.widgets.*;
  * or define profiles.
  * 
  * @since 3.4
- * 
  */
 public class ProfileGroup {
 

--- a/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/preferences/ProvUIPreferenceInitializer.java
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/src/org/eclipse/equinox/internal/p2/ui/admin/preferences/ProvUIPreferenceInitializer.java
@@ -20,7 +20,6 @@ import org.eclipse.jface.preference.IPreferenceStore;
 /**
  * Initializes the preferences for the provisioning UI.
  * @since 3.4
- *
  */
 public class ProvUIPreferenceInitializer extends AbstractPreferenceInitializer {
 

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.discovery;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/DiscoveryImages.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/DiscoveryImages.java
@@ -80,7 +80,6 @@ public class DiscoveryImages {
 	/**
 	 * Lazily initializes image map.
 	 * 
-	 * @param imageDescriptor
 	 * @return Image
 	 */
 	public static Image getImage(ImageDescriptor imageDescriptor) {

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/ControlListItem.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/ControlListItem.java
@@ -82,10 +82,6 @@ public abstract class ControlListItem<T> extends Composite {
 
 	/**
 	 * Create a new instance of the receiver with the specified parent, style and info object/
-	 * 
-	 * @param parent
-	 * @param style
-	 * @param element
 	 */
 	public ControlListItem(Composite parent, int style, T element) {
 		super(parent, style | SWT.NO_FOCUS);
@@ -180,8 +176,6 @@ public abstract class ControlListItem<T> extends Composite {
 
 	/**
 	 * Set the color base on the index
-	 * 
-	 * @param index
 	 */
 	public void updateColors(int index) {
 		currentIndex = index;
@@ -230,8 +224,6 @@ public abstract class ControlListItem<T> extends Composite {
 
 	/**
 	 * Set the listener for index changes.
-	 * 
-	 * @param indexListener
 	 */
 	void setIndexListener(IndexListener indexListener) {
 		this.indexListener = indexListener;
@@ -248,9 +240,6 @@ public abstract class ControlListItem<T> extends Composite {
 
 	/**
 	 * Set whether or not the receiver is being displayed based on the top and bottom of the currently visible area.
-	 * 
-	 * @param top
-	 * @param bottom
 	 */
 	void setDisplayed(int top, int bottom) {
 		int itemTop = getLocation().y;
@@ -261,8 +250,6 @@ public abstract class ControlListItem<T> extends Composite {
 
 	/**
 	 * Set whether or not the receiver is being displayed
-	 * 
-	 * @param displayed
 	 */
 	private void setDisplayed(boolean displayed) {
 		// See if this element has been turned off

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/ControlListViewer.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/ControlListViewer.java
@@ -29,7 +29,6 @@ import org.eclipse.swt.widgets.*;
 
 /**
  * Based on {@link org.eclipse.ui.internal.progress.DetailedProgressViewer}.
- * 
  */
 @SuppressWarnings("restriction")
 public abstract class ControlListViewer extends StructuredViewer {
@@ -44,9 +43,6 @@ public abstract class ControlListViewer extends StructuredViewer {
 
 	/**
 	 * Create a new instance of the receiver with a control that is a child of parent with style style.
-	 * 
-	 * @param parent
-	 * @param style
 	 */
 	public ControlListViewer(Composite parent, int style) {
 		scrolled = new ScrolledComposite(parent, style | SWT.VERTICAL);
@@ -237,7 +233,6 @@ public abstract class ControlListViewer extends StructuredViewer {
 	/**
 	 * Create a new item for info.
 	 * 
-	 * @param element
 	 * @return ControlListItem
 	 */
 	private ControlListItem<?> createNewItem(Object element) {

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/PatternFilter.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/PatternFilter.java
@@ -91,8 +91,6 @@ public class PatternFilter extends ViewerFilter {
 	 * Returns true if any of the elements makes it through the filter. This method
 	 * uses caching if enabled; the computation is done in computeAnyVisible.
 	 * 
-	 * @param viewer
-	 * @param parent
 	 * @param elements the elements (must not be an empty array)
 	 * @return true if any of the elements makes it through the filter.
 	 */
@@ -150,8 +148,6 @@ public class PatternFilter extends ViewerFilter {
 	/**
 	 * The pattern string for which this filter should select elements in the
 	 * viewer.
-	 * 
-	 * @param patternString
 	 */
 	public void setPattern(String patternString) {
 		// these 2 strings allow the PatternFilter to be extended in
@@ -203,7 +199,6 @@ public class PatternFilter extends ViewerFilter {
 	 * may not be a valid selection since it is used merely to organize the
 	 * elements.
 	 * 
-	 * @param element
 	 * @return true if this element is eligible for automatic selection
 	 */
 	public boolean isElementSelectable(Object element) {
@@ -269,7 +264,6 @@ public class PatternFilter extends ViewerFilter {
 	 * Take the given filter text and break it down into words using a
 	 * BreakIterator.
 	 * 
-	 * @param text
 	 * @return an array of words
 	 */
 	private String[] getWords(String text) {

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.importexport;singleton:=true
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/P2ImportExport.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/P2ImportExport.java
@@ -23,9 +23,7 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 public interface P2ImportExport {
 	/**
 	 * 
-	 * @param input
 	 * @return iu listed in the file
-	 * @throws IOException
 	 * @throws VersionIncompatibleException if the given file version is not supported
 	 */
 	List<IUDetail> importP2F(InputStream input) throws IOException;

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/VersionIncompatibleException.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/VersionIncompatibleException.java
@@ -19,9 +19,6 @@ public class VersionIncompatibleException extends RuntimeException {
 		super(message);
 	}
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = -7584242899366859010L;
 
 }

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/AbstractPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/AbstractPage.java
@@ -77,7 +77,6 @@ public abstract class AbstractPage extends WizardPage implements Listener {
 	 * runClearPlaceholderJob and DelayedFilterCheckboxTree.doCreateRefreshJob().new
 	 * JobChangeAdapter() {...}.done(IJobChangeEvent) has timing issue, I can't find
 	 * a way to guarantee the first job is executed firstly
-	 *
 	 */
 	final class ImportExportFilteredTree extends FilteredTree {
 		ArrayList<Object> checkState = new ArrayList<>();

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ImportWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ImportWizard.java
@@ -88,8 +88,6 @@ public class ImportWizard extends InstallWizard implements IImportWizard {
 	 * Recompute the provisioning plan based on the items in the IUElementListRoot
 	 * and the given provisioning context. Report progress using the specified
 	 * runnable context. This method may be called before the page is created.
-	 *
-	 * @param runnableContext
 	 */
 	@Override
 	public void recomputePlan(IRunnableContext runnableContext, final boolean withRemediation) {

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/StyledErrorDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/StyledErrorDialog.java
@@ -59,9 +59,6 @@ public class StyledErrorDialog extends MessageDialog {
 		return dialog.open() == 0;
 	}
 
-	/**
-	 * @param kind
-	 */
 	static String[] getButtonLabels(int kind) {
 		String[] dialogButtonLabels;
 		switch (kind) {

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.sdk.scheduler;singleton:=true
-Bundle-Version: 1.6.100.qualifier
+Bundle-Version: 1.6.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.sdk.scheduler.AutomaticUpdatePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatesFailPopup.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatesFailPopup.java
@@ -23,7 +23,6 @@ import org.eclipse.ui.dialogs.PreferencesUtil;
 /**
  * UpdatesFailPopup is an async popup dialog for notifying the user of updates
  * that can't be installed.
- *
  */
 class AutomaticUpdatesFailPopup extends UpdatesPopup {
 

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatesPreferencePage.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatesPreferencePage.java
@@ -36,7 +36,6 @@ import org.eclipse.ui.*;
  * Preference page for automated updates.
  * 
  * @since 3.4
- * 
  */
 public class AutomaticUpdatesPreferencePage extends PreferencePage implements IWorkbenchPreferencePage {
 

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/migration/MigrationPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/migration/MigrationPage.java
@@ -90,7 +90,6 @@ public class MigrationPage extends WizardPage implements ISelectableIUsPage, Lis
 	 * runClearPlaceholderJob and DelayedFilterCheckboxTree.doCreateRefreshJob().new
 	 * JobChangeAdapter() {...}.done(IJobChangeEvent) has timing issue, I can't find
 	 * a way to guarantee the first job is executed firstly
-	 *
 	 */
 	final class ImportExportFilteredTree extends FilteredTree {
 		ArrayList<Object> checkState = new ArrayList<>();

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/migration/MigrationWizardDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/migration/MigrationWizardDialog.java
@@ -26,7 +26,6 @@ import org.eclipse.swt.widgets.Shell;
 /**
  * Subclass of WizardDialog that provides bounds saving behavior.
  * @since 3.5
- *
  */
 public class MigrationWizardDialog extends WizardDialog {
 	private ProvisioningOperationWizard wizard;

--- a/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui;singleton:=true
-Bundle-Version: 2.8.200.qualifier
+Bundle-Version: 2.8.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.ProvUIActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.ui/build.properties
+++ b/bundles/org.eclipse.equinox.p2.ui/build.properties
@@ -20,3 +20,4 @@ bin.includes = plugin.properties,\
                OSGI-INF/
 src.includes = about.html
 source.. = src/
+output.. = bin/

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ElementQueryDescriptor.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ElementQueryDescriptor.java
@@ -54,7 +54,6 @@ public class ElementQueryDescriptor {
 
 	/**
 	 * Performs the query returning a collection of results.
-	 * @param monitor
 	 */
 	public Collection<?> performQuery(IProgressMonitor monitor) {
 		Collector<Object> results = this.collector;

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ProvUIAdapterFactory.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ProvUIAdapterFactory.java
@@ -25,7 +25,6 @@ import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
  * Adapter factory for provisioning elements
  *
  * @since 3.4
- *
  */
 
 public class ProvUIAdapterFactory implements IAdapterFactory {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ProvUIProvisioningListener.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ProvUIProvisioningListener.java
@@ -179,7 +179,6 @@ public abstract class ProvUIProvisioningListener implements SynchronousProvision
 	 * A repository's enablement state has changed.  This is treated
 	 * as repository addition or removal by default.  Subclasses may
 	 * override.  May be called from a non-UI thread.
-	 * @param event
 	 */
 	protected void repositoryEnablement(RepositoryEvent event) {
 		// We treat enablement of a repository as if one were added.

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ProvisioningOperationRunner.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ProvisioningOperationRunner.java
@@ -68,8 +68,6 @@ public class ProvisioningOperationRunner {
 	/**
 	 * Request a restart of the platform according to the specified
 	 * restart policy.
-	 *
-	 * @param restartPolicy
 	 */
 	void requestRestart(final int restartPolicy) {
 		// Global override of restart (used in test cases).

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/UpdateManagerCompatibility.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/UpdateManagerCompatibility.java
@@ -38,7 +38,6 @@ import org.xml.sax.SAXException;
  * Utility methods involving compatibility with the Eclipse Update Manager.
  *
  * @since 3.4
- *
  */
 public class UpdateManagerCompatibility {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ValidationDialogServiceUI.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ValidationDialogServiceUI.java
@@ -52,7 +52,6 @@ import org.eclipse.ui.PlatformUI;
 /**
  * The default GUI-based implementation of {@link UIServices}. The service
  * declaration is made in the serviceui_component.xml file.
- *
  */
 public class ValidationDialogServiceUI extends UIServices implements IArtifactUIServices, IInstallableUnitUIServices {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/actions/ExistingIUInProfileAction.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/actions/ExistingIUInProfileAction.java
@@ -31,7 +31,6 @@ import org.eclipse.jface.viewers.ISelectionProvider;
  * IU's involved are top level IU's from the same profile.
  *
  * @since 3.5
- *
  */
 public abstract class ExistingIUInProfileAction extends ProfileModificationAction {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/actions/ProfileModificationAction.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/actions/ProfileModificationAction.java
@@ -118,7 +118,6 @@ public abstract class ProfileModificationAction extends ProvisioningAction {
 	/**
 	 * Validate the operation and return true if the operation should
 	 * be performed with plan.  Report any errors to the user before returning false.
-	 * @param operation
 	 * @return a boolean indicating whether the operation should be used in a
 	 * provisioning operation.
 	 */

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/actions/PropertyDialogAction.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/actions/PropertyDialogAction.java
@@ -21,7 +21,6 @@ import org.eclipse.jface.window.IShellProvider;
  * PropertyDialogAction which sets its enablement on construction.
  *
  * @since 3.4
- *
  */
 
 public class PropertyDialogAction extends org.eclipse.ui.dialogs.PropertyDialogAction {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/actions/RefreshAction.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/actions/RefreshAction.java
@@ -24,12 +24,9 @@ import org.eclipse.swt.widgets.Control;
 
 /**
  * @since 3.4
- *
  */
 public abstract class RefreshAction extends ProvisioningAction {
 
-	/**
-	 */
 	public RefreshAction(ProvisioningUI ui, ISelectionProvider selectionProvider, Control control) {
 		super(ui, ProvUIMessages.RefreshAction_Label, selectionProvider);
 		setToolTipText(ProvUIMessages.RefreshAction_Tooltip);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AddRepositoryDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AddRepositoryDialog.java
@@ -37,7 +37,6 @@ import org.eclipse.ui.PlatformUI;
  * will dictate what kind of repository and how it's created.
  *
  * @since 3.4
- *
  */
 public abstract class AddRepositoryDialog extends RepositoryNameAndLocationDialog {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUGroup.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUGroup.java
@@ -256,7 +256,6 @@ public class AvailableIUGroup extends StructuredIUGroup {
 	 * Set a boolean indicating whether a bold font should be used when
 	 * showing filtered items.  This method does not refresh the tree or
 	 * labels, so that must be done explicitly by the caller.
-	 * @param useBoldFont
 	 */
 	public void setUseBoldFontForFilteredItems(boolean useBoldFont) {
 		if (labelProvider != null)
@@ -446,7 +445,6 @@ public class AvailableIUGroup extends StructuredIUGroup {
 	 * Set the checked elements to the specified selections.  This method
 	 * does not force visibility/expansion of the checked elements.  If they are not
 	 * visible, they will not be checked.
-	 * @param selections
 	 */
 	public void setChecked(Object[] selections) {
 		filteredTree.getCheckboxTreeViewer().setCheckedElements(selections);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUPatternFilter.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUPatternFilter.java
@@ -24,7 +24,6 @@ import org.eclipse.ui.dialogs.PatternFilter;
  * A class that handles filtering IU's based on a supplied matching string.
  *
  * @since 3.4
- *
  */
 public class AvailableIUPatternFilter extends PatternFilter {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUsPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUsPage.java
@@ -681,8 +681,6 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 	 * Set the selections to be used in this page.  This method only changes the
 	 * selections of items that are already visible.  It does not expand items
 	 * or change the repository elements in order to make the selections valid.
-	 *
-	 * @param elements
 	 */
 	@Override
 	public void setCheckedElements(Object[] elements) {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ContainerCheckedTreeViewer.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ContainerCheckedTreeViewer.java
@@ -104,8 +104,6 @@ public class ContainerCheckedTreeViewer extends CheckboxTreeViewer {
 
 	/**
 	 * Update element after a checkstate change.
-	 *
-	 * @param element
 	 */
 	protected void doCheckStateChanged(Object element) {
 		Widget item = findItem(element);
@@ -231,9 +229,6 @@ public class ContainerCheckedTreeViewer extends CheckboxTreeViewer {
 
 	/**
 	 * Recursively add the filtered children of element to the result.
-	 *
-	 * @param element
-	 * @param result
 	 */
 	private void collectChildren(Object element, ArrayList<Object> result) {
 		Object[] filteredChildren = getFilteredChildren(element);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/DelayedFilterCheckboxTree.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/DelayedFilterCheckboxTree.java
@@ -30,7 +30,6 @@ import org.eclipse.ui.progress.WorkbenchJob;
  * elements that can survive a change of input.
  *
  * @since 3.4
- *
  */
 public class DelayedFilterCheckboxTree extends FilteredTree {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/IPreFilterJobProvider.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/IPreFilterJobProvider.java
@@ -19,7 +19,6 @@ import org.eclipse.core.runtime.jobs.Job;
  * IPreFilterJobProvider provides an optional job that must be run before
  * filtering can be allowed to occur in a filtered tree.  The client is assumed
  * to have set the expected job priority.
- *
  */
 public interface IPreFilterJobProvider {
 	public Job getPreFilterJob();

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/IResolutionErrorReportingPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/IResolutionErrorReportingPage.java
@@ -23,7 +23,6 @@ import org.eclipse.equinox.p2.operations.ProfileChangeOperation;
  * errors on a wizard page.
  *
  * @since 3.5
- *
  */
 public interface IResolutionErrorReportingPage extends ISelectableIUsPage {
 	public void updateStatus(IUElementListRoot root, ProfileChangeOperation operation);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ISelectableIUsPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ISelectableIUsPage.java
@@ -22,7 +22,6 @@ import org.eclipse.jface.wizard.IWizardPage;
  * wizard page.
  *
  * @since 3.5
- *
  */
 public interface ISelectableIUsPage extends IWizardPage {
 	public Object[] getCheckedIUElements();

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/IUDetailsGroup.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/IUDetailsGroup.java
@@ -49,9 +49,6 @@ public class IUDetailsGroup {
 	private boolean scrollable;
 	private String lastText;
 
-	/**
-	 *
-	 */
 	public IUDetailsGroup(Composite parent, ISelectionProvider selectionProvider, int widthHint, boolean scrollable) {
 		this.selectionProvider = selectionProvider;
 		this.widthHint = widthHint;

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/IViewMenuProvider.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/IViewMenuProvider.java
@@ -20,7 +20,6 @@ import org.eclipse.jface.action.IMenuManager;
  *
  * IViewMenuProvider is used to fill a view menu in dialog groups that support them.
  * @since 3.4
- *
  */
 public interface IViewMenuProvider {
 	public void fillViewMenu(IMenuManager viewMenu);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/InstallWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/InstallWizard.java
@@ -243,7 +243,6 @@ public class InstallWizard extends WizardWithLicenses {
 	 * the wizard's couldNotResolveStatus is reset on every new resolution, so that
 	 * status only holds the installHandler status when it is the current status.
 	 * The installHandlerStatus must be non-OK for it to matter at all.
-	 *
 	 */
 	@Override
 	public boolean statusOverridesOperation() {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ProvisioningOperationWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ProvisioningOperationWizard.java
@@ -322,8 +322,6 @@ public abstract class ProvisioningOperationWizard extends Wizard {
 	 * Recompute the provisioning plan based on the items in the IUElementListRoot
 	 * and the given provisioning context. Report progress using the specified
 	 * runnable context. This method may be called before the page is created.
-	 *
-	 * @param runnableContext
 	 */
 	public void recomputePlan(IRunnableContext runnableContext, final boolean withRemediation) {
 		couldNotResolveStatus = Status.OK_STATUS;

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ProvisioningWizardDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ProvisioningWizardDialog.java
@@ -24,7 +24,6 @@ import org.eclipse.swt.widgets.Shell;
 /**
  * Subclass of WizardDialog that provides bounds saving behavior.
  * @since 3.5
- *
  */
 public class ProvisioningWizardDialog extends WizardDialog {
 	private ProvisioningOperationWizard wizard;

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/RepositoryManipulatorDropTarget.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/RepositoryManipulatorDropTarget.java
@@ -34,7 +34,6 @@ import org.eclipse.ui.statushandlers.StatusManager;
  * user wishes to add these files as repositories.
  *
  * @since 3.4
- *
  */
 public class RepositoryManipulatorDropTarget extends URLDropAdapter {
 	ProvisioningUI ui;

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/RepositoryNameAndLocationDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/RepositoryNameAndLocationDialog.java
@@ -34,7 +34,6 @@ import org.eclipse.swt.widgets.*;
  * Class for showing a repository name and location
  *
  * @since 3.4
- *
  */
 public class RepositoryNameAndLocationDialog extends StatusDialog {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ResolutionResultsWizardPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ResolutionResultsWizardPage.java
@@ -43,7 +43,6 @@ import org.eclipse.ui.statushandlers.StatusManager;
  * operation.  It allows drill down into the elements that will be installed.
  *
  * @since 3.4
- *
  */
 public abstract class ResolutionResultsWizardPage extends ResolutionStatusPage {
 
@@ -272,7 +271,6 @@ public abstract class ResolutionResultsWizardPage extends ResolutionStatusPage {
 	 * @see ProvisioningJob#RESTART_NONE
 	 * @see ProvisioningJob#RESTART_ONLY
 	 * @see ProvisioningJob#RESTART_OR_APPLY
-	 *
 	 */
 	protected int getRestartPolicy() {
 		return ProvisioningJob.RESTART_OR_APPLY;

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ResolutionStatusPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ResolutionStatusPage.java
@@ -36,7 +36,6 @@ import org.eclipse.ui.statushandlers.StatusManager;
  * before advancing to resolution detail.
  *
  * @since 3.5
- *
  */
 public abstract class ResolutionStatusPage extends ProvisioningWizardPage {
 	private static final String LIST_WEIGHT = "ListSashWeight"; //$NON-NLS-1$
@@ -46,9 +45,6 @@ public abstract class ResolutionStatusPage extends ProvisioningWizardPage {
 	private static final String ID_COLUMN_WIDTH = "IDColumnWidth"; //$NON-NLS-1$
 	private IUColumnConfig nameColumn, versionColumn, idColumn;
 
-	/**
-	 * @param pageName
-	 */
 	protected ResolutionStatusPage(String pageName, ProvisioningUI ui, ProvisioningOperationWizard wizard) {
 		super(pageName, ui, wizard);
 	}

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/SelectableIUsPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/SelectableIUsPage.java
@@ -41,7 +41,6 @@ import org.eclipse.swt.widgets.*;
  * before advancing to resolution detail.
  *
  * @since 3.5
- *
  */
 public class SelectableIUsPage extends ResolutionStatusPage implements IResolutionErrorReportingPage {
 
@@ -260,7 +259,6 @@ public class SelectableIUsPage extends ResolutionStatusPage implements IResoluti
 	 * Overridden so that we don't call getNextPage(). We use getNextPage() to start
 	 * resolving the operation so we only want to do that when the next button is
 	 * pressed.
-	 *
 	 */
 	@Override
 	public boolean canFlipToNextPage() {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TextURLDropAdapter.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TextURLDropAdapter.java
@@ -20,7 +20,6 @@ import org.eclipse.swt.widgets.Text;
 
 /**
  * @since 3.4
- *
  */
 public class TextURLDropAdapter extends URLDropAdapter {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/URLDropAdapter.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/URLDropAdapter.java
@@ -28,7 +28,6 @@ import org.eclipse.swt.dnd.*;
  * the URLTransfer mechanism unless otherwise stated.
  *
  * @since 3.4
- *
  */
 public abstract class URLDropAdapter extends DropTargetAdapter {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/ArtifactRepositories.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/ArtifactRepositories.java
@@ -22,7 +22,6 @@ import org.eclipse.equinox.p2.ui.ProvisioningUI;
  * the content provider.
  *
  * @since 3.4
- *
  */
 public class ArtifactRepositories extends RootElement {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/ElementUtils.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/ElementUtils.java
@@ -32,7 +32,6 @@ import org.eclipse.equinox.p2.ui.ProvisioningUI;
  * Utility methods for manipulating model elements.
  *
  * @since 3.4
- *
  */
 public class ElementUtils {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/EmptyElementExplanation.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/EmptyElementExplanation.java
@@ -33,7 +33,6 @@ public class EmptyElementExplanation extends ProvElement {
 	 *
 	 * @param parent      the parent of this element
 	 * @param severity    the severity of the explanation {@link IStatus#INFO},
-	 * @param explanation
 	 */
 	public EmptyElementExplanation(Object parent, int severity, String explanation, String description) {
 		super(parent);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/MetadataRepositories.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/MetadataRepositories.java
@@ -25,7 +25,6 @@ import org.eclipse.equinox.p2.ui.ProvisioningUI;
  * the children.
  *
  * @since 3.4
- *
  */
 public class MetadataRepositories extends RootElement {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/MetadataRepositoryElement.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/MetadataRepositoryElement.java
@@ -204,7 +204,6 @@ public class MetadataRepositoryElement extends RootElement implements IRepositor
 	 * children to the viewer. see
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=229069 see
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=226343
-	 *
 	 */
 	@Override
 	public boolean hasQueryable() {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/Profiles.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/Profiles.java
@@ -22,7 +22,6 @@ import org.eclipse.equinox.p2.ui.ProvisioningUI;
  * the profiles that match the specified query for profiles.
  *
  * @since 3.4
- *
  */
 public class Profiles extends RootElement {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/ProvElement.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/ProvElement.java
@@ -29,7 +29,6 @@ import org.eclipse.ui.statushandlers.StatusManager;
  * Generic element that represents a provisioning element in a viewer.
  *
  * @since 3.4
- *
  */
 public abstract class ProvElement implements IWorkbenchAdapter, IAdaptable {
 
@@ -83,7 +82,6 @@ public abstract class ProvElement implements IWorkbenchAdapter, IAdaptable {
 	 *
 	 * @param object the object whose image id is requested
 	 * @return the string id of the image in the provisioning image registry
-	 *
 	 */
 	public Image getImage(Object object) {
 		String id = getImageId(object);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/QueriedElement.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/QueriedElement.java
@@ -28,7 +28,6 @@ import org.eclipse.equinox.p2.ui.ProvisioningUI;
  * query.
  *
  * @since 3.4
- *
  */
 public abstract class QueriedElement extends ProvElement {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/RootElement.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/RootElement.java
@@ -23,7 +23,6 @@ import org.eclipse.equinox.p2.ui.ProvisioningUI;
  * with its own ui and query context.
  *
  * @since 3.5
- *
  */
 public abstract class RootElement extends RemoteQueriedElement {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/Updates.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/Updates.java
@@ -21,7 +21,6 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
  * Element class that represents available updates.
  *
  * @since 3.4
- *
  */
 public class Updates extends QueriedElement {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/DeferredQueryContentProvider.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/DeferredQueryContentProvider.java
@@ -27,7 +27,6 @@ import org.eclipse.jface.viewers.Viewer;
  * query mechanisms.
  *
  * @since 3.4
- *
  */
 public class DeferredQueryContentProvider extends ProvElementContentProvider {
 
@@ -40,9 +39,6 @@ public class DeferredQueryContentProvider extends ProvElementContentProvider {
 	boolean synchronous = false;
 	IDeferredQueryTreeListener onFetchingActionListener;
 
-	/**
-	 *
-	 */
 	public DeferredQueryContentProvider() {
 		// Default constructor
 	}

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/DeferredQueryTreeContentManager.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/DeferredQueryTreeContentManager.java
@@ -28,7 +28,6 @@ import org.eclipse.ui.progress.*;
  * contents.
  *
  * @since 3.4
- *
  */
 public class DeferredQueryTreeContentManager extends DeferredTreeContentManager {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IDeferredQueryTreeListener.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IDeferredQueryTreeListener.java
@@ -22,7 +22,6 @@ import java.util.EventListener;
  * capabilities of the viewer.
  *
  * @since 3.4
- *
  */
 public interface IDeferredQueryTreeListener extends EventListener {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IInputChangeListener.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IInputChangeListener.java
@@ -22,7 +22,6 @@ import org.eclipse.jface.viewers.Viewer;
  * in a viewer.
  *
  * @since 3.4
- *
  */
 public interface IInputChangeListener extends EventListener {
 	public void inputChanged(Viewer v, Object oldInput, Object newInput);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUColumnConfig.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUColumnConfig.java
@@ -124,7 +124,6 @@ public class IUColumnConfig {
 	 * control.  If a specific width in pixels has already been specified by a client,
 	 * that width is used.  Otherwise, the value is computed based on the character
 	 * width specified for the column.
-	 * @param control
 	 * @return the width in pixels that should be used for the column
 	 *
 	 * @since 3.6

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUComparator.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUComparator.java
@@ -32,8 +32,6 @@ public class IUComparator extends ViewerComparator {
 	/**
 	 * Use the specified column config to determine whether the id should be used in
 	 * lieu of an empty name when sorting.
-	 *
-	 * @param columnConfigs
 	 */
 	public void useColumnConfig(IUColumnConfig[] columnConfigs) {
 		for (IUColumnConfig columnConfig : columnConfigs) {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/ProvElementContentProvider.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/ProvElementContentProvider.java
@@ -27,7 +27,6 @@ import org.eclipse.ui.progress.*;
  * Content provider that retrieves children of a ProvElement.
  *
  * @since 3.5
- *
  */
 public class ProvElementContentProvider implements ITreeContentProvider {
 
@@ -37,9 +36,6 @@ public class ProvElementContentProvider implements ITreeContentProvider {
 	// family is used by test cases
 	Object fetchFamily = new Object();
 
-	/**
-	 *
-	 */
 	public ProvElementContentProvider() {
 		// Default constructor
 	}

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/RepositoryContentProvider.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/RepositoryContentProvider.java
@@ -22,7 +22,6 @@ import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
  * using the IDeferredWorkbenchAdapter mechanism.
  *
  * @since 3.4
- *
  */
 public class RepositoryContentProvider extends DeferredQueryContentProvider {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/InstalledSoftwarePage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/InstalledSoftwarePage.java
@@ -51,7 +51,6 @@ import org.eclipse.ui.statushandlers.StatusManager;
  * @noextend This class is not intended to be subclassed by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  * @since 2.0
- *
  */
 public class InstalledSoftwarePage extends InstallationPage implements ICopyable {
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/LicenseManager.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/LicenseManager.java
@@ -32,7 +32,6 @@ public abstract class LicenseManager {
 	 *
 	 * @return <code>true</code> if the license was recorded as accepted, <code>false</code> if
 	 * it was not.
-	 *
 	 */
 	public abstract boolean accept(ILicense license);
 
@@ -43,7 +42,6 @@ public abstract class LicenseManager {
 	 *
 	 * @return <code>true</code> if the license was recorded as rejected, <code>false</code> if
 	 * it was not.
-	 *
 	 */
 	public abstract boolean reject(ILicense license);
 
@@ -55,7 +53,6 @@ public abstract class LicenseManager {
 	 *
 	 * @return <code>true</code> if the license has previously been accepted,
 	 * <code>false</code> if it has not been accepted before.
-	 *
 	 */
 	public abstract boolean isAccepted(ILicense license);
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/Policy.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/Policy.java
@@ -49,7 +49,6 @@ public class Policy {
 	/**
 	 * A constant indicating that restart should be forced (without confirmation)
 	 * immediately after completion of a provisioning operation.
-	 *
 	 */
 	public static final int RESTART_POLICY_FORCE = 1;
 

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RevertProfilePage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RevertProfilePage.java
@@ -55,7 +55,6 @@ import org.eclipse.ui.statushandlers.StatusManager;
  * @noextend This class is not intended to be subclassed by clients.
  * @noinstantiate This class is not intended to be instantiated by clients.
  * @since 2.0
- *
  */
 public class RevertProfilePage extends InstallationPage implements ICopyable {
 

--- a/bundles/org.eclipse.equinox.p2.updatesite/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.updatesite/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.updatesite;singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.updatesite.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/CategoryParser.java
+++ b/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/CategoryParser.java
@@ -84,7 +84,6 @@ public class CategoryParser extends DefaultHandler {
 	private MultiStatus status;
 
 	/*
-	 *
 	 */
 	private static void debug(String s) {
 		Tracing.debug("CategoryParser: " + s); //$NON-NLS-1$
@@ -569,14 +568,12 @@ public class CategoryParser extends DefaultHandler {
 	}
 
 	/*
-	 *
 	 */
 	private void internalError(String message) {
 		error(new Status(IStatus.ERROR, PLUGIN_ID, IStatus.OK, message, null));
 	}
 
 	/*
-	 *
 	 */
 	private void internalErrorUnknownTag(String msg) {
 		stateStack.push(Integer.valueOf(STATE_IGNORED_ELEMENT));
@@ -591,7 +588,6 @@ public class CategoryParser extends DefaultHandler {
 	}
 
 	/*
-	 *
 	 */
 	private void logStatus(SAXParseException ex) {
 		String name = ex.getSystemId();

--- a/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/DefaultSiteParser.java
+++ b/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/DefaultSiteParser.java
@@ -97,7 +97,6 @@ public class DefaultSiteParser extends DefaultHandler {
 	private final URI siteLocation;
 
 	/*
-	 * 
 	 */
 	private static void debug(String s) {
 		Tracing.debug("DefaultSiteParser: " + s); //$NON-NLS-1$
@@ -563,14 +562,12 @@ public class DefaultSiteParser extends DefaultHandler {
 	}
 
 	/*
-	 * 
 	 */
 	private void internalError(String message) {
 		error(new Status(IStatus.ERROR, PLUGIN_ID, IStatus.OK, message, null));
 	}
 
 	/*
-	 * 
 	 */
 	private void internalErrorUnknownTag(String msg) {
 		stateStack.push(Integer.valueOf(STATE_IGNORED_ELEMENT));
@@ -585,7 +582,6 @@ public class DefaultSiteParser extends DefaultHandler {
 	}
 
 	/*
-	 * 
 	 */
 	private void logStatus(SAXParseException ex) {
 		String name = ex.getSystemId();

--- a/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/SiteModel.java
+++ b/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/SiteModel.java
@@ -332,7 +332,6 @@ public class SiteModel {
 
 	/**
 	 * Returns the URI from which the list of mirrors of this site can be retrieved.
-	 * 
 	 */
 	public String getMirrorsURI() {
 		return mirrorsURIString;

--- a/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/UpdateSite.java
+++ b/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/UpdateSite.java
@@ -83,10 +83,7 @@ public class UpdateSite {
 	/**
 	 * Loads and returns a category file
 	 * 
-	 * @param location
-	 * @param monitor
 	 * @return A CategoryFile
-	 * @throws ProvisionException
 	 */
 	public static synchronized UpdateSite loadCategoryFile(URI location, Transport transport, IProgressMonitor monitor)
 			throws ProvisionException {

--- a/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.simpleconfigurator.manipulator;singleton:=true
-Bundle-Version: 2.3.0.qualifier
+Bundle-Version: 2.3.100.qualifier
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.equinox.frameworkadmin;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/src/org/eclipse/equinox/internal/simpleconfigurator/manipulator/SimpleConfiguratorManipulatorImpl.java
+++ b/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/src/org/eclipse/equinox/internal/simpleconfigurator/manipulator/SimpleConfiguratorManipulatorImpl.java
@@ -58,7 +58,6 @@ public class SimpleConfiguratorManipulatorImpl implements SimpleConfiguratorMani
 	 * Return the ConfiguratorConfigFile which is determined by the parameters set
 	 * in Manipulator.
 	 *
-	 * @param manipulator
 	 * @return File
 	 */
 	private static File getConfigFile(Manipulator manipulator) throws IllegalStateException {

--- a/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/src/org/eclipse/equinox/internal/simpleconfigurator/manipulator/SimpleConfiguratorManipulatorUtils.java
+++ b/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/src/org/eclipse/equinox/internal/simpleconfigurator/manipulator/SimpleConfiguratorManipulatorUtils.java
@@ -57,9 +57,6 @@ public class SimpleConfiguratorManipulatorUtils {
 
 	/**
 	 * The output stream is left open
-	 * @param simpleInfos
-	 * @param stream
-	 * @throws IOException
 	 */
 	public static void writeConfiguration(BundleInfo[] simpleInfos, OutputStream stream) throws IOException {
 		// sort by symbolic name

--- a/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/src/org/eclipse/equinox/simpleconfigurator/manipulator/SimpleConfiguratorManipulator.java
+++ b/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/src/org/eclipse/equinox/simpleconfigurator/manipulator/SimpleConfiguratorManipulator.java
@@ -59,7 +59,6 @@ public interface SimpleConfiguratorManipulator {
 	 * @param bundleInfoPath - pass null or a path to the bundle info file to read, relative to the configuration location.  Pass {@link #SOURCE_INFO}
 	 * to load the default source configuration.  Common locations are {@link #BUNDLES_INFO_PATH} and {@link #SOURCE_INFO_PATH}.
 	 * @return The loaded configuration.  Bundles will have at least symbolic name, version and location information.
-	 * @throws IOException
 	 */
 	public BundleInfo[] loadConfiguration(BundleContext context, String bundleInfoPath) throws IOException;
 
@@ -70,7 +69,6 @@ public interface SimpleConfiguratorManipulator {
 	 * @param configuration - the input stream to read the configuration from.  The stream will be closed even if an exception is thrown
 	 * @param installArea - Relative URIs from the configuration file will be resolved relative to here
 	 * @return The loaded configuration.   Bundles will have at least symbolic name, version and location information.
-	 * @throws IOException
 	 */
 	public BundleInfo[] loadConfiguration(InputStream configuration, URI installArea) throws IOException;
 
@@ -82,7 +80,6 @@ public interface SimpleConfiguratorManipulator {
 	 * @param configuration - bundle information to save
 	 * @param outputStream - the output stream to write to.  Stream is not closed
 	 * @param installArea - bundle locations are written as relative to this URI
-	 * @throws IOException
 	 */
 	public void saveConfiguration(BundleInfo[] configuration, OutputStream outputStream, URI installArea) throws IOException;
 
@@ -93,8 +90,6 @@ public interface SimpleConfiguratorManipulator {
 	 * @param configuration - bundle information to save
 	 * @param configurationFile - file to save the configuration in
 	 * @param installArea - bundle locations are written as relative to this URI
-	 *
-	 * @throws IOException
 	 */
 	public void saveConfiguration(BundleInfo[] configuration, File configurationFile, URI installArea) throws IOException;
 }

--- a/bundles/org.eclipse.equinox.simpleconfigurator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.equinox.simpleconfigurator;singleton:=true
-Bundle-Version: 1.5.0.qualifier
+Bundle-Version: 1.5.100.qualifier
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/provisional/configurator/Configurator.java
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/provisional/configurator/Configurator.java
@@ -40,7 +40,6 @@ import java.net.URL;
  * At its stopping, the service registered will be unregistered.
  *
  * see org.eclipse.equinox.internal.provisional.configuratormanipulato.ConfiguratorManipulator
- *
  */
 public interface Configurator {
 

--- a/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/Activator.java
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/Activator.java
@@ -41,7 +41,6 @@ import org.osgi.framework.*;
  * the bundles will not be listed in the specified url but installed at the time
  * of the method call except SystemBundle will be uninstalled.
  * Otherwise, no uninstallation will not be done.
- *
  */
 public class Activator implements BundleActivator {
 	public final static boolean DEBUG = false;

--- a/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/console/ConfiguratorCommandProvider.java
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/console/ConfiguratorCommandProvider.java
@@ -44,7 +44,6 @@ public class ConfiguratorCommandProvider implements CommandProvider {
 
 	/**
 	 * Apply the current configuration
-	 * @param interpreter
 	 */
 	public void _confapply(CommandInterpreter interpreter) {
 		String parameter = interpreter.nextArgument();
@@ -58,7 +57,6 @@ public class ConfiguratorCommandProvider implements CommandProvider {
 	/**
 	 * Handles the help command
 	 *
-	 * @param intp
 	 * @return description for a particular command or false if there is no command with the specified name
 	 */
 	public Object _help(CommandInterpreter intp) {

--- a/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/utils/SimpleConfiguratorUtils.java
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/utils/SimpleConfiguratorUtils.java
@@ -204,9 +204,7 @@ public class SimpleConfiguratorUtils {
 	 * Read the configuration from the given InputStream
 	 *
 	 * @param stream - the stream is always closed
-	 * @param base
 	 * @return List of {@link BundleInfo}
-	 * @throws IOException
 	 */
 	public static List<BundleInfo> readConfiguration(InputStream stream, URI base) throws IOException {
 		List<BundleInfo> bundles = new ArrayList<>();

--- a/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/utils/URIUtil.java
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/utils/URIUtil.java
@@ -180,8 +180,6 @@ public class URIUtil {
 
 	/**
 	 * Returns a URI as a URL.
-	 *
-	 * @throws MalformedURLException
 	 */
 	public static URL toURL(URI uri) throws MalformedURLException {
 		return new URL(uri.toString());

--- a/features/org.eclipse.equinox.p2.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.core.feature"
       label="%featureName"
-      version="1.7.0.qualifier"
+      version="1.7.100.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.discovery.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.discovery.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.discovery.feature"
       label="%featureName"
-      version="1.3.200.qualifier"
+      version="1.3.300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.extras.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.extras.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.extras.feature"
       label="%featureName"
-      version="1.4.2200.qualifier"
+      version="1.4.2300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.rcp.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.rcp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.rcp.feature"
       label="%featureName"
-      version="1.4.2200.qualifier"
+      version="1.4.2300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.sdk/feature.xml
+++ b/features/org.eclipse.equinox.p2.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.sdk"
       label="%featureName"
-      version="3.11.2200.qualifier"
+      version="3.11.2300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.user.ui/feature.xml
+++ b/features/org.eclipse.equinox.p2.user.ui/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.user.ui"
       label="%featureName"
-      version="2.4.2200.qualifier"
+      version="2.4.2300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.server.p2/feature.xml
+++ b/features/org.eclipse.equinox.server.p2/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.p2"
       label="%featureName"
-      version="1.12.1100.qualifier"
+      version="1.12.1200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
This commit cleans up Javadoc that does not add information. It resolves ecj warnings:
 `Javadoc: Description expected after ...`
It helps to prevent future empty javadoc by disabling missingJavaDoc warnings. This resolves
 `Javadoc: Missing ...`

The modification is a result of regular expression search&replace:

in files `*.java`
 `^[\s]*\*[\s]*(@return|@param[\s]*[^\s]+|@throws[\s]*[^\s]+)\R([\s]*\*[\s]*@|[\s]*\*/\R)`
 ->`$2`
 `^([\s]*\*[\s]*\R)([\s]*\*/\R)`
 ->`$2`
 `^[\S\t ]*/\*\*\R[\s]*\*/\R`
 ->``

in files `org.eclipse.jdt.core.prefs`
 `org\.eclipse\.jdt\.core\.compiler\.problem\.missingJavadoc(Comments|Tags)\=[^\s]*`
 ->`org\.eclipse\.jdt\.core\.compiler\.problem\.missingJavadoc$1\=ignore`