### PR TITLE
Ignore the UnsupportedOperationException in case of descriptor removal

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/Messages.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/Messages.java
@@ -57,6 +57,8 @@ public class Messages extends NLS {
 	public static String MirrorLog_Exception_Occurred;
 
 	public static String MirrorRequest_multipleDownloadProblems;
+
+	public static String MirrorRequest_removal_failed;
 	public static String MirrorRequest_transferFailed;
 
 	public static String exception_unableToCreateParentDir;

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/messages.properties
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/messages.properties
@@ -48,6 +48,7 @@ exception_noComparators = No Artifact Comparators are available.
 MirrorLog_Console_Log=Logging to the console instead.
 MirrorLog_Exception_Occurred=An exception occurred while writing to the log:
 MirrorRequest_multipleDownloadProblems=Multiple problems occurred while downloading.
+MirrorRequest_removal_failed=Target repository contains descriptor after failed download but it can't be removed: {0}
 MirrorRequest_transferFailed=Failed to transfer artifact {0}.
 
 exception_unsupportedAddToComposite = Cannot add descriptors to a composite repository.


### PR DESCRIPTION
If removal of the errornous descriptor failed this can have different reasons:

1) it was never added because the target is not capable of downloading 2) the repository does not support removal of descriptors 3) some bug in the implementation

in any case we want to report the original error an not an error that says we can't remove the descriptor.