### PR TITLE
Adjust maven metadata to the ones actually published to central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ bin/
 .META-INF_*
 pom.tycho
 .tycho-consumer-pom.xml
+.flattened-pom.xml
 apiAnalyzer-workspace/

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pbuild-individual-bundles
 -Dtycho.surefire.deleteWorkDir=true
+-Dtycho.localArtifacts=ignore

--- a/bundles/org.eclipse.equinox.p2.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests/pom.xml
@@ -8,7 +8,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.eclipse.equinox.p2</groupId>
+		<groupId>org.eclipse.platform</groupId>
 		<artifactId>rt.equinox.p2</artifactId>
 		<version>${releaseVersion}${qualifier}</version>
 		<relativePath>../../</relativePath>
@@ -39,7 +39,7 @@
 	<dependencies>
 		<!-- The tests require the reconciler product -->
 		<dependency>
-			<groupId>org.eclipse.equinox.p2</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>org.eclipse.equinox.p2.reconciler</artifactId>
 			<version>1.1.0-SNAPSHOT</version>
 			<type>pom</type>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.eclipse.equinox.p2</groupId>
+    <groupId>org.eclipse.platform</groupId>
     <artifactId>rt.equinox.p2</artifactId>
     <version>${releaseVersion}${qualifier}</version>
     <relativePath>../pom.xml</relativePath>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 
-  <groupId>org.eclipse.equinox.p2</groupId>
+  <groupId>org.eclipse.platform</groupId>
   <artifactId>rt.equinox.p2</artifactId>
   <packaging>pom</packaging>
   <version>${releaseVersion}${qualifier}</version>
@@ -125,6 +125,18 @@
             <goals>
               <goal>p2-metadata</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-update-consumer-pom</id>
+            <configuration>
+				<skipPomGeneration>false</skipPomGeneration>
+			</configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Currently the project is configured to use the org.eclipse.equinox.p2 group id but it is actually published to org.eclipse.platform. That is both confusing and makes the metadata in p2 pointless and not allows to use local build artifacts (e.g. for Tycho).

This changes the group id and configures the update-consumer-pom to create a pom that can be used in a local maven setup similar to one published on maven central.

This is what is generated by Tycho for example:
```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.eclipse.platform</groupId>
  <artifactId>org.eclipse.equinox.p2.publisher.eclipse</artifactId>
  <version>1.6.0-SNAPSHOT</version>
  <name>[bundle] Equinox Provisioning Publisher for Eclipse</name>
  <organization>
    <name>Eclipse.org - Equinox</name>
  </organization>
  <dependencies>
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.equinox.p2.metadata.repository</artifactId>
      <version>1.5.300-SNAPSHOT</version>
      <scope>compile</scope>
      <optional>false</optional>
    </dependency>
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.equinox.simpleconfigurator.manipulator</artifactId>
      <version>2.3.100-SNAPSHOT</version>
      <scope>compile</scope>
      <optional>false</optional>
    </dependency>
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.equinox.frameworkadmin</artifactId>
      <version>2.3.100-SNAPSHOT</version>
      <scope>compile</scope>
      <optional>false</optional>
    </dependency>
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.equinox.p2.metadata</artifactId>
      <version>2.9.0-SNAPSHOT</version>
      <scope>compile</scope>
      <optional>false</optional>
    </dependency>
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.equinox.p2.artifact.repository</artifactId>
      <version>1.5.300-SNAPSHOT</version>
      <scope>compile</scope>
      <optional>false</optional>
    </dependency>
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.equinox.frameworkadmin.equinox</artifactId>
      <version>1.3.100-SNAPSHOT</version>
      <scope>compile</scope>
      <optional>false</optional>
    </dependency>
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.equinox.p2.core</artifactId>
      <version>2.11.0-SNAPSHOT</version>
      <scope>compile</scope>
      <optional>false</optional>
    </dependency>
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.equinox.p2.repository</artifactId>
      <version>2.8.100-SNAPSHOT</version>
      <scope>compile</scope>
      <optional>false</optional>
    </dependency>
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.equinox.p2.publisher</artifactId>
      <version>1.9.100-SNAPSHOT</version>
      <scope>compile</scope>
      <optional>false</optional>
    </dependency>
    <dependency>
      <groupId>org.bouncycastle</groupId>
      <artifactId>bcpg-jdk18on</artifactId>
      <version>1.77</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.bouncycastle</groupId>
      <artifactId>bcprov-jdk18on</artifactId>
      <version>1.77</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.tukaani</groupId>
      <artifactId>xz</artifactId>
      <version>1.9</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.equinox.p2.jarprocessor</artifactId>
      <version>1.3.300-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.osgi</groupId>
      <artifactId>org.osgi.service.prefs</artifactId>
      <version>1.1.2</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.equinox.simpleconfigurator</artifactId>
      <version>1.5.100-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
</project>
```