### PR TITLE
Version bump for pde.tests for 4.31

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.tests;singleton:=true
-Bundle-Version: 1.9.200.qualifier
+Bundle-Version: 1.9.300.qualifier
 Bundle-Activator: org.eclipse.equinox.p2.tests.TestActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.equinox.p2.tests</artifactId>
-	<version>1.9.200-SNAPSHOT</version>
+	<version>1.9.300-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>


### PR DESCRIPTION
The bundle is excluded from comparison as it contains broken zips that break it (as per comment in the pom) thus it was not autodetected. Removed the org.eclipse.osgi.compatibility.state extra dep for surefire as it shouldn't be needed anymore.