### PR TITLE
UpdateSitePublisher -addJREIU argument doesn't add current JVM

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/JREAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/JREAction.java
@@ -40,9 +40,12 @@ import org.eclipse.osgi.util.NLS;
 import org.osgi.framework.*;
 
 public class JREAction extends AbstractPublisherAction {
+
+	private static final int RUNTIME_VERSION = Runtime.version().feature();
+
 	private static final String DEFAULT_JRE_NAME = "a.jre"; //$NON-NLS-1$
-	private static final Version DEFAULT_JRE_VERSION = Version.parseVersion("17.0"); //$NON-NLS-1$
-	private static final String DEFAULT_PROFILE = "JavaSE-17"; //$NON-NLS-1$
+	private static final Version DEFAULT_JRE_VERSION = Version.parseVersion(RUNTIME_VERSION + ".0"); //$NON-NLS-1$
+	private static final String DEFAULT_PROFILE = "JavaSE-" + RUNTIME_VERSION; //$NON-NLS-1$
 	private static final String PROFILE_LOCATION = "jre.action.profile.location"; //$NON-NLS-1$
 	private static final String PROFILE_NAME = "osgi.java.profile.name"; //$NON-NLS-1$
 	private static final String PROFILE_TARGET_VERSION = "org.eclipse.jdt.core.compiler.codegen.targetPlatform"; //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/JREActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/JREActionTest.java
@@ -36,7 +36,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.ZipInputStream;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.equinox.internal.p2.core.helpers.FileUtils;
@@ -146,9 +145,9 @@ public class JREActionTest extends ActionTest {
 	@Test
 	public void testDefaultJavaProfile() throws Exception {
 		performAction(new JREAction((String) null));
-
+		int runtimeVersion = Runtime.version().feature();
 		// these assertions need to be changed each time the default java profile, hardcoded in o.e.e.p2.publisher.actions.JREAction, is changed;
-		verifyMetadataIU("a.jre.javase", 226, 23, Version.parseVersion("17.0.0"));
+		verifyMetadataIU("a.jre.javase", 226, 23, Version.parseVersion(runtimeVersion + ".0.0"));
 		// verifyConfigIU(DEFAULT_JRE_NAME, DEFAULT_JRE_VERSION); // TODO config IU is not needed!?
 	}
 


### PR DESCRIPTION
Don't hard code "default" JRE version if we "guess one" and create some profile based on current JRE packages. 
Just read & use the version from the running JRE.

Fixes https://github.com/eclipse-equinox/p2/issues/461