### PR TITLE
Ensure the product *.ini is loaded and saved using the native encoding

### DIFF
--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.frameworkadmin.equinox;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Import-Package: org.eclipse.equinox.frameworkadmin;version="[2.0.0,3.0.0)",

--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EclipseLauncherParser.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EclipseLauncherParser.java
@@ -338,7 +338,8 @@ public class EclipseLauncherParser {
 
 		// only write the file if we actually have content
 		if (newlines.size() > 0) {
-			try (BufferedWriter bw = new BufferedWriter(new FileWriter(launcherConfigFile));) {
+			try (BufferedWriter bw = new BufferedWriter(
+					new FileWriter(launcherConfigFile, FileUtils.getNativeCharset()));) {
 				for (String arg : newlines) {
 					if (arg == null)
 						continue;

--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/utils/FileUtils.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/utils/FileUtils.java
@@ -16,6 +16,7 @@ package org.eclipse.equinox.internal.frameworkadmin.equinox.utils;
 
 import java.io.*;
 import java.net.*;
+import java.nio.charset.Charset;
 import java.util.*;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.URIUtil;
@@ -214,9 +215,12 @@ public class FileUtils {
 	 * Loads an ini file, returning a list of all non-blank lines in the file. Like
 	 * eclipseConfig.c/readConfigFile() comment lines ('#' its first character) are
 	 * skipped too.
+	 * 
+	 * This must load the content using the native system encoding because that's
+	 * what the native launcher executable does.
 	 */
 	public static List<String> loadFile(File file) throws IOException {
-		try (BufferedReader br = new BufferedReader(new FileReader(file));) {
+		try (BufferedReader br = new BufferedReader(new FileReader(file, getNativeCharset()));) {
 			String line;
 			List<String> list = new ArrayList<>();
 			while ((line = br.readLine()) != null) {
@@ -228,6 +232,15 @@ public class FileUtils {
 			}
 			return list;
 		}
+	}
+
+	/**
+	 * The encoding used for reading and writing the ini file. This must be the
+	 * native encoding; as of Java 21, the default encoding is UTF-8.
+	 */
+	public static Charset getNativeCharset() {
+		String encoding = System.getProperty("native.encoding"); //$NON-NLS-1$
+		return encoding != null ? Charset.forName(encoding) : Charset.defaultCharset();
 	}
 
 }

--- a/features/org.eclipse.equinox.p2.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.core.feature"
       label="%featureName"
-      version="1.7.100.qualifier"
+      version="1.7.200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.extras.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.extras.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.extras.feature"
       label="%featureName"
-      version="1.4.2300.qualifier"
+      version="1.4.2400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.rcp.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.rcp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.rcp.feature"
       label="%featureName"
-      version="1.4.2300.qualifier"
+      version="1.4.2400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.sdk/feature.xml
+++ b/features/org.eclipse.equinox.p2.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.sdk"
       label="%featureName"
-      version="3.11.2300.qualifier"
+      version="3.11.2400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.user.ui/feature.xml
+++ b/features/org.eclipse.equinox.p2.user.ui/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.user.ui"
       label="%featureName"
-      version="2.4.2300.qualifier"
+      version="2.4.2400.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.server.p2/feature.xml
+++ b/features/org.eclipse.equinox.server.p2/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.p2"
       label="%featureName"
-      version="1.12.1200.qualifier"
+      version="1.12.1300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
The native launcher executable reads the product *.ini, e.g., eclipse.ini, using the native system encoding. Currently the *.ini is loaded and saved in the launched Java application using the system default encoding, but in Java 21 the default encoding is always UTF-8 so we need to be more careful to always use the native encoding regardless of the default encoding.