### PR TITLE
Touch bundles affected by the changed ecj version

### DIFF
--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.frameworkadmin.test/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.frameworkadmin.test/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.frameworkadmin/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.frameworkadmin/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 407707 - A number of .class files changed, after changing to M7 JDT compiler
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.console/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.console/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.core/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.core/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.director.app/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.director.app/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.director/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.director/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.discovery.compatibility/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.discovery.compatibility/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.discovery/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.p2.discovery;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",

--- a/bundles/org.eclipse.equinox.p2.discovery/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.discovery/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.engine/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.engine/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 542873 - IBuild I20181217-1800 failed due to unresolved project dependencies.
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.extensionlocation/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.installer/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.installer/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.jarprocessor/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.jarprocessor/forceQualifierUpdate.txt
@@ -11,3 +11,4 @@ Bug 578351 - Lambda generation order is unstable in ecj
 Bug 579126 - 4.24 I-Build: I20220307-0340 - Comparator Errors Found
 Comparator errors in I20230307-0840
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.metadata/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.metadata/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.publisher/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.publisher/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.reconciler.dropins/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.reconciler.dropins/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.repository.tools/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.repository/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.repository/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.tests.discovery/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.p2.tests.discovery;singleton:=true
-Bundle-Version: 1.4.300.qualifier
+Bundle-Version: 1.4.400.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.p2.discovery.tests;x-internal:=true,

--- a/bundles/org.eclipse.equinox.p2.tests.discovery/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.tests.discovery/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.tests.ui/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 420588 - Unanticipated comparator errors in I20131028-2000
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.tests.verifier/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.tests.verifier/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.tests/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.tests/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.transport.ecf/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 414457 - Comparator report indicates problem with org.eclipse.equinox.p2.ui.
 Bug 416980 - ControlListViewer.class appears to have changed, though qualifier has not
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.ui/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.ui/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 509973 - Comparator errors in I20170105-0320
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1378
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.p2.updatesite/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.updatesite/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 407707 - A number of .class files changed, after changing to M7 JDT compiler
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/bundles/org.eclipse.equinox.simpleconfigurator/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394 
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659