### PR TITLE
Use copy in provided cap

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/ProvidedCapability.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/ProvidedCapability.java
@@ -16,7 +16,6 @@
  *******************************************************************************/
 package org.eclipse.equinox.internal.p2.metadata;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,8 +65,7 @@ public class ProvidedCapability implements IProvidedCapability, IMemberProvider 
 		} else {
 			resolvedProps.put(PROPERTY_VERSION, Version.emptyVersion);
 		}
-
-		this.properties = Collections.unmodifiableMap(resolvedProps);
+		this.properties = Map.copyOf(resolvedProps);
 	}
 
 	public ProvidedCapability(String namespace, String name, Version version) {

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/JREAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/JREAction.java
@@ -16,52 +16,28 @@
  ******************************************************************************/
 package org.eclipse.equinox.p2.publisher.actions;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleDescriptor.Exports;
 import java.net.URL;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.MultiStatus;
-import org.eclipse.core.runtime.Status;
+import java.util.*;
+import org.eclipse.core.runtime.*;
 import org.eclipse.equinox.internal.p2.core.helpers.CollectionUtils;
 import org.eclipse.equinox.internal.p2.metadata.ArtifactKey;
 import org.eclipse.equinox.internal.p2.publisher.Activator;
 import org.eclipse.equinox.internal.p2.publisher.Messages;
-import org.eclipse.equinox.p2.metadata.IArtifactKey;
-import org.eclipse.equinox.p2.metadata.IInstallableUnit;
-import org.eclipse.equinox.p2.metadata.IProvidedCapability;
-import org.eclipse.equinox.p2.metadata.MetadataFactory;
+import org.eclipse.equinox.p2.metadata.*;
 import org.eclipse.equinox.p2.metadata.MetadataFactory.InstallableUnitDescription;
 import org.eclipse.equinox.p2.metadata.MetadataFactory.InstallableUnitFragmentDescription;
 import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.equinox.p2.metadata.VersionRange;
-import org.eclipse.equinox.p2.publisher.AbstractPublisherAction;
-import org.eclipse.equinox.p2.publisher.IPublisherInfo;
-import org.eclipse.equinox.p2.publisher.IPublisherResult;
+import org.eclipse.equinox.p2.publisher.*;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactDescriptor;
 import org.eclipse.equinox.spi.p2.publisher.PublisherHelper;
 import org.eclipse.osgi.util.ManifestElement;
 import org.eclipse.osgi.util.NLS;
-import org.osgi.framework.BundleException;
-import org.osgi.framework.Constants;
-import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.*;
 
 public class JREAction extends AbstractPublisherAction {
 	private static final String DEFAULT_JRE_NAME = "a.jre"; //$NON-NLS-1$
@@ -248,11 +224,8 @@ public class JREAction extends AbstractPublisherAction {
 				Version parsedVersion = Version.parseVersion(rawVersion);
 
 				// complete record -> store
-				Map<String, Object> capAttrs = new HashMap<>();
-				capAttrs.put(NAMESPACE_OSGI_EE, eeName);
-				capAttrs.put(VERSION_OSGI_EE, parsedVersion);
-
-				parsingResult.add(MetadataFactory.createProvidedCapability(NAMESPACE_OSGI_EE, capAttrs));
+				parsingResult.add(MetadataFactory.createProvidedCapability(NAMESPACE_OSGI_EE,
+						Map.of(NAMESPACE_OSGI_EE, eeName, VERSION_OSGI_EE, parsedVersion)));
 
 			} catch (IllegalArgumentException e) {
 				parsingStatus.add(newErrorStatus(NLS.bind(Messages.message_eeInvalidVersionAttribute, rawVersion), e));


### PR DESCRIPTION
in the context of Tycho it could easily happen that there are hundred of
thousands of ProvidedCapability's. Each of them currently carry a
HashMap that is then wrapped in an unmodifiable collection.

This replaces it with Map.copyOf(...) now to ensure it is unmodifiable
and only ever contains the exact number of entries saving a few bytes
for object references and possible null table entries.