### PR TITLE
Allow to pass an agent at the constructor for publisher applications

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/FeaturesAndBundlesPublisherApplication.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/FeaturesAndBundlesPublisherApplication.java
@@ -17,6 +17,7 @@ package org.eclipse.equinox.p2.publisher.eclipse;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.equinox.p2.publisher.*;
 import org.eclipse.equinox.p2.publisher.actions.RootIUAction;
@@ -41,7 +42,11 @@ public class FeaturesAndBundlesPublisherApplication extends AbstractPublisherApp
 	protected String rootVersion = null;
 
 	public FeaturesAndBundlesPublisherApplication() {
-		// nothing to do
+		super();
+	}
+
+	public FeaturesAndBundlesPublisherApplication(IProvisioningAgent agent) {
+		super(agent);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/InstallPublisherApplication.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/InstallPublisherApplication.java
@@ -17,6 +17,7 @@ package org.eclipse.equinox.p2.publisher.eclipse;
 
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.metadata.*;
 import org.eclipse.equinox.p2.publisher.*;
@@ -33,7 +34,11 @@ public class InstallPublisherApplication extends AbstractPublisherApplication {
 	protected String[] rootExclusions;
 
 	public InstallPublisherApplication() {
-		//hidden
+		super();
+	}
+
+	public InstallPublisherApplication(IProvisioningAgent agent) {
+		super(agent);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ProductPublisherApplication.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ProductPublisherApplication.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import org.eclipse.equinox.internal.p2.publisher.Messages;
 import org.eclipse.equinox.internal.p2.publisher.eclipse.IProductDescriptor;
 import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductFile;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.publisher.*;
 import org.eclipse.equinox.p2.publisher.actions.VersionAdvice;
@@ -35,7 +36,11 @@ public class ProductPublisherApplication extends AbstractPublisherApplication {
 	private String jreLocation;
 
 	public ProductPublisherApplication() {
-		//hidden
+		super();
+	}
+
+	public ProductPublisherApplication(IProvisioningAgent agent) {
+		super(agent);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/CategoryPublisherApplication.java
+++ b/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/CategoryPublisherApplication.java
@@ -17,6 +17,7 @@ package org.eclipse.equinox.internal.p2.updatesite;
 import java.net.URI;
 import java.net.URISyntaxException;
 import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.publisher.*;
 import org.eclipse.equinox.p2.repository.IRepository;
@@ -24,8 +25,9 @@ import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
 
 /**
  * <p>
- * This application categorizes the elements in a repo based on a category definition file.  The category definition
- * file is specified with <source>-categoryDefinition</source>
+ * This application categorizes the elements in a repo based on a category
+ * definition file. The category definition file is specified with
+ * <source>-categoryDefinition</source>
  * </p>
  */
 public class CategoryPublisherApplication extends AbstractPublisherApplication {
@@ -34,7 +36,11 @@ public class CategoryPublisherApplication extends AbstractPublisherApplication {
 	private URI categoryDefinition = null;
 
 	public CategoryPublisherApplication() {
-		// nothing todo
+		super();
+	}
+
+	public CategoryPublisherApplication(IProvisioningAgent agent) {
+		super(agent);
 	}
 
 	/*
@@ -44,9 +50,12 @@ public class CategoryPublisherApplication extends AbstractPublisherApplication {
 	protected void initializeRepositories(PublisherInfo publisherInfo) throws ProvisionException {
 		try {
 			if (metadataLocation != null) {
-				// Try to load the metadata repository. If it loads, check the "compressed" flag, and cache it.
-				// If there are any errors loading it (i.e. it doesn't exist), just skip this step
-				// If there are serious problems with the repository, the superclass initializeRepositories method
+				// Try to load the metadata repository. If it loads, check the "compressed"
+				// flag, and cache it.
+				// If there are any errors loading it (i.e. it doesn't exist), just skip this
+				// step
+				// If there are serious problems with the repository, the superclass
+				// initializeRepositories method
 				// will handle it.
 				IMetadataRepository result = Publisher.loadMetadataRepository(agent, metadataLocation, true, true);
 				if (result != null) {
@@ -58,7 +67,7 @@ public class CategoryPublisherApplication extends AbstractPublisherApplication {
 				}
 			}
 		} catch (ProvisionException e) {
-			//do nothing
+			// do nothing
 		}
 		super.initializeRepositories(publisherInfo);
 	}
@@ -79,6 +88,6 @@ public class CategoryPublisherApplication extends AbstractPublisherApplication {
 
 	@Override
 	protected IPublisherAction[] createActions() {
-		return new IPublisherAction[] {new CategoryXMLAction(categoryDefinition, categoryQualifier)};
+		return new IPublisherAction[] { new CategoryXMLAction(categoryDefinition, categoryQualifier) };
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/UpdateSitePublisherApplication.java
+++ b/bundles/org.eclipse.equinox.p2.updatesite/src/org/eclipse/equinox/internal/p2/updatesite/UpdateSitePublisherApplication.java
@@ -15,13 +15,15 @@
 package org.eclipse.equinox.internal.p2.updatesite;
 
 import java.net.URISyntaxException;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.publisher.*;
 import org.eclipse.equinox.p2.publisher.actions.JREAction;
 
 /**
  * <p>
- * This application generates meta-data/artifact repositories from a local update site.
- * The -source <localdir> parameter must specify the top-level directory containing the update site.
+ * This application generates meta-data/artifact repositories from a local
+ * update site. The -source <localdir> parameter must specify the top-level
+ * directory containing the update site.
  * </p>
  */
 public class UpdateSitePublisherApplication extends AbstractPublisherApplication {
@@ -30,7 +32,11 @@ public class UpdateSitePublisherApplication extends AbstractPublisherApplication
 	private String categoryVersion = null;
 
 	public UpdateSitePublisherApplication() {
-		// nothing todo
+		super();
+	}
+
+	public UpdateSitePublisherApplication(IProvisioningAgent agent) {
+		super(agent);
 	}
 
 	@Override
@@ -49,9 +55,9 @@ public class UpdateSitePublisherApplication extends AbstractPublisherApplication
 		LocalUpdateSiteAction action = new LocalUpdateSiteAction(source, categoryQualifier);
 		action.setCategoryVersion(categoryVersion);
 		if (addJRE) {
-			return new IPublisherAction[] {action, new JREAction((String) null)};
+			return new IPublisherAction[] { action, new JREAction((String) null) };
 		}
-		return new IPublisherAction[] {action};
+		return new IPublisherAction[] { action };
 	}
 
 	/** by default don't generate the JRE IU */


### PR DESCRIPTION
Currently the agent is always determined implicitly by query the service registry, even though one can extend the application and the overwrite `setupAgent` it seems much more suitable to offer a way to set the agent at construction time.

@merks this should be transparent for existing code but just in case you maybe can have a deeper look at this.

I noticed that the lack of constructor is one reason Tycho currently uses some workaround or extends applications and so other might do as well, adding a suitable constructor seems not really harm or defeat any purpose, the default i just for the use cases where the application is used at the extension points that can't pass constructor argument easily.