### PR TITLE
Migrate AutomaticUpdateScheduler from IStartup to OSGi EventHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ pom.tycho
 .tycho-consumer-pom.xml
 .flattened-pom.xml
 apiAnalyzer-workspace/
+
+#Generated OSGi declarative service files
+**/OSGI-INF/org.eclipse.*.xml

--- a/bundles/org.eclipse.equinox.p2.core/OSGI-INF/.gitignore
+++ b/bundles/org.eclipse.equinox.p2.core/OSGI-INF/.gitignore
@@ -1,1 +1,0 @@
-/org.eclipse.equinox.*.xml

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/.project
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/.project
@@ -25,6 +25,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/.settings/org.eclipse.pde.ds.annotations.prefs
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/.settings/org.eclipse.pde.ds.annotations.prefs
@@ -1,0 +1,7 @@
+dsVersion=V1_4
+eclipse.preferences.version=1
+enabled=true
+generateBundleActivationPolicyLazy=true
+path=OSGI-INF
+validationErrorLevel=error
+validationErrorLevel.missingImplicitUnbindMethod=error

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/META-INF/MANIFEST.MF
@@ -8,11 +8,14 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.ui.sdk.scheduler;x-internal:=true,
  org.eclipse.equinox.internal.p2.ui.sdk.scheduler.migration;x-internal:=true
-Require-Bundle: org.eclipse.ui;bundle-version="3.208.0",
- org.eclipse.core.runtime;bundle-version="[3.34.200,4)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.34.200,4)",
  org.eclipse.equinox.p2.updatechecker;bundle-version="[1.4.300,2)",
  org.eclipse.equinox.p2.ui;bundle-version="[2.5.0,3)",
- org.eclipse.equinox.p2.repository;bundle-version="2.3.0"
+ org.eclipse.equinox.p2.repository;bundle-version="2.3.0",
+ org.eclipse.e4.ui.workbench;bundle-version="[1.15.0,2.0.0)",
+ org.eclipse.ui.workbench;bundle-version="[3.131.0,4.0.0)",
+ org.eclipse.jface;bundle-version="[3.33.0,4.0.0)"
+Service-Component: OSGI-INF/org.eclipse.equinox.internal.p2.ui.sdk.scheduler.AutomaticUpdateScheduler.xml
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.equinox.internal.p2.core.helpers,
@@ -31,6 +34,8 @@ Import-Package: org.eclipse.equinox.internal.p2.core.helpers,
  org.eclipse.equinox.p2.query;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.ui;version="[2.0.0,3.0.0)",
  org.eclipse.osgi.util;version="1.1.0",
- org.osgi.framework;version="1.6.0"
+ org.osgi.framework;version="1.6.0",
+ org.osgi.service.event;version="[1.4.0,2.0.0)",
+ org.osgi.service.event.propertytypes;version="[1.4.0,2.0.0)"
 Automatic-Module-Name: org.eclipse.equinox.p2.ui.sdk.scheduler
 Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.sdk.scheduler;singleton:=true
-Bundle-Version: 1.7.100.qualifier
+Bundle-Version: 1.7.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.sdk.scheduler.AutomaticUpdatePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/build.properties
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/build.properties
@@ -14,6 +14,7 @@
 bin.includes = plugin.properties,\
                icons/,\
                .,\
+               OSGI-INF/,\
                about.html,\
                META-INF/,\
                plugin.xml

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/plugin.xml
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/plugin.xml
@@ -6,11 +6,6 @@
 		<initializer class="org.eclipse.equinox.internal.p2.ui.sdk.scheduler.PreferenceInitializer"/>
 	</extension>
    <extension
-         point="org.eclipse.ui.startup">
-      <startup class="org.eclipse.equinox.internal.p2.ui.sdk.scheduler.AutomaticUpdateScheduler">
-      </startup>
-   </extension>
-   <extension
          point="org.eclipse.ui.preferencePages">
           <page
             name="%automaticUpdatesPrefPage"

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdateScheduler.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdateScheduler.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.Random;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.e4.ui.workbench.UIEvents;
 import org.eclipse.equinox.internal.p2.core.helpers.ServiceHelper;
 import org.eclipse.equinox.internal.p2.garbagecollector.GarbageCollector;
 import org.eclipse.equinox.internal.p2.ui.sdk.scheduler.migration.MigrationSupport;
@@ -33,16 +34,21 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.repository.IRepositoryManager;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.ui.IStartup;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.statushandlers.StatusManager;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.event.propertytypes.EventTopics;
 
 /**
  * This plug-in is loaded on startup to register with the update checker.
  *
  * @since 3.5
  */
-public class AutomaticUpdateScheduler implements IStartup {
+@Component(service = EventHandler.class)
+@EventTopics(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE)
+public class AutomaticUpdateScheduler implements EventHandler {
 	public static final String MIGRATION_DIALOG_SHOWN = "migrationDialogShown"; //$NON-NLS-1$
 
 	public static final String P_FUZZY_RECURRENCE = "fuzzy_recurrence"; //$NON-NLS-1$
@@ -57,7 +63,7 @@ public class AutomaticUpdateScheduler implements IStartup {
 	private IUpdateChecker checker;
 
 	@Override
-	public void earlyStartup() {
+	public void handleEvent(Event event) {
 		AutomaticUpdatePlugin.getDefault().setScheduler(this);
 
 		Job updateJob = new Job("Update Job") { //$NON-NLS-1$


### PR DESCRIPTION
... for the `UIEvents.UILifeCycle.APP_STARTUP_COMPLETE` event.

This is a less Eclipse specific approach and also prevents the user from disabling the start-up task.
The automatic search for updates can still be disabled.

Based on the work in https://github.com/eclipse-platform/eclipse.platform.ui/pull/1362.