### PR TITLE
Unwind ExecutionException when testing for retry exceptions

### DIFF
--- a/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryStatusHelper.java
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryStatusHelper.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.util.concurrent.ExecutionException;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
@@ -135,7 +136,8 @@ public abstract class RepositoryStatusHelper {
 			// We don't use instanceof operator since we want
 			// the explicit class, not subclasses.
 			//
-			if (tc != RuntimeException.class && tc != InvocationTargetException.class && tc != IOException.class)
+			if (tc != RuntimeException.class && tc != InvocationTargetException.class && tc != IOException.class
+					&& tc != ExecutionException.class)
 				break;
 
 			Throwable cause = t.getCause();


### PR DESCRIPTION
The httpclientjava implementation can throw an ExecutionException, e.g., when jdk.internal.net.http.Http2Connection.handleGoAway(GoAwayFrame) is called.  This should be unwound so that a retry will be attempted.