### PR TITLE
Do not duplicate failed repository attempts

### DIFF
--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RepositoryTracker.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RepositoryTracker.java
@@ -44,7 +44,7 @@ public abstract class RepositoryTracker {
 	/**
 	 * List<URI> of repositories that have already been reported to the user as not found.
 	 */
-	private final List<URI> reposNotFound = Collections.synchronizedList(new ArrayList<>());
+	private final Set<URI> reposNotFound = Collections.synchronizedSet(new LinkedHashSet<>());
 
 	/**
 	 * Return an array of repository locations known for the specified provisioning session.

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/LoadMetadataRepositoryJob.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/LoadMetadataRepositoryJob.java
@@ -136,6 +136,11 @@ public class LoadMetadataRepositoryJob extends ProvisioningJob {
 
 	private void handleLoadFailure(ProvisionException e, URI location) {
 		if (shouldAccumulateFailures()) {
+			RepositoryTracker repositoryTracker = ui.getRepositoryTracker();
+			if (accumulatedStatus != null && repositoryTracker.hasNotFoundStatusBeenReported(location)) {
+				// no need to report the same failure multiple times...
+				return;
+			}
 			// Some ProvisionExceptions include an empty multi status with a message.
 			// Since empty multi statuses have a severity OK, The platform status handler
 			// doesn't handle
@@ -151,7 +156,7 @@ public class LoadMetadataRepositoryJob extends ProvisioningJob {
 			} else {
 				accumulatedStatus.add(status);
 			}
-			ui.getRepositoryTracker().addNotFound(location);
+			repositoryTracker.addNotFound(location);
 			// Always log the complete exception so the detailed stack trace is in the log.
 			LogHelper.log(e);
 		} else {


### PR DESCRIPTION
Currently it can happen that when the same repository is reported as a problem multiple times then the accumulated status show the same repository multiple times.

This do the following:

1) using a set to record failed URIs
2) check if the URI was failing before

as discovered here:
- https://github.com/eclipse-equinox/p2/pull/343

![image](https://github.com/eclipse-equinox/p2/assets/208716/9463b038-54f4-4c17-9523-b4fc4769ebf2)

![image](https://github.com/eclipse-equinox/p2/assets/208716/8d90a35b-ceb6-45b2-a3fb-5bf68f15b2aa)