### PR TITLE
Add a way to pass the artifact to be downloaded to the transport

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
@@ -656,7 +656,7 @@ public class SimpleArtifactRepository extends AbstractArtifactRepository impleme
 		if (baseLocation == null)
 			return new Status(IStatus.ERROR, Activator.ID, NLS.bind(Messages.no_location, descriptor));
 		URI mirrorLocation = getMirror(baseLocation, subMon.split(1));
-		IStatus status = downloadArtifact(mirrorLocation, destination, subMon.split(1));
+		IStatus status = downloadArtifact(descriptor, mirrorLocation, destination, subMon.split(1));
 		IStatus result = reportStatus(descriptor, destination, status);
 		// if the original download went reasonably but the reportStatus found some issues
 		// (e..g, in the processing steps/validators) then mark the mirror as bad and return
@@ -727,14 +727,15 @@ public class SimpleArtifactRepository extends AbstractArtifactRepository impleme
 		return status;
 	}
 
-	private IStatus downloadArtifact(URI mirrorLocation, OutputStream destination, IProgressMonitor monitor) {
+	private IStatus downloadArtifact(IArtifactDescriptor descriptor, URI mirrorLocation, OutputStream destination,
+			IProgressMonitor monitor) {
 		monitor = IProgressMonitor.nullSafe(monitor);
 		//Bug 340352: transport has performance overhead of 100ms and more, bypass it for local copies
 		IStatus result = Status.OK_STATUS;
 		if (SimpleArtifactRepositoryFactory.PROTOCOL_FILE.equals(mirrorLocation.getScheme()))
 			result = copyFileToStream(new File(mirrorLocation), destination, monitor);
 		else
-			result = getTransport().download(mirrorLocation, destination, monitor);
+			result = getTransport().downloadArtifact(mirrorLocation, destination, descriptor, monitor);
 		if (mirrors != null)
 			mirrors.reportResult(mirrorLocation.toString(), result);
 		if (result.isOK() || result.getSeverity() == IStatus.CANCEL)

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/Transport.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/Transport.java
@@ -28,6 +28,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
 import org.eclipse.equinox.internal.provisional.p2.repository.IStateful;
 import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
 import org.eclipse.osgi.util.NLS;
 import org.osgi.service.prefs.BackingStoreException;
 
@@ -125,6 +126,30 @@ public abstract class Transport {
 	 * @throws OperationCanceledException if the operation was canceled.
 	 */
 	public abstract IStatus download(URI toDownload, OutputStream target, IProgressMonitor monitor);
+
+	/**
+	 * Perform a download, writing into the target output stream. Progress is
+	 * reported on the monitor. If the <code>target</code> is an instance of
+	 * {@link IStateful} the resulting status is also set on the target. This method
+	 * differs to {@link #download(URI, OutputStream, long, IProgressMonitor)} in
+	 * that it allows to optionally pass in additional context of the download
+	 * request. The default implementation simply delegates to the former method and
+	 * do not make any special handling but subclasses may overwrite.
+	 *
+	 * @return IStatus, that is a {@link DownloadStatus} on success.
+	 * @param source URI of file to download, this might be a mirror of the
+	 *                   actual artifact repository
+	 * @param target     OutputStream where result is written
+	 * @param descriptor the descriptor of the artifact that is about to be
+	 *                   downloaded
+	 * @param monitor    where progress should be reported
+	 * @throws OperationCanceledException if the operation was canceled.
+	 */
+	public IStatus downloadArtifact(URI source, OutputStream target, IArtifactDescriptor descriptor,
+			IProgressMonitor monitor) {
+		Objects.requireNonNull(descriptor);
+		return download(source, target, monitor);
+	}
 
 	/**
 	 * Perform a stream download, writing into an InputStream that is returned.


### PR DESCRIPTION
Currently the transport only ever knows the URL but that is not enough to make good decisions as it could be a mirror url or the same artifact available from different update-sites.

For this purpose we should offer a new method that allows to pass the repository and the descriptor one want to download from it to the transport so it is possible to make better decisions, especially when the transport supports a native caching mechanism,

This should be backward compatible change of internal class.