### PR TITLE
Touch bundle affected by compiler implementation change

### DIFF
--- a/bundles/org.eclipse.equinox.p2.director/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.director/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1744


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1744