### PR TITLE
Migrate p2 engine to agent properties

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/.settings/.api_filters
+++ b/bundles/org.eclipse.equinox.p2.engine/.settings/.api_filters
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.equinox.p2.engine" version="2">
+    <resource path="src/org/eclipse/equinox/p2/engine/PhaseSetFactory.java" type="org.eclipse.equinox.p2.engine.PhaseSetFactory">
+        <filter id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.engine.PhaseSetFactory"/>
+                <message_argument value="PHASE_CHECK_TRUST"/>
+            </message_arguments>
+        </filter>
+        <filter id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.engine.PhaseSetFactory"/>
+                <message_argument value="PHASE_COLLECT"/>
+            </message_arguments>
+        </filter>
+        <filter id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.engine.PhaseSetFactory"/>
+                <message_argument value="PHASE_CONFIGURE"/>
+            </message_arguments>
+        </filter>
+        <filter id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.engine.PhaseSetFactory"/>
+                <message_argument value="PHASE_INSTALL"/>
+            </message_arguments>
+        </filter>
+        <filter id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.engine.PhaseSetFactory"/>
+                <message_argument value="PHASE_PROPERTY"/>
+            </message_arguments>
+        </filter>
+        <filter id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.engine.PhaseSetFactory"/>
+                <message_argument value="PHASE_UNCONFIGURE"/>
+            </message_arguments>
+        </filter>
+        <filter id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.engine.PhaseSetFactory"/>
+                <message_argument value="PHASE_UNINSTALL"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.engine;singleton:=true
-Bundle-Version: 2.9.100.qualifier
+Bundle-Version: 2.10.0.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.engine.EngineActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/DebugHelper.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/DebugHelper.java
@@ -129,7 +129,7 @@ public class DebugHelper {
 
 	public static String formatPhaseSet(PhaseSet phaseSet) {
 		StringBuilder buffer = new StringBuilder(phaseSet.getClass().getName());
-		buffer.append(DebugHelper.formatArray(Arrays.asList(phaseSet.getPhases()), false, false));
+		buffer.append(DebugHelper.formatArray(Arrays.asList(phaseSet.getPhaseIds()), false, false));
 		return buffer.toString();
 	}
 

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Engine.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Engine.java
@@ -83,7 +83,7 @@ public class Engine implements IEngine {
 			String property = context.getProperty(ProvisioningContext.CHECK_AUTHORITIES);
 			if (property == null) {
 				// Allow a system property to force the property.
-				property = EngineActivator.getContext().getProperty(ProvisioningContext.CHECK_AUTHORITIES);
+				property = EngineActivator.getProperty(ProvisioningContext.CHECK_AUTHORITIES, agent);
 				if (property == null) {
 					// Otherwise, if we are checking trust, also check the authorities.
 					if (Arrays.asList(phases.getPhaseIds()).contains(PhaseSetFactory.PHASE_CHECK_TRUST)) {
@@ -136,7 +136,7 @@ public class Engine implements IEngine {
 			monitor = new NullProgressMonitor();
 
 		ActionManager actionManager = agent.getService(ActionManager.class);
-		return phaseSet.validate(actionManager, iprofile, operands, context, monitor);
+		return phaseSet.validate(actionManager, iprofile, operands, context, agent, monitor);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/EngineActivator.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/EngineActivator.java
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *     Red Hat, Inc - fragments support added
@@ -22,6 +22,7 @@ import java.util.*;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
+import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.osgi.util.NLS;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -174,5 +175,16 @@ public class EngineActivator implements BundleActivator {
 			}
 		}
 		return result;
+	}
+
+	public static String getProperty(String key, IProvisioningAgent agent) {
+		if (agent != null) {
+			return agent.getProperty(key);
+		}
+		BundleContext bc = EngineActivator.getContext();
+		if (bc != null) {
+			return bc.getProperty(key);
+		}
+		return System.getProperty(key);
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/SimpleProfileRegistry.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/SimpleProfileRegistry.java
@@ -635,7 +635,7 @@ public class SimpleProfileRegistry implements IProfileRegistry, IAgentService {
 	 */
 	private boolean shouldGzipFile(Profile profile) {
 		//check system property controlling compression
-		String format = EngineActivator.getContext().getProperty(EngineActivator.PROP_PROFILE_FORMAT);
+		String format = EngineActivator.getProperty(EngineActivator.PROP_PROFILE_FORMAT, agent);
 		if (format != null && format.equals(EngineActivator.PROFILE_FORMAT_UNCOMPRESSED))
 			return false;
 

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/SurrogateProfileHandler.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/SurrogateProfileHandler.java
@@ -54,7 +54,8 @@ public class SurrogateProfileHandler implements ISurrogateProfileHandler {
 
 	private SoftReference<IProfile> cachedProfile;
 
-	private static void addSharedProfileBaseIUs(final IProfile sharedProfile, final Profile userProfile) {
+	private static void addSharedProfileBaseIUs(final IProfile sharedProfile, final Profile userProfile,
+			IProvisioningAgent agent) {
 		IQuery<IInstallableUnit> rootIUQuery = QueryUtil.createMatchQuery( //
 				"profileProperties[$0] == 'true' || (touchpointType != null && touchpointType.id == $1)", //$NON-NLS-1$
 				IProfile.PROP_PROFILE_ROOT_IU, NATIVE_TOUCHPOINT_TYPE);
@@ -62,8 +63,7 @@ public class SurrogateProfileHandler implements ISurrogateProfileHandler {
 		for (IInstallableUnit iu : rootIUs) {
 			userProfile.addInstallableUnit(iu);
 			userProfile.addInstallableUnitProperties(iu, sharedProfile.getInstallableUnitProperties(iu));
-			String profileLockedIUSystemProperty = EngineActivator.getContext()
-					.getProperty(IProfile.PROP_PROFILE_LOCKED_IU);
+			String profileLockedIUSystemProperty = EngineActivator.getProperty(IProfile.PROP_PROFILE_LOCKED_IU, agent);
 			if (profileLockedIUSystemProperty == null) {
 				userProfile.setInstallableUnitProperty(iu, IProfile.PROP_PROFILE_LOCKED_IU, IU_LOCKED);
 			} else {
@@ -150,7 +150,7 @@ public class SurrogateProfileHandler implements ISurrogateProfileHandler {
 
 	private synchronized SimpleProfileRegistry getProfileRegistry() {
 		if (profileRegistry == null) {
-			String installArea = EngineActivator.getContext().getProperty(OSGI_INSTALL_AREA);
+			String installArea = EngineActivator.getProperty(OSGI_INSTALL_AREA, agent);
 			try {
 				URL registryURL = new URL(installArea + P2_ENGINE_DIR + SimpleProfileRegistry.DEFAULT_STORAGE_DIR);
 				File sharedRegistryDirectory = URIUtil.toFile(URIUtil.toURI(registryURL));
@@ -233,7 +233,7 @@ public class SurrogateProfileHandler implements ISurrogateProfileHandler {
 			userProfile.setProperty(PROP_SURROGATE, Boolean.TRUE.toString());
 			userProfile.setSurrogateProfileHandler(this);
 			updateProperties(sharedProfile, userProfile);
-			addSharedProfileBaseIUs(sharedProfile, userProfile);
+			addSharedProfileBaseIUs(sharedProfile, userProfile, agent);
 
 			return userProfile;
 		}
@@ -279,7 +279,7 @@ public class SurrogateProfileHandler implements ISurrogateProfileHandler {
 		userProfile.setProperty(PROP_SURROGATE, Boolean.TRUE.toString());
 		userProfile.setSurrogateProfileHandler(this);
 		updateProperties(sharedProfile, userProfile);
-		addSharedProfileBaseIUs(sharedProfile, userProfile);
+		addSharedProfileBaseIUs(sharedProfile, userProfile, agent);
 
 		return userProfile;
 	}

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/AuthorityChecker.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/AuthorityChecker.java
@@ -179,7 +179,7 @@ public class AuthorityChecker {
 		var result = new LinkedHashSet<URI>();
 		var preferences = getEnngineProfilePreferences();
 		if (preferences != null) {
-			String defaultValue = EngineActivator.getContext().getProperty("p2.trustedAuthorities");
+			String defaultValue = EngineActivator.getProperty("p2.trustedAuthorities", agent);
 			if (defaultValue == null) {
 				defaultValue = "https://download.eclipse.org https://archive.eclipse.org";
 			} else {

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/CertificateChecker.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/CertificateChecker.java
@@ -490,7 +490,7 @@ public class CertificateChecker {
 	 * Return the policy on unsigned content.
 	 */
 	private String getUnsignedContentPolicy() {
-		String policy = EngineActivator.getContext().getProperty(EngineActivator.PROP_UNSIGNED_POLICY);
+		String policy = EngineActivator.getProperty(EngineActivator.PROP_UNSIGNED_POLICY, agent);
 		if (policy == null)
 			policy = EngineActivator.UNSIGNED_PROMPT;
 		return policy;

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/p2/engine/PhaseSetFactory.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/p2/engine/PhaseSetFactory.java
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -15,7 +15,6 @@ package org.eclipse.equinox.p2.engine;
 
 import java.util.*;
 import org.eclipse.equinox.internal.p2.engine.*;
-import org.eclipse.equinox.internal.p2.engine.phases.*;
 
 /**
  * @since 2.0
@@ -23,58 +22,61 @@ import org.eclipse.equinox.internal.p2.engine.phases.*;
  */
 public class PhaseSetFactory {
 
-	private static final boolean forcedUninstall = Boolean.parseBoolean(EngineActivator.getContext().getProperty("org.eclipse.equinox.p2.engine.forcedUninstall")); //$NON-NLS-1$
-
 	/**
 	 * A phase id (value "checkTrust") describing the certificate trust check phase.
 	 * This phase examines the code signing certificates of the artifacts being installed
 	 * to ensure they are signed and trusted by the running system.
 	 */
-	public static String PHASE_CHECK_TRUST = "checkTrust"; //$NON-NLS-1$
+	public static final String PHASE_CHECK_TRUST = "checkTrust"; //$NON-NLS-1$
 	/**
 	 * A phase id (value "collect") describing the collect phase.
 	 * This phase gathers all the artifacts to be installed, typically by copying them
 	 * from some repository into a suitable local location for the application being installed.
 	 */
-	public static String PHASE_COLLECT = "collect"; //$NON-NLS-1$
+	public static final String PHASE_COLLECT = "collect"; //$NON-NLS-1$
 	/**
 	 * A phase id (value "configure") describing the configuration phase.
 	 * This phase writes configuration data related to the software being provisioned.
 	 * Until configuration occurs the end user of the software will be have access to
 	 * the installed functionality.
 	 */
-	public static String PHASE_CONFIGURE = "configure"; //$NON-NLS-1$
+	public static final String PHASE_CONFIGURE = "configure"; //$NON-NLS-1$
 	/**
 	 * A phase id (value "install") describing the install phase.
 	 * This phase performs any necessary transformations on the downloaded
 	 * artifacts to put them in the correct shape for the running application, such
 	 * as decompressing or moving content, setting file permissions, etc).
 	 */
-	public static String PHASE_INSTALL = "install"; //$NON-NLS-1$
+	public static final String PHASE_INSTALL = "install"; //$NON-NLS-1$
 	/**
 	 * A phase id (value "property") describing the property modification phase.
 	 * This phase performs changes to profile properties.
 	 */
-	public static String PHASE_PROPERTY = "property"; //$NON-NLS-1$
+	public static final String PHASE_PROPERTY = "property"; //$NON-NLS-1$
 	/**
 	 * A phase id (value "unconfigure") describing the unconfigure phase.
 	 * This phase removes configuration data related to the software being removed.
 	 * This phase is the inverse of the changes performed in the configure phase.
 	 */
-	public static String PHASE_UNCONFIGURE = "unconfigure"; //$NON-NLS-1$
+	public static final String PHASE_UNCONFIGURE = "unconfigure"; //$NON-NLS-1$
 	/**
 	 * A phase id (value "uninstall") describing the uninstall phase.
 	 * This phase removes artifacts from the system being provisioned that are
 	 * no longer required in the new profile.
 	 */
-	public static String PHASE_UNINSTALL = "uninstall"; //$NON-NLS-1$
+	public static final String PHASE_UNINSTALL = "uninstall"; //$NON-NLS-1$
+
+	/**
+	 * @since 2.10
+	 */
+	public static final String NATIVE_ARTIFACTS = "nativeArtifacts"; //$NON-NLS-1$
 
 	private static final List<String> ALL_PHASES_LIST = Arrays.asList(new String[] {PHASE_COLLECT, PHASE_UNCONFIGURE, PHASE_UNINSTALL, PHASE_PROPERTY, PHASE_CHECK_TRUST, PHASE_INSTALL, PHASE_CONFIGURE});
 
 	/**
 	 * Creates a default phase set that covers all the provisioning operations.
 	 * Phases can be specified for exclusion.
-	 * 
+	 *
 	 * @param exclude - A set of bit options that specify the phases to exclude.
 	 * See {@link PhaseSetFactory} for possible options
 	 * @return the {@link PhaseSet}
@@ -91,35 +93,20 @@ public class PhaseSetFactory {
 	/**
 	 * Creates a default phase set that covers all the provisioning operations.
 	 * Phases can be specified for inclusion.
-	 * 
-	 * @param include - A set of bit options that specify the phases to include.
-	 * See {@link PhaseSetFactory} for possible options
+	 *
+	 * @param include - A set of bit options that specify the phases to include. See
+	 *                {@link PhaseSetFactory} for possible options
 	 * @return the {@link PhaseSet}
 	 */
 	public static final IPhaseSet createPhaseSetIncluding(String[] include) {
-		if (include == null || include.length == 0)
+		if (include == null || include.length == 0) {
 			return new PhaseSet(new Phase[0]);
-		List<String> includeList = Arrays.asList(include);
-		ArrayList<Phase> phases = new ArrayList<>();
-		if (includeList.contains(PHASE_COLLECT))
-			phases.add(new Collect(100));
-		if (includeList.contains(PHASE_CHECK_TRUST))
-			phases.add(new CheckTrust(10));
-		if (includeList.contains(PHASE_UNCONFIGURE))
-			phases.add(new Unconfigure(10, forcedUninstall));
-		if (includeList.contains(PHASE_UNINSTALL))
-			phases.add(new Uninstall(50, forcedUninstall));
-		if (includeList.contains(PHASE_PROPERTY))
-			phases.add(new Property(1));
-		if (includeList.contains(PHASE_INSTALL))
-			phases.add(new Install(50));
-		if (includeList.contains(PHASE_CONFIGURE))
-			phases.add(new Configure(10));
-		return new PhaseSet(phases.toArray(new Phase[phases.size()]));
+		}
+		return new PhaseSet(include);
 	}
 
 	public static IPhaseSet createDefaultPhaseSet() {
-		return createPhaseSetIncluding(ALL_PHASES_LIST.toArray(new String[ALL_PHASES_LIST.size()]));
+		return createPhaseSetIncluding(ALL_PHASES_LIST.toArray(String[]::new));
 	}
 
 	public static ISizingPhaseSet createSizingPhaseSet() {

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/engine/PhaseSetTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/engine/PhaseSetTest.java
@@ -75,7 +75,7 @@ public class PhaseSetTest extends AbstractProvisioningTest {
 
 	public void testNullPhases() {
 		assertThrows(IllegalArgumentException.class, () ->
-			new PhaseSet(null) {
+			new PhaseSet((Phase[]) null) {
 				// empty PhaseSet
 		});
 	}


### PR DESCRIPTION
Now that agent properties are possible we should use them in the engine, to not rely on only static OSGi context properties.