### PR TITLE
Use the ECJ generated compiler logs to parse compiler problems

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
 				always {
 					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log', allowEmptyArchive: true
 					junit '**/target/surefire-reports/TEST-*.xml'
-					recordIssues tools: [eclipse(), java(), javaDoc(), mavenConsole()]
+					recordIssues tools: [eclipse(pattern: '**/target/compilelogs/*.xml'), javaDoc(), mavenConsole()]
 				}
 			}
 		}


### PR DESCRIPTION
Using the XML is much more reliable than parsing a log file