### PR TITLE
Make Projector extensible

### DIFF
--- a/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Projector.java
+++ b/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/internal/p2/director/Projector.java
@@ -333,12 +333,12 @@ public class Projector {
 	}
 
 	// Check whether the requirement is applicable
-	private boolean isApplicable(IRequirement req) {
+	protected boolean isApplicable(IRequirement req) {
 		IMatchExpression<IInstallableUnit> filter = req.getFilter();
 		return filter == null || filter.isMatch(selectionContext);
 	}
 
-	private boolean isApplicable(IInstallableUnit iu) {
+	protected boolean isApplicable(IInstallableUnit iu) {
 		IMatchExpression<IInstallableUnit> filter = iu.getFilter();
 		return filter == null || filter.isMatch(selectionContext);
 	}
@@ -487,7 +487,7 @@ public class Projector {
 		}
 	}
 
-	private Collection<IRequirement> getRequiredCapabilities(IInstallableUnit iu) {
+	protected Collection<IRequirement> getRequiredCapabilities(IInstallableUnit iu) {
 		boolean isFragment = iu instanceof IInstallableUnitFragment;
 		//Short-circuit for the case of an IInstallableUnit
 		if ((!isFragment) && iu.getMetaRequirements().size() == 0)


### PR DESCRIPTION
Currently the Projector has no way to influence what requirements/units are considered.

This makes some of the methods protected that are used to take a decision to allow customizing how the projector handles certain things.