### PR TITLE
Refresh a subset of bundles if they provide missing requirements

### DIFF
--- a/bundles/org.eclipse.equinox.simpleconfigurator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/META-INF/MANIFEST.MF
@@ -1,20 +1,23 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.equinox.simpleconfigurator;singleton:=true
-Bundle-Version: 1.5.100.qualifier
+Bundle-Version: 1.5.200.qualifier
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.equinox.internal.simpleconfigurator.Activator
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.osgi.framework.console;version="1.0.0";resolution:=optional,
+ org.eclipse.osgi.report.resolution;version="[1.0.0,2.0.0]",
  org.eclipse.osgi.service.datalocation;version="1.0.0";resolution:=optional,
  org.osgi.framework;version="1.3.0",
+ org.osgi.framework.hooks.resolver;version="[1.0.0,2.0.0]",
  org.osgi.framework.namespace;version="1.0.0",
  org.osgi.framework.startlevel;version="1.0.0",
  org.osgi.framework.wiring;version="1.2.0",
  org.osgi.resource;version="1.0.0",
  org.osgi.service.packageadmin;version="1.2.0",
+ org.osgi.service.resolver;version="[1.1.0,2.0.0]",
  org.osgi.service.startlevel;version="1.0.0",
  org.osgi.util.tracker;version="1.3.0"
 Export-Package: org.eclipse.equinox.internal.provisional.configurator;

--- a/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/Activator.java
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/Activator.java
@@ -43,7 +43,7 @@ import org.osgi.framework.*;
  * Otherwise, no uninstallation will not be done.
  */
 public class Activator implements BundleActivator {
-	public final static boolean DEBUG = false;
+	public final static boolean DEBUG = Boolean.getBoolean("equinox.simpleconfigurator.debug");
 
 	/**
 	 * If this property is set to true, simpleconfigurator will attempt to read

--- a/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/ResolutionReportListener.java
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/src/org/eclipse/equinox/internal/simpleconfigurator/ResolutionReportListener.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ * All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which accompanies this distribution,
+ * and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.simpleconfigurator;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.eclipse.osgi.report.resolution.ResolutionReport;
+import org.osgi.framework.hooks.resolver.ResolverHook;
+import org.osgi.framework.hooks.resolver.ResolverHookFactory;
+import org.osgi.framework.wiring.*;
+
+class ResolutionReportListener implements ResolverHookFactory, ResolverHook, ResolutionReport.Listener {
+
+	private List<ResolutionReport> reports = new CopyOnWriteArrayList<>();
+
+	@Override
+	public ResolverHook begin(Collection<BundleRevision> triggers) {
+		return this;
+	}
+
+	@Override
+	public void handleResolutionReport(ResolutionReport report) {
+		reports.add(report);
+	}
+
+	@Override
+	public void filterResolvable(Collection<BundleRevision> candidates) {
+		// nothing to do...
+	}
+
+	@Override
+	public void filterSingletonCollisions(BundleCapability singleton,
+			Collection<BundleCapability> collisionCandidates) {
+		// nothing to do...
+	}
+
+	@Override
+	public void filterMatches(BundleRequirement requirement, Collection<BundleCapability> candidates) {
+		// nothing to do...
+	}
+
+	@Override
+	public void end() {
+		// nothing to do...
+	}
+
+	public List<ResolutionReport> getReports() {
+		return List.copyOf(reports);
+	}
+}


### PR DESCRIPTION
When refreshing large sets of bundles the resolver sometimes take a choice where a requirement can't be bound even though it is there and resolvable.

This adds some additional code to detect this situation and then refresh a smaller set of bundles that provide these until a max retry is reached, all bundles are resolved, or all providers have been tried to refresh already.