### PR TITLE
Add a filter to  requirements corresponding to a feature's imports

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.publisher.eclipse;singleton:=true
-Bundle-Version: 1.5.400.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-Activator: org.eclipse.pde.internal.publishing.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/FeatureManifestParser.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/FeatureManifestParser.java
@@ -40,7 +40,7 @@ public class FeatureManifestParser extends DefaultHandler {
 	private SAXParser parser;
 	protected Feature result;
 	private URL url;
-	private StringBuffer characters = null;
+	private StringBuilder characters = null;
 	private MultiStatus status = null;
 	private boolean hasImports = false;
 
@@ -140,12 +140,12 @@ public class FeatureManifestParser extends DefaultHandler {
 
 	private void processCopyright(Attributes attributes) {
 		result.setCopyrightURL(attributes.getValue("url")); //$NON-NLS-1$
-		characters = new StringBuffer();
+		characters = new StringBuilder();
 	}
 
 	private void processDescription(Attributes attributes) {
 		result.setDescriptionURL(attributes.getValue("url")); //$NON-NLS-1$
-		characters = new StringBuffer();
+		characters = new StringBuilder();
 	}
 
 	private void processDiscoverySite(Attributes attributes) {
@@ -207,9 +207,9 @@ public class FeatureManifestParser extends DefaultHandler {
 		if ("versionRange".equals(attributes.getValue("match"))) { //$NON-NLS-1$//$NON-NLS-2$
 			VersionRange versionRange = VersionRange.create(versionStr);
 			entry = FeatureEntry.createRequires(id, versionRange, attributes.getValue("match"), //$NON-NLS-1$
-					attributes.getValue("filter"), isPlugin); //$NON-NLS-1$
+					attributes.getValue("filter"), isPlugin, true); //$NON-NLS-1$
 		} else {
-			entry = FeatureEntry.createRequires(id, versionStr, match, attributes.getValue("filter"), isPlugin); //$NON-NLS-1$
+			entry = FeatureEntry.createRequires(id, versionStr, match, attributes.getValue("filter"), isPlugin, true); //$NON-NLS-1$
 		}
 		if (isPatch) {
 			entry.setPatch(true);
@@ -241,7 +241,7 @@ public class FeatureManifestParser extends DefaultHandler {
 
 	private void processLicense(Attributes attributes) {
 		result.setLicenseURL(attributes.getValue("url")); //$NON-NLS-1$
-		characters = new StringBuffer();
+		characters = new StringBuilder();
 	}
 
 	private void processPlugin(Attributes attributes) {

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/FeatureEntry.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/FeatureEntry.java
@@ -27,17 +27,28 @@ public class FeatureEntry implements IPlatformEntry {
 	private String nl;
 	private String match;
 	private final boolean isPlugin;
-	private boolean isFragment = false;
-	private boolean isRequires = false;
-	private Boolean unpack = null;
-	private boolean optional = false;
-	private boolean isPatch = false;
-	/**
-	 * Temporary field to add provorg.eclipse.pde.internal.publishing.model.filters to features
-	 */
+	private boolean isFragment;
+	private boolean isRequires;
+	private Boolean unpack;
+	private boolean optional;
+	private boolean isPatch;
 	private String filter;
+	private boolean isImport;
 
+	/**
+	 * @deprecated Use
+	 *             {@link #createRequires(String, String, String, String, boolean, boolean)}
+	 */
+	@Deprecated
 	public static FeatureEntry createRequires(String id, String version, String match, String filter, boolean isPlugin) {
+		return createRequires(id, version, match, filter, isPlugin, true);
+	}
+
+	/**
+	 * @since 1.6.0
+	 */
+	public static FeatureEntry createRequires(String id, String version, String match, String filter, boolean isPlugin,
+			boolean isImport) {
 		FeatureEntry result = new FeatureEntry(id, version, isPlugin);
 		result.match = match;
 		result.isRequires = true;
@@ -45,10 +56,24 @@ public class FeatureEntry implements IPlatformEntry {
 		result.unpack = false;
 		if (filter != null)
 			result.setFilter(filter);
+		result.isImport = isImport;
 		return result;
 	}
 
+	/**
+	 * @deprecated Use
+	 *             {@link #createRequires(String, VersionRange, String, String, boolean, boolean)}
+	 */
+	@Deprecated(since = "1.6.0")
 	public static FeatureEntry createRequires(String id, VersionRange versionRange, String match, String filter, boolean isPlugin) {
+		return createRequires(id, versionRange, match, filter, isPlugin, true);
+	}
+
+	/**
+	 * @since 1.6.0
+	 */
+	public static FeatureEntry createRequires(String id, VersionRange versionRange, String match, String filter,
+			boolean isPlugin, boolean isImport) {
 		FeatureEntry result = new FeatureEntry(id, versionRange, isPlugin);
 		result.match = match;
 		result.isRequires = true;
@@ -56,6 +81,7 @@ public class FeatureEntry implements IPlatformEntry {
 		result.unpack = false;
 		if (filter != null)
 			result.setFilter(filter);
+		result.isImport = isImport;
 		return result;
 	}
 
@@ -225,5 +251,19 @@ public class FeatureEntry implements IPlatformEntry {
 
 	public void setPatch(boolean patch) {
 		this.isPatch = patch;
+	}
+
+	/**
+	 * @since 1.6.0
+	 */
+	public boolean isImport() {
+		return isImport;
+	}
+
+	/**
+	 * @since 1.6.0
+	 */
+	public void setImport(boolean isImport) {
+		this.isImport = isImport;
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/FeaturesAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/FeaturesAction.java
@@ -525,10 +525,13 @@ public class FeaturesAction extends AbstractPublisherAction {
 	}
 
 	private IMatchExpression<IInstallableUnit> getFilter(FeatureEntry entry) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		result.append("(&"); //$NON-NLS-1$
 		if (entry.getFilter() != null)
 			result.append(entry.getFilter());
+		if (entry.isImport()) {
+			result.append("(!(org.eclipse.equinox.p2.exclude.import=true))"); //$NON-NLS-1$
+		}
 		expandFilter(entry.getOS(), "osgi.os", result); //$NON-NLS-1$
 		expandFilter(entry.getWS(), "osgi.ws", result); //$NON-NLS-1$
 		expandFilter(entry.getArch(), "osgi.arch", result);//$NON-NLS-1$
@@ -539,7 +542,7 @@ public class FeaturesAction extends AbstractPublisherAction {
 		return InstallableUnit.parseFilter(result.toString());
 	}
 
-	private void expandFilter(String filter, String osgiFilterValue, StringBuffer result) {
+	private void expandFilter(String filter, String osgiFilterValue, StringBuilder result) {
 		if (filter != null && filter.length() != 0) {
 			StringTokenizer token = new StringTokenizer(filter, ","); //$NON-NLS-1$
 			if (token.countTokens() == 1)

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/FeaturesActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/FeaturesActionTest.java
@@ -219,9 +219,13 @@ public class FeaturesActionTest extends ActionTest {
 				assertEquals(ExpressionUtil.parseLDAP("(&(my.prop=foo)(osgi.os=win32))"),
 						require.getFilter().getParameters()[0]);
 			} else if (((IRequiredCapability) require).getName().equals("org.plug2")) {
-				assertEquals(ExpressionUtil.parseLDAP("(my.prop=foo)"), require.getFilter().getParameters()[0]);
+				assertEquals(
+						ExpressionUtil.parseLDAP("(&(my.prop=foo)(!(org.eclipse.equinox.p2.exclude.import=true)))"),
+						require.getFilter().getParameters()[0]);
 			} else if (((IRequiredCapability) require).getName().equals("org.foo2.feature.group")) {
-				assertEquals(ExpressionUtil.parseLDAP("(my.prop=foo)"), require.getFilter().getParameters()[0]);
+				assertEquals(
+						ExpressionUtil.parseLDAP("(&(my.prop=foo)(!(org.eclipse.equinox.p2.exclude.import=true)))"),
+						require.getFilter().getParameters()[0]);
 			}
 		}
 	}


### PR DESCRIPTION
Provide new FeatureEntry.createRequires methods that specify isImport, deprecating the older ones, and provide a field as well as accessors for isImport. Use that attribute in FeaturesAction.getFilter(FeatureEntry) to add a filter (!(org.eclipse.equinox.p2.exclude.import=true)) to the synthesized requirement.

Update StringBuffer to StringBuilder in the otherwise-modified files.

https://github.com/eclipse-equinox/p2/issues/138