### PR TITLE
TarFile: fix deprecated finalize()

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/TarFile.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/TarFile.java
@@ -117,9 +117,4 @@ public class TarFile implements Closeable {
 	public String getName() {
 		return file.getPath();
 	}
-
-	@Override
-	protected void finalize() throws Throwable {
-		close();
-	}
 }


### PR DESCRIPTION
finalize() not needed - only used as autoclosable.