### PR TITLE
Save state should be reset to the previous state

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
@@ -1414,6 +1414,7 @@ public class SimpleArtifactRepository extends AbstractArtifactRepository impleme
 
 		boolean lockAcquired = false;
 		synchronized (this) {
+			boolean disableSaveState = disableSave;
 			try {
 				if (canLock()) {
 					lockAcquired = lockAndLoad(false, monitor);
@@ -1428,9 +1429,11 @@ public class SimpleArtifactRepository extends AbstractArtifactRepository impleme
 			} catch (Throwable e) {
 				result = new Status(IStatus.ERROR, Activator.ID, e.getMessage(), e);
 			} finally {
-				disableSave = false;
+				disableSave = disableSaveState;
 				try {
-					save();
+					if (!disableSaveState) {
+						save();
+					}
 				} catch (Exception e) {
 					if (result != null)
 						result = new MultiStatus(Activator.ID, IStatus.ERROR, new IStatus[] {result}, e.getMessage(), e);

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/LocalMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/LocalMetadataRepository.java
@@ -331,6 +331,7 @@ public class LocalMetadataRepository extends AbstractMetadataRepository implemen
 	public IStatus executeBatch(IRunnableWithProgress runnable, IProgressMonitor monitor) {
 		IStatus result = null;
 		synchronized (this) {
+			boolean disableSaveState = disableSave;
 			try {
 				disableSave = true;
 				runnable.run(monitor);
@@ -339,9 +340,11 @@ public class LocalMetadataRepository extends AbstractMetadataRepository implemen
 			} catch (Throwable e) {
 				result = new Status(IStatus.ERROR, Constants.ID, e.getMessage(), e);
 			} finally {
-				disableSave = false;
+				disableSave = disableSaveState;
 				try {
-					save();
+					if (!disableSaveState) {
+						save();
+					}
 				} catch (Exception e) {
 					if (result != null)
 						result = new MultiStatus(Constants.ID, IStatus.ERROR, new IStatus[] {result}, e.getMessage(), e);


### PR DESCRIPTION
Currently if one performs an operation as batch and then inside that also performs a batch this resets the save flag even though there are more items to batch in the operation.

This saves the current state and restore that state on completion, save is only performed if saving was not already disabled before.