### PR TITLE
Absence of an unpack attribute must not result in BundleShapeAdvice

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/FeaturesAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/FeaturesAction.java
@@ -186,7 +186,7 @@ public class FeaturesAction extends AbstractPublisherAction {
 	private void createBundleShapeAdvice(Feature feature, IPublisherInfo publisherInfo) {
 		FeatureEntry entries[] = feature.getEntries();
 		for (FeatureEntry entry : entries) {
-			if (entry.isUnpack() && entry.isPlugin() && !entry.isRequires())
+			if (entry.unpackSet() && entry.isUnpack() && entry.isPlugin() && !entry.isRequires())
 				publisherInfo.addAdvice(new BundleShapeAdvice(entry.getId(), Version.parseVersion(entry.getVersion()), IBundleShapeAdvice.DIR));
 		}
 	}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/AbstractProvisioningTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/AbstractProvisioningTest.java
@@ -739,7 +739,7 @@ public abstract class AbstractProvisioningTest extends TestCase {
 			}
 	}
 
-	public static void writeBuffer(File outputFile, StringBuilder buffer) throws IOException {
+	public static void writeBuffer(File outputFile, CharSequence buffer) throws IOException {
 		outputFile.getParentFile().mkdirs();
 		try (FileOutputStream stream = new FileOutputStream(outputFile)) {
 			stream.write(buffer.toString().getBytes());


### PR DESCRIPTION
Currently the FeaturesAction assumes that the unpack attribute is always set, if that is not the case it leads to unexpected results because then unpack=true is assumed always. This is especially dangerous as PDE since 2023-12 release removes the attributes and Tycho assume they are false by default the same as PDE has done in the past when adding new items.

To mitigate this this adds an additional check to only evaluate the unpack if it is set, together with a testcase that covers all possible combinations.

I give +1 as project lead for this really late fix but I think it is urgent enough as it has unexpected side-effects for users using already released PDE that will likely be hard to discover and the previous state was to always specify this attribute so existing setup won't be affected. Waiting for one more release to fix this seems therefore not acceptable for me.