### PR TITLE
Require ecf http5 in core feature

### DIFF
--- a/features/org.eclipse.equinox.p2.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.core.feature/feature.xml
@@ -24,6 +24,7 @@
       <import feature="org.eclipse.ecf.core.ssl.feature" version="1.1.0" match="compatible"/>
       <import feature="org.eclipse.ecf.filetransfer.feature" version="3.13.7" match="compatible"/>
       <import feature="org.eclipse.ecf.filetransfer.httpclientjava.feature" version="2.0.0" match="compatible"/>
+      <import feature="org.eclipse.ecf.filetransfer.httpclient5.feature" version="1.0.0" match="compatible"/>
       <import feature="org.eclipse.ecf.filetransfer.ssl.feature" version="1.1.0" match="compatible"/>
    </requires>
 


### PR DESCRIPTION
FYI @akurtakov @merks @tjwatson requires PL/PMC approval

See
- https://github.com/eclipse-equinox/p2/issues/381
- https://github.com/eclipse-platform/www.eclipse.org-eclipse/pull/86