### PR TITLE
Replace StringBuffer by StringBuilder in p2.metadata

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.metadata/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.metadata;singleton:=true
-Bundle-Version: 2.8.100.qualifier
+Bundle-Version: 2.9.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.metadata;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/BasicVersion.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/BasicVersion.java
@@ -63,7 +63,7 @@ public abstract class BasicVersion extends Version {
 	public abstract String getQualifier();
 
 	/**
-	 * Appends the original for this version onto the <code>sb</code> StringBuffer
+	 * Appends the original for this version onto the <code>sb</code> StringBuilder
 	 * if present.
 	 * @param sb The buffer that will receive the raw string format
 	 * @param rangeSafe Set to <code>true</code> if range delimiters should be escaped
@@ -71,7 +71,7 @@ public abstract class BasicVersion extends Version {
 	public abstract void originalToString(StringBuilder sb, boolean rangeSafe);
 
 	/**
-	 * Appends the raw format for this version onto the <code>sb</code> StringBuffer.
+	 * Appends the raw format for this version onto the <code>sb</code> StringBuilder.
 	 * @param sb The buffer that will receive the raw string format
 	 * @param rangeSafe Set to <code>true</code> if range delimiters should be escaped
 	 */

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/BasicVersion.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/BasicVersion.java
@@ -68,14 +68,14 @@ public abstract class BasicVersion extends Version {
 	 * @param sb The buffer that will receive the raw string format
 	 * @param rangeSafe Set to <code>true</code> if range delimiters should be escaped
 	 */
-	public abstract void originalToString(StringBuffer sb, boolean rangeSafe);
+	public abstract void originalToString(StringBuilder sb, boolean rangeSafe);
 
 	/**
 	 * Appends the raw format for this version onto the <code>sb</code> StringBuffer.
 	 * @param sb The buffer that will receive the raw string format
 	 * @param rangeSafe Set to <code>true</code> if range delimiters should be escaped
 	 */
-	public abstract void rawToString(StringBuffer sb, boolean rangeSafe);
+	public abstract void rawToString(StringBuilder sb, boolean rangeSafe);
 
 	/**
 	 * This method is package protected since it violates the immutable

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/EnumDefinition.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/EnumDefinition.java
@@ -91,7 +91,7 @@ class EnumDefinition implements Comparable<EnumDefinition>, Serializable {
 			return definition.getIdentifier(ordinal);
 		}
 
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			definition.toString(sb, ordinal);
 		}
 
@@ -253,12 +253,12 @@ class EnumDefinition implements Comparable<EnumDefinition>, Serializable {
 
 	@Override
 	public String toString() {
-		StringBuffer bld = new StringBuffer();
+		StringBuilder bld = new StringBuilder();
 		toString(bld);
 		return bld.toString();
 	}
 
-	public void toString(StringBuffer bld) {
+	public void toString(StringBuilder bld) {
 		bld.append('{');
 		int top = identifiers.length;
 		for (int ordinal = 0;;) {
@@ -276,7 +276,7 @@ class EnumDefinition implements Comparable<EnumDefinition>, Serializable {
 		bld.append('}');
 	}
 
-	void toString(StringBuffer bld, int selectedOrdinal) {
+	void toString(StringBuilder bld, int selectedOrdinal) {
 		bld.append('{');
 		int top = identifiers.length;
 		for (int ordinal = 0;;) {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/OSGiVersion.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/OSGiVersion.java
@@ -176,12 +176,12 @@ public class OSGiVersion extends BasicVersion {
 	}
 
 	@Override
-	public void originalToString(StringBuffer sb, boolean rangeSafe) {
+	public void originalToString(StringBuilder sb, boolean rangeSafe) {
 		toString(sb);
 	}
 
 	@Override
-	public void rawToString(StringBuffer sb, boolean rangeSafe) {
+	public void rawToString(StringBuilder sb, boolean rangeSafe) {
 		sb.append(major);
 		sb.append('.');
 		sb.append(minor);
@@ -194,7 +194,7 @@ public class OSGiVersion extends BasicVersion {
 	}
 
 	@Override
-	public void toString(StringBuffer sb) {
+	public void toString(StringBuilder sb) {
 		sb.append(major);
 		sb.append('.');
 		sb.append(minor);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/OmniVersion.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/OmniVersion.java
@@ -179,7 +179,7 @@ public class OmniVersion extends BasicVersion {
 	}
 
 	/**
-	 * Appends the original for this version onto the <code>sb</code> StringBuffer
+	 * Appends the original for this version onto the <code>sb</code> StringBuilder
 	 * if present.
 	 * @param sb The buffer that will receive the raw string format
 	 * @param rangeSafe Set to <code>true</code> if range delimiters should be escaped
@@ -203,7 +203,7 @@ public class OmniVersion extends BasicVersion {
 	}
 
 	/**
-	 * Appends the raw format for this version onto the <code>sb</code> StringBuffer.
+	 * Appends the raw format for this version onto the <code>sb</code> StringBuilder.
 	 * @param sb The buffer that will receive the raw string format
 	 * @param rangeSafe Set to <code>true</code> if range delimiters should be escaped
 	 */
@@ -214,7 +214,7 @@ public class OmniVersion extends BasicVersion {
 
 	/**
 	 * Appends the string representation of this version onto the
-	 * <code>sb</code> StringBuffer.
+	 * <code>sb</code> StringBuilder.
 	 * @param sb The buffer that will receive the version string
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/OmniVersion.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/OmniVersion.java
@@ -185,7 +185,7 @@ public class OmniVersion extends BasicVersion {
 	 * @param rangeSafe Set to <code>true</code> if range delimiters should be escaped
 	 */
 	@Override
-	public void originalToString(StringBuffer sb, boolean rangeSafe) {
+	public void originalToString(StringBuilder sb, boolean rangeSafe) {
 		if (original != null) {
 			if (rangeSafe) {
 				// Escape all range delimiters while appending
@@ -208,7 +208,7 @@ public class OmniVersion extends BasicVersion {
 	 * @param rangeSafe Set to <code>true</code> if range delimiters should be escaped
 	 */
 	@Override
-	public void rawToString(StringBuffer sb, boolean rangeSafe) {
+	public void rawToString(StringBuilder sb, boolean rangeSafe) {
 		VersionVector.toString(sb, vector, padValue, rangeSafe);
 	}
 
@@ -218,7 +218,7 @@ public class OmniVersion extends BasicVersion {
 	 * @param sb The buffer that will receive the version string
 	 */
 	@Override
-	public void toString(StringBuffer sb) {
+	public void toString(StringBuilder sb) {
 		if (this == emptyVersion)
 			sb.append("0.0.0"); //$NON-NLS-1$
 		else {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/TouchpointInstruction.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/TouchpointInstruction.java
@@ -69,7 +69,7 @@ public class TouchpointInstruction implements ITouchpointInstruction {
 	 * @return An encoded touchpoint instruction statement
 	 */
 	public static String encodeAction(String actionName, Map<String, String> parameters) {
-		StringBuffer result = new StringBuffer(actionName);
+		StringBuilder result = new StringBuilder(actionName);
 		result.append('(');
 		boolean first = true;
 		for (Entry<String, String> entry : parameters.entrySet()) {
@@ -89,7 +89,7 @@ public class TouchpointInstruction implements ITouchpointInstruction {
 	 * Append the given value to the given buffer, encoding any illegal characters
 	 * with appropriate escape sequences.
 	 */
-	private static void appendEncoded(StringBuffer buf, String value) {
+	private static void appendEncoded(StringBuilder buf, String value) {
 		char[] chars = value.toCharArray();
 		for (char c : chars) {
 			switch (c) {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionFormat.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionFormat.java
@@ -208,7 +208,7 @@ public class VersionFormat implements IVersionFormat, Serializable {
 				: OmniVersion.fromVector(vector, originalFormat, original);
 	}
 
-	static void rawToString(StringBuffer sb, boolean forRange, Comparable<?> e) {
+	static void rawToString(StringBuilder sb, boolean forRange, Comparable<?> e) {
 		if (e instanceof String) {
 			writeQuotedString(sb, forRange, (String) e, '\'', 0, false);
 		} else if (e instanceof VersionVector) {
@@ -239,7 +239,7 @@ public class VersionFormat implements IVersionFormat, Serializable {
 	 * @param didFlip   True if the call is recursive and thus, cannot switch quotes
 	 *                  in the first string.
 	 */
-	private static void writeQuotedString(StringBuffer sb, boolean rangeSafe, String s, char quote, int startPos,
+	private static void writeQuotedString(StringBuilder sb, boolean rangeSafe, String s, char quote, int startPos,
 			boolean didFlip) {
 		int quotePos = sb.length();
 		sb.append(quote);
@@ -330,14 +330,14 @@ public class VersionFormat implements IVersionFormat, Serializable {
 	@Override
 	public synchronized String toString() {
 		if (fmtString == null) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			toString(sb);
 		}
 		return fmtString;
 	}
 
 	@Override
-	public synchronized void toString(StringBuffer sb) {
+	public synchronized void toString(StringBuilder sb) {
 		if (fmtString != null)
 			sb.append(fmtString);
 		else {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionFormatParser.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionFormatParser.java
@@ -76,7 +76,7 @@ class VersionFormatParser {
 			return null;
 		}
 
-		void toString(StringBuffer bld) {
+		void toString(StringBuilder bld) {
 			bld.append('=');
 			definition.toString(bld);
 			if (begins)
@@ -142,7 +142,7 @@ class VersionFormatParser {
 
 		@Override
 		public String toString() {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			toString(sb);
 			return sb.toString();
 		}
@@ -173,7 +173,7 @@ class VersionFormatParser {
 			// No-op at this level
 		}
 
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			if (!(qualifier == VersionFormatParser.EXACT_ONE_QUALIFIER || (qualifier == VersionFormatParser.ZERO_OR_ONE_QUALIFIER && this.isGroup())))
 				qualifier.toString(sb);
 		}
@@ -210,7 +210,7 @@ class VersionFormatParser {
 
 		@Override
 		public String toString() {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			toString(sb);
 			return sb.toString();
 		}
@@ -290,7 +290,7 @@ class VersionFormatParser {
 			}
 		}
 
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			if (min == 0) {
 				switch (max) {
 					case 1:
@@ -420,7 +420,7 @@ class VersionFormatParser {
 		}
 
 		@Override
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			sb.append('a');
 			super.toString(sb);
 		}
@@ -468,7 +468,7 @@ class VersionFormatParser {
 		}
 
 		@Override
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			sb.append('d');
 			if (delimChars != null)
 				appendCharacterRange(sb, delimChars, inverted);
@@ -476,7 +476,7 @@ class VersionFormatParser {
 		}
 	}
 
-	static void appendCharacterRange(StringBuffer sb, char[] range, boolean inverted) {
+	static void appendCharacterRange(StringBuilder sb, char[] range, boolean inverted) {
 		sb.append('=');
 		sb.append('[');
 		if (inverted)
@@ -592,7 +592,7 @@ class VersionFormatParser {
 		}
 
 		@Override
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			if (ignored) {
 				sb.append('=');
 				sb.append('!');
@@ -677,7 +677,7 @@ class VersionFormatParser {
 		}
 
 		@Override
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			if (array) {
 				sb.append('<');
 				for (Fragment fragment : fragments)
@@ -725,7 +725,7 @@ class VersionFormatParser {
 		}
 
 		@Override
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			String str = string;
 			if (str.length() != 1) {
 				sb.append('\'');
@@ -830,7 +830,7 @@ class VersionFormatParser {
 		}
 
 		@Override
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			sb.append(signed ? 'N' : 'n');
 			super.toString(sb);
 		}
@@ -861,7 +861,7 @@ class VersionFormatParser {
 		}
 
 		@Override
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			sb.append('p');
 			super.toString(sb);
 		}
@@ -932,7 +932,7 @@ class VersionFormatParser {
 		}
 
 		@Override
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			sb.append('q');
 			super.toString(sb);
 		}
@@ -1005,7 +1005,7 @@ class VersionFormatParser {
 		}
 
 		@Override
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			if (characters != null)
 				appendCharacterRange(sb, characters, inverted);
 			if (rangeMin != 0 || rangeMax != Integer.MAX_VALUE) {
@@ -1047,7 +1047,7 @@ class VersionFormatParser {
 		}
 
 		@Override
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			sb.append('r');
 			super.toString(sb);
 		}
@@ -1166,7 +1166,7 @@ class VersionFormatParser {
 		}
 
 		@Override
-		void toString(StringBuffer sb) {
+		void toString(StringBuilder sb) {
 			sb.append(anyChar ? 'S' : 's');
 			super.toString(sb);
 		}
@@ -1772,7 +1772,7 @@ class VersionFormatParser {
 		currentList.add(createStringFragment(ep, parseQualifier(), unlimited));
 	}
 
-	static void toStringEscaped(StringBuffer sb, String value, String escapes) {
+	static void toStringEscaped(StringBuilder sb, String value, String escapes) {
 		for (int idx = 0; idx < value.length(); ++idx) {
 			char c = value.charAt(idx);
 			if (c == '\\' || escapes.indexOf(c) >= 0)

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionVector.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionVector.java
@@ -179,7 +179,7 @@ public class VersionVector implements Comparable<VersionVector>, Serializable {
 		return hashCode;
 	}
 
-	static void toString(StringBuffer sb, Comparable<?>[] vector, Comparable<?> padValue, boolean rangeSafe) {
+	static void toString(StringBuilder sb, Comparable<?>[] vector, Comparable<?> padValue, boolean rangeSafe) {
 		int top = vector.length;
 		if (top == 0)
 			// Write one pad value as explicit. It will be considered
@@ -316,7 +316,7 @@ public class VersionVector implements Comparable<VersionVector>, Serializable {
 
 	@Override
 	public String toString() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		toString(sb);
 		return sb.toString();
 	}
@@ -326,7 +326,7 @@ public class VersionVector implements Comparable<VersionVector>, Serializable {
 	 * <code>sb</code> buffer.
 	 * @param sb The buffer to append to
 	 */
-	public void toString(StringBuffer sb) {
+	public void toString(StringBuilder sb) {
 		toString(sb, vector, padValue, false);
 	}
 
@@ -337,7 +337,7 @@ public class VersionVector implements Comparable<VersionVector>, Serializable {
 	 * @param rangeSafe If <code>true</code>, the range delimiters will be escaped
 	 * with backslash.
 	 */
-	void toString(StringBuffer sb, boolean rangeSafe) {
+	void toString(StringBuilder sb, boolean rangeSafe) {
 		toString(sb, vector, padValue, rangeSafe);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/And.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/And.java
@@ -49,7 +49,7 @@ final class And extends NAry {
 	}
 
 	@Override
-	public void toLDAPString(StringBuffer buf) {
+	public void toLDAPString(StringBuilder buf) {
 		buf.append("(&"); //$NON-NLS-1$
 		for (Expression operand : operands)
 			operand.toLDAPString(buf);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Array.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Array.java
@@ -70,7 +70,7 @@ final class Array extends NAry {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		bld.append('[');
 		elementsToString(bld, rootVariable, operands);
 		bld.append(']');

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/At.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/At.java
@@ -86,7 +86,7 @@ class At extends Binary {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		appendOperand(bld, rootVariable, lhs, getPriority());
 		bld.append('[');
 		appendOperand(bld, rootVariable, rhs, PRIORITY_MAX);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Binary.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Binary.java
@@ -68,7 +68,7 @@ public abstract class Binary extends Expression {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		appendOperand(bld, rootVariable, lhs, getPriority());
 		bld.append(' ');
 		bld.append(getOperator());
@@ -82,7 +82,7 @@ public abstract class Binary extends Expression {
 	 * @throws UnsupportedOperationException when this expression does not conform to an
 	 * LDAP filter binary expression
 	 */
-	void appendLDAPAttribute(StringBuffer buf) {
+	void appendLDAPAttribute(StringBuilder buf) {
 		if (lhs instanceof DynamicMember) {
 			DynamicMember attr = (DynamicMember) lhs;
 			if (attr.operand instanceof Variable) {
@@ -97,11 +97,11 @@ public abstract class Binary extends Expression {
 		return (char) (value < 10 ? ('0' + value) : ('a' + (value - 10)));
 	}
 
-	static void appendLDAPEscaped(StringBuffer bld, String str) {
+	static void appendLDAPEscaped(StringBuilder bld, String str) {
 		appendLDAPEscaped(bld, str, true);
 	}
 
-	static void appendLDAPEscaped(StringBuffer bld, String str, boolean escapeWild) {
+	static void appendLDAPEscaped(StringBuilder bld, String str, boolean escapeWild) {
 		int top = str.length();
 		for (int idx = 0; idx < top; ++idx) {
 			char c = str.charAt(idx);
@@ -131,7 +131,7 @@ public abstract class Binary extends Expression {
 	 * @throws UnsupportedOperationException when this expression does not conform to an
 	 * LDAP filter binary expression
 	 */
-	void appendLDAPValue(StringBuffer buf) {
+	void appendLDAPValue(StringBuilder buf) {
 		if (rhs instanceof Literal) {
 			Object value = rhs.evaluate(null);
 			if (value instanceof String || value instanceof Version) {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/CollectionFilter.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/CollectionFilter.java
@@ -24,7 +24,7 @@ import org.eclipse.equinox.p2.metadata.index.IIndexProvider;
  * <code>x.&lt;operation&gt;(y | &lt;expression&gt;)</code>
  */
 public abstract class CollectionFilter extends Unary {
-	public static void appendProlog(StringBuffer bld, Variable rootVariable, Expression lhs, String operator) {
+	public static void appendProlog(StringBuilder bld, Variable rootVariable, Expression lhs, String operator) {
 		if (lhs != rootVariable) {
 			appendOperand(bld, rootVariable, lhs, PRIORITY_COLLECTION);
 			bld.append('.');
@@ -73,7 +73,7 @@ public abstract class CollectionFilter extends Unary {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		appendProlog(bld, rootVariable, operand, getOperator());
 		appendOperand(bld, rootVariable, lambda, PRIORITY_LAMBDA);
 		bld.append(')');

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Compare.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Compare.java
@@ -74,7 +74,7 @@ final class Compare extends Binary {
 	}
 
 	@Override
-	public void toLDAPString(StringBuffer buf) {
+	public void toLDAPString(StringBuilder buf) {
 		if (!equalOK)
 			buf.append("(!"); //$NON-NLS-1$
 		buf.append('(');

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Condition.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Condition.java
@@ -48,7 +48,7 @@ final class Condition extends Binary {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		super.toString(bld, rootVariable);
 		bld.append(' ');
 		bld.append(OPERATOR_ELSE);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/ContextExpression.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/ContextExpression.java
@@ -37,7 +37,7 @@ public class ContextExpression<T> extends Unary implements IContextExpression<T>
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		operand.toString(bld, rootVariable);
 	}
 
@@ -95,7 +95,7 @@ public class ContextExpression<T> extends Unary implements IContextExpression<T>
 	}
 
 	@Override
-	public void toString(StringBuffer bld) {
+	public void toString(StringBuilder bld) {
 		toString(bld, ExpressionFactory.EVERYTHING);
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/CurryedLambdaExpression.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/CurryedLambdaExpression.java
@@ -60,7 +60,7 @@ final class CurryedLambdaExpression extends LambdaExpression {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		int top = assignments.length;
 		if (top > 0) {
 			for (int idx = 0; idx < top; ++idx) {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Equals.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Equals.java
@@ -59,7 +59,7 @@ final class Equals extends Binary {
 	}
 
 	@Override
-	public void toLDAPString(StringBuffer buf) {
+	public void toLDAPString(StringBuilder buf) {
 		if (negate)
 			buf.append("(!"); //$NON-NLS-1$
 		buf.append('(');

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Expression.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Expression.java
@@ -34,7 +34,7 @@ public abstract class Expression implements IExpression, Comparable<Expression>,
 
 	static final Expression[] emptyArray = new Expression[0];
 
-	public static void appendOperand(StringBuffer bld, Variable rootVariable, Expression operand, int priority) {
+	public static void appendOperand(StringBuilder bld, Variable rootVariable, Expression operand, int priority) {
 		if (priority < operand.getPriority()) {
 			bld.append('(');
 			operand.toString(bld, rootVariable);
@@ -96,7 +96,7 @@ public abstract class Expression implements IExpression, Comparable<Expression>,
 		return result;
 	}
 
-	public static void elementsToString(StringBuffer bld, Variable rootVariable, Expression[] elements) {
+	public static void elementsToString(StringBuilder bld, Variable rootVariable, Expression[] elements) {
 		int top = elements.length;
 		if (top > 0) {
 			elements[0].toString(bld, rootVariable);
@@ -172,29 +172,29 @@ public abstract class Expression implements IExpression, Comparable<Expression>,
 	}
 
 	public final String toLDAPString() {
-		StringBuffer bld = new StringBuffer();
+		StringBuilder bld = new StringBuilder();
 		toLDAPString(bld);
 		return bld.toString();
 	}
 
 	@Override
-	public void toLDAPString(StringBuffer buf) {
+	public void toLDAPString(StringBuilder buf) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public final String toString() {
-		StringBuffer bld = new StringBuffer();
+		StringBuilder bld = new StringBuilder();
 		toString(bld);
 		return bld.toString();
 	}
 
 	@Override
-	public void toString(StringBuffer bld) {
+	public void toString(StringBuilder bld) {
 		toString(bld, ExpressionFactory.THIS);
 	}
 
-	public abstract void toString(StringBuffer bld, Variable rootVariable);
+	public abstract void toString(StringBuilder bld, Variable rootVariable);
 
 	private static class Compacter {
 		private Expression base;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/ExpressionFactory.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/ExpressionFactory.java
@@ -271,7 +271,7 @@ public class ExpressionFactory implements IExpressionFactory, IExpressionConstan
 		// Insert functions that takes arguments here
 
 		//
-		StringBuffer bld = new StringBuffer();
+		StringBuilder bld = new StringBuilder();
 		bld.append("Don't know how to do a member call with "); //$NON-NLS-1$
 		bld.append(name);
 		bld.append('(');

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Function.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Function.java
@@ -76,7 +76,7 @@ public abstract class Function extends NAry {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		bld.append(getOperator());
 		bld.append('(');
 		elementsToString(bld, rootVariable, operands);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/LDAPFilter.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/LDAPFilter.java
@@ -91,7 +91,7 @@ public class LDAPFilter extends Unary implements IFilterExpression {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		operand.toLDAPString(bld);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/LambdaExpression.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/LambdaExpression.java
@@ -57,7 +57,7 @@ public class LambdaExpression extends Unary {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		each.toString(bld, rootVariable);
 		bld.append(" | "); //$NON-NLS-1$
 		appendOperand(bld, rootVariable, operand, IExpressionConstants.PRIORITY_COMMA);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Limit.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Limit.java
@@ -83,7 +83,7 @@ final class Limit extends Binary {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		CollectionFilter.appendProlog(bld, rootVariable, lhs, getOperator());
 		appendOperand(bld, rootVariable, rhs, IExpressionConstants.PRIORITY_COMMA);
 		bld.append(')');

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Literal.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Literal.java
@@ -101,18 +101,18 @@ public final class Literal extends Expression {
 	}
 
 	@Override
-	public void toLDAPString(StringBuffer buf) {
+	public void toLDAPString(StringBuilder buf) {
 		if (!(value instanceof Filter))
 			throw new UnsupportedOperationException();
 		buf.append(value.toString());
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		appendValue(bld, value);
 	}
 
-	private static void appendValue(StringBuffer bld, Object value) {
+	private static void appendValue(StringBuilder bld, Object value) {
 		if (value == null)
 			bld.append("null"); //$NON-NLS-1$
 		else if (value == Boolean.TRUE)
@@ -152,7 +152,7 @@ public final class Literal extends Expression {
 
 	}
 
-	private static void appendLiteralCollection(StringBuffer bld, Collection<?> collection) {
+	private static void appendLiteralCollection(StringBuilder bld, Collection<?> collection) {
 		bld.append('[');
 		Iterator<?> iter = collection.iterator();
 		if (iter.hasNext()) {
@@ -165,7 +165,7 @@ public final class Literal extends Expression {
 		bld.append(']');
 	}
 
-	private static void appendQuotedString(StringBuffer bld, String str) {
+	private static void appendQuotedString(StringBuilder bld, String str) {
 		if (str.indexOf('\'') < 0) {
 			bld.append('\'');
 			bld.append(str);
@@ -174,7 +174,7 @@ public final class Literal extends Expression {
 			appendEscaped(bld, '"', str);
 	}
 
-	private static void appendEscaped(StringBuffer bld, char delimiter, String str) {
+	private static void appendEscaped(StringBuilder bld, char delimiter, String str) {
 		bld.append(delimiter);
 		int top = str.length();
 		for (int idx = 0; idx < top; ++idx) {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/MatchExpression.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/MatchExpression.java
@@ -96,12 +96,12 @@ public class MatchExpression<T> extends Unary implements IMatchExpression<T> {
 	}
 
 	@Override
-	public void toLDAPString(StringBuffer bld) {
+	public void toLDAPString(StringBuilder bld) {
 		operand.toLDAPString(bld);
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		operand.toString(bld, rootVariable);
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Matches.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Matches.java
@@ -104,7 +104,7 @@ public class Matches extends Binary {
 	}
 
 	@Override
-	public void toLDAPString(StringBuffer buf) {
+	public void toLDAPString(StringBuilder buf) {
 		if (!(rhs instanceof Literal))
 			throw new UnsupportedOperationException();
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Member.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Member.java
@@ -251,7 +251,7 @@ public abstract class Member extends Unary {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		if (operand != rootVariable) {
 			appendOperand(bld, rootVariable, operand, getPriority());
 			bld.append('.');

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/NAry.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/NAry.java
@@ -56,7 +56,7 @@ public abstract class NAry extends Expression {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		appendOperand(bld, rootVariable, operands[0], getPriority());
 		for (int idx = 1; idx < operands.length; ++idx) {
 			bld.append(' ');

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Not.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Not.java
@@ -49,7 +49,7 @@ final class Not extends Unary {
 	}
 
 	@Override
-	public void toLDAPString(StringBuffer buf) {
+	public void toLDAPString(StringBuilder buf) {
 		buf.append("(!"); //$NON-NLS-1$
 		operand.toLDAPString(buf);
 		buf.append(')');

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Or.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Or.java
@@ -49,7 +49,7 @@ final class Or extends NAry {
 	}
 
 	@Override
-	public void toLDAPString(StringBuffer buf) {
+	public void toLDAPString(StringBuilder buf) {
 		buf.append("(|"); //$NON-NLS-1$
 		for (Expression operand : operands)
 			operand.toLDAPString(buf);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Parameter.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Parameter.java
@@ -68,7 +68,7 @@ public class Parameter extends Expression {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		bld.append('$');
 		bld.append(position);
 	}

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Unary.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Unary.java
@@ -59,7 +59,7 @@ public abstract class Unary extends Expression {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		bld.append(getOperator());
 		appendOperand(bld, rootVariable, operand, getPriority());
 	}

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/UnaryCollectionFilter.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/UnaryCollectionFilter.java
@@ -32,7 +32,7 @@ abstract class UnaryCollectionFilter extends Unary {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		if (operand instanceof Select) {
 			Select select = (Select) operand;
 			CollectionFilter.appendProlog(bld, rootVariable, select.operand, getOperator());

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Unique.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Unique.java
@@ -72,7 +72,7 @@ final class Unique extends Binary {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		CollectionFilter.appendProlog(bld, rootVariable, lhs, getOperator());
 		if (rhs != Literal.NULL_CONSTANT)
 			appendOperand(bld, rootVariable, rhs, IExpressionConstants.PRIORITY_COMMA);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Variable.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Variable.java
@@ -85,7 +85,7 @@ public class Variable extends Expression {
 	}
 
 	@Override
-	public void toString(StringBuffer bld, Variable rootVariable) {
+	public void toString(StringBuilder bld, Variable rootVariable) {
 		bld.append(name);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/parser/LDAPFilterParser.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/parser/LDAPFilterParser.java
@@ -44,7 +44,7 @@ public class LDAPFilterParser {
 
 	private final IExpression self;
 
-	private final StringBuffer sb = new StringBuffer();
+	private final StringBuilder sb = new StringBuilder();
 
 	private String filterString;
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/IVersionFormat.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/IVersionFormat.java
@@ -41,7 +41,7 @@ public interface IVersionFormat {
 	 * the given StringBuffer.
 	 * @param sb The buffer that will receive the string representation
 	 */
-	void toString(StringBuffer sb);
+	void toString(StringBuilder sb);
 
 	/**
 	 * Parse the given version string.

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/IVersionFormat.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/IVersionFormat.java
@@ -37,9 +37,25 @@ public interface IVersionFormat {
 	static final String DEFAULT_MIN_STRING_TRANSLATION = "-"; //$NON-NLS-1$
 
 	/**
-	 * Appends the string representation of this compiled format to
-	 * the given StringBuffer.
+	 * Appends the string representation of this compiled format to the given
+	 * StringBuffer.
+	 * 
 	 * @param sb The buffer that will receive the string representation
+	 * @deprecated Use {@link #toString(StringBuilder)} instead
+	 */
+	@Deprecated(since = "2.9")
+	default void toString(StringBuffer sb) {
+		StringBuilder builder = new StringBuilder();
+		toString(builder);
+		sb.append(builder);
+	}
+
+	/**
+	 * Appends the string representation of this compiled format to the given
+	 * StringBuilder.
+	 * 
+	 * @param sb The builder that will receive the string representation
+	 * @since 2.9
 	 */
 	void toString(StringBuilder sb);
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/Version.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/Version.java
@@ -208,7 +208,7 @@ public abstract class Version implements Comparable<Version>, Serializable {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer(20);
+		StringBuilder buf = new StringBuilder(20);
 		toString(buf);
 		return buf.toString();
 	}
@@ -218,5 +218,5 @@ public abstract class Version implements Comparable<Version>, Serializable {
 	 * <code>sb</code> StringBuffer.
 	 * @param sb The buffer that will receive the version string
 	 */
-	public abstract void toString(StringBuffer sb);
+	public abstract void toString(StringBuilder sb);
 }

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/Version.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/Version.java
@@ -217,6 +217,21 @@ public abstract class Version implements Comparable<Version>, Serializable {
 	 * Appends the string representation of this version onto the
 	 * <code>sb</code> StringBuffer.
 	 * @param sb The buffer that will receive the version string
+	 * @deprecated use {@link #toString(StringBuilder)} instead
+	 */
+	@Deprecated(since = "2.9")
+	public void toString(StringBuffer sb) {
+		StringBuilder builder = new StringBuilder();
+		toString(builder);
+		sb.append(builder);
+	}
+
+	/**
+	 * Appends the string representation of this version onto the <code>sb</code>
+	 * StringBuilder.
+	 * 
+	 * @param sb The builder that will receive the version string
+	 * @since 2.9
 	 */
 	public abstract void toString(StringBuilder sb);
 }

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/VersionRange.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/VersionRange.java
@@ -46,7 +46,7 @@ public class VersionRange implements Serializable {
 	private final Version maxVersion;
 	private final boolean includeMax;
 
-	private static int copyEscaped(String vr, int pos, String breakChars, StringBuffer sb) {
+	private static int copyEscaped(String vr, int pos, String breakChars, StringBuilder sb) {
 		int top = vr.length();
 		pos = VersionParser.skipWhite(vr, pos);
 		if (pos >= top)
@@ -153,7 +153,7 @@ public class VersionRange implements Serializable {
 
 		String minStr;
 		String maxStr;
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (c == '[' || c == '(') {
 			includeMin = (c == '[');
 			pos = copyEscaped(versionRange, ++pos, ",)]", sb); //$NON-NLS-1$
@@ -173,7 +173,7 @@ public class VersionRange implements Serializable {
 			c = versionRange.charAt(pos++);
 			includeMax = (c == ']');
 		} else {
-			StringBuffer sbMin = new StringBuffer();
+			StringBuilder sbMin = new StringBuilder();
 			pos = copyEscaped(versionRange, pos, rawPrefix ? "/" : null, sbMin); //$NON-NLS-1$
 			includeMin = includeMax = true;
 			minStr = sbMin.toString();
@@ -438,12 +438,12 @@ public class VersionRange implements Serializable {
 
 	@Override
 	public String toString() {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		toString(result);
 		return result.toString();
 	}
 
-	public void toString(StringBuffer result) {
+	public void toString(StringBuilder result) {
 		boolean gtEqual = includeMin && includeMax && Version.MAX_VERSION.equals(maxVersion);
 		if (gtEqual && Version.emptyVersion.equals(minVersion)) {
 			minVersion.toString(result);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/VersionRange.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/VersionRange.java
@@ -443,6 +443,19 @@ public class VersionRange implements Serializable {
 		return result.toString();
 	}
 
+	/**
+	 * @deprecated use {@link #toString(StringBuilder)} instead.
+	 */
+	@Deprecated(since = "2.9")
+	public void toString(StringBuffer result) {
+		StringBuilder builder = new StringBuilder();
+		toString(builder);
+		result.append(builder);
+	}
+
+	/**
+	 * @since 2.9
+	 */
 	public void toString(StringBuilder result) {
 		boolean gtEqual = includeMin && includeMax && Version.MAX_VERSION.equals(maxVersion);
 		if (gtEqual && Version.emptyVersion.equals(minVersion)) {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/expression/IExpression.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/expression/IExpression.java
@@ -77,12 +77,12 @@ public interface IExpression {
 	/**
 	 * Appends the string representation of this expression to the collector <code>collector</code>.
 	 */
-	void toString(StringBuffer collector);
+	void toString(StringBuilder collector);
 
 	/**
 	 * Appends the an LDAP filter representation of this expression to the <code>collector</code>.
 	 * @throws UnsupportedOperationException if the expression contains nodes
 	 * that cannot be represented in an LDAP filter
 	 */
-	void toLDAPString(StringBuffer collector);
+	void toLDAPString(StringBuilder collector);
 }

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/expression/IExpression.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/expression/IExpression.java
@@ -75,14 +75,48 @@ public interface IExpression {
 	int getExpressionType();
 
 	/**
-	 * Appends the string representation of this expression to the collector <code>collector</code>.
+	 * Appends the string representation of this expression to the collector
+	 * <code>collector</code>.
+	 * 
+	 * @deprecated use {@link #toString(StringBuilder)} instead
+	 */
+	@Deprecated(since = "2.9")
+	default void toString(StringBuffer collector) {
+		StringBuilder builder = new StringBuilder();
+		toString(builder);
+		collector.append(builder);
+	}
+
+	/**
+	 * Appends the string representation of this expression to the collector
+	 * <code>collector</code>.
+	 * 
+	 * @since 2.9
 	 */
 	void toString(StringBuilder collector);
 
 	/**
-	 * Appends the an LDAP filter representation of this expression to the <code>collector</code>.
-	 * @throws UnsupportedOperationException if the expression contains nodes
-	 * that cannot be represented in an LDAP filter
+	 * Appends the an LDAP filter representation of this expression to the
+	 * <code>collector</code>.
+	 * 
+	 * @throws UnsupportedOperationException if the expression contains nodes that
+	 *                                       cannot be represented in an LDAP filter
+	 * @deprecated use {@link #toLDAPString(StringBuilder)} instead
+	 */
+	@Deprecated(since = "2.9")
+	default void toLDAPString(StringBuffer collector) {
+		StringBuilder builder = new StringBuilder();
+		toLDAPString(builder);
+		collector.append(builder);
+	}
+
+	/**
+	 * Appends the an LDAP filter representation of this expression to the
+	 * <code>collector</code>.
+	 * 
+	 * @throws UnsupportedOperationException if the expression contains nodes that
+	 *                                       cannot be represented in an LDAP filter
+	 * @since 2.9
 	 */
 	void toLDAPString(StringBuilder collector);
 }


### PR DESCRIPTION
This PR consists of two steps

1. Apply 'Convert `StringBuffer` to `StringBuilder`' clean-up to p2.metadata
2. Manually restore API compatibility after `StringBuffer` clean-up
Keep the old `StringBuffer` accepting method as default implementations that redirect to the `StringBuilder` impls.
