### PR TITLE
Correctly consider cardinality based on the directives

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/BundlesAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/BundlesAction.java
@@ -398,10 +398,10 @@ public class BundlesAction extends AbstractPublisherAction {
 		Map<String, String> directives = req.getDirectives();
 
 		String capFilter = directives.get(Namespace.REQUIREMENT_FILTER_DIRECTIVE);
-		boolean optional = directives.get(Namespace.REQUIREMENT_RESOLUTION_DIRECTIVE) == Namespace.RESOLUTION_OPTIONAL;
-		boolean greedy = optional ? INSTALLATION_GREEDY.equals(directives.get(INSTALLATION_DIRECTIVE)) : true;
-
-		IRequirement requireCap = MetadataFactory.createRequirement(namespace, capFilter, null, optional ? 0 : 1, 1,
+		boolean greedy = isGreedy(directives);
+		int minCard = getMinCardinality(directives);
+		int maxCard = getMaxCardinality(directives);
+		IRequirement requireCap = MetadataFactory.createRequirement(namespace, capFilter, null, minCard, maxCard,
 				greedy);
 		reqsDeps.add(requireCap);
 	}
@@ -414,12 +414,29 @@ public class BundlesAction extends AbstractPublisherAction {
 		Map<String, String> directives = req.getDirectives();
 
 		String capFilter = directives.get(Namespace.REQUIREMENT_FILTER_DIRECTIVE);
-		boolean optional = directives.get(Namespace.REQUIREMENT_RESOLUTION_DIRECTIVE) == Namespace.RESOLUTION_OPTIONAL;
-		boolean greedy = optional ? INSTALLATION_GREEDY.equals(directives.get(INSTALLATION_DIRECTIVE)) : true;
-
-		IRequirement requireCap = MetadataFactory.createRequirement(namespace, capFilter, null, optional ? 0 : 1, 1,
+		boolean greedy = isGreedy(directives);
+		int minCard = getMinCardinality(directives);
+		int maxCard = getMaxCardinality(directives);
+		IRequirement requireCap = MetadataFactory.createRequirement(namespace, capFilter, null, minCard, maxCard,
 				greedy, bd.getSymbolicName());
 		reqsDeps.add(requireCap);
+	}
+
+	protected int getMinCardinality(Map<String, String> directives) {
+		return Namespace.RESOLUTION_OPTIONAL.equals(directives.get(Namespace.REQUIREMENT_RESOLUTION_DIRECTIVE)) ? 0 : 1;
+	}
+
+	protected int getMaxCardinality(Map<String, String> directives) {
+		return Namespace.CARDINALITY_MULTIPLE.equals(directives.get(Namespace.REQUIREMENT_CARDINALITY_DIRECTIVE))
+				? Integer.MAX_VALUE
+				: 1;
+	}
+
+	protected boolean isGreedy(Map<String, String> directives) {
+		if (getMinCardinality(directives) == 0) {
+			return INSTALLATION_GREEDY.equals(directives.get(INSTALLATION_DIRECTIVE));
+		}
+		return true;
 	}
 
 	protected void addCapability(List<IProvidedCapability> caps, GenericDescription provideCapDesc,

--- a/bundles/org.eclipse.equinox.p2.tests/testData/requireMultiple/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests/testData/requireMultiple/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: require.multiple
+Bundle-SymbolicName: require.multiple
+Bundle-Version: 1.0.0
+Require-Capability: single.required;filter:="(objectClass=testme)",
+ single.optional;filter:="(objectClass=testme)";resolution:=optional,
+ multiple.required;filter:="(objectClass=testme)";cardinality:=multiple,
+ multiple.optional;filter:="(objectClass=testme)";cardinality:=multiple;resolution:=optional


### PR DESCRIPTION
Currently the BundlesAction uses either 0 or 1 as the cardinality but actually a requirement can be a multi-cardinality as well.

This adds new dedicated methods to not duplicate the computation and a testcase that ensures all combination are covered and correctly translated.