### PR TITLE
Enhance p2 director with "addJREIU" option.

### DIFF
--- a/bundles/org.eclipse.equinox.p2.director.app/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.director.app/META-INF/MANIFEST.MF
@@ -2,12 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.director.app;singleton:=true
-Bundle-Version: 1.3.300.qualifier
+Bundle-Version: 1.3.400.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.director.app.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.director.app;x-internal:=true
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.5.0,4.0.0)"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.5.0,4.0.0)",
+ org.eclipse.equinox.p2.publisher;bundle-version="[1.9.200,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.bouncycastle.openpgp,

--- a/bundles/org.eclipse.equinox.p2.director.app/src/org/eclipse/equinox/internal/p2/director/app/DirectorApplication.java
+++ b/bundles/org.eclipse.equinox.p2.director.app/src/org/eclipse/equinox/internal/p2/director/app/DirectorApplication.java
@@ -59,6 +59,7 @@ import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.equinox.p2.metadata.VersionRange;
 import org.eclipse.equinox.p2.planner.IPlanner;
 import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
+import org.eclipse.equinox.p2.publisher.actions.JREAction;
 import org.eclipse.equinox.p2.query.*;
 import org.eclipse.equinox.p2.repository.IRepository;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepositoryManager;
@@ -421,6 +422,9 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
 	private static final CommandLineOption OPTION_IGNORED = new CommandLineOption(new String[] { //
 			"-showLocation", "-eclipse.password", "-eclipse.keyring" }, //$NON-NLS-1$ //$NON-NLS-2$//$NON-NLS-3$
 			null, ""); //$NON-NLS-1$
+	private static final CommandLineOption OPTION_ADD_JRE_IU = new CommandLineOption(new String[] { //
+			"-addJREIU" }, //$NON-NLS-1$
+			null, Messages.Help_Add_JRE_IU);
 
 	private static final Integer EXIT_ERROR = 13;
 	static private final String FLAVOR_DEFAULT = "tooling"; //$NON-NLS-1$
@@ -579,6 +583,7 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
 	private boolean targetAgentIsSelfAndUp;
 	private boolean noArtifactRepositorySpecified;
 	private AvoidTrustPromptService trustService;
+	private boolean addJREIU;
 
 	protected ProfileChangeRequest buildProvisioningRequest(IProfile profile, Collection<IInstallableUnit> installs,
 			Collection<IInstallableUnit> uninstalls) {
@@ -1058,6 +1063,10 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
 			context.setProperty(ProvisioningContext.FOLLOW_REPOSITORY_REFERENCES, String.valueOf(followReferences));
 			context.setProperty(FOLLOW_ARTIFACT_REPOSITORY_REFERENCES, String.valueOf(followReferences));
 
+			if (addJREIU) {
+				context.setExtraInstallableUnits(List.of(JREAction.createJREIU()));
+			}
+
 			ProfileChangeRequest request = buildProvisioningRequest(profile, installs, uninstalls);
 			printRequest(request);
 
@@ -1361,6 +1370,11 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
 				continue;
 			}
 
+			if (OPTION_ADD_JRE_IU.isOption(opt)) {
+				this.addJREIU = true;
+				continue;
+			}
+
 			if (opt != null && opt.length() > 0)
 				throw new ProvisionException(NLS.bind(Messages.unknown_option_0, opt));
 		}
@@ -1593,6 +1607,7 @@ public class DirectorApplication implements IApplication, ProvisioningListener {
 				OPTION_TRUSTED_PGP_KEYS, //
 				OPTION_TRUSTED_CERTIFCATES, //
 				OPTION_HELP, //
+				OPTION_ADD_JRE_IU, //
 		};
 
 		for (CommandLineOption allOption : allOptions) {

--- a/bundles/org.eclipse.equinox.p2.director.app/src/org/eclipse/equinox/internal/p2/director/app/Messages.java
+++ b/bundles/org.eclipse.equinox.p2.director.app/src/org/eclipse/equinox/internal/p2/director/app/Messages.java
@@ -117,6 +117,8 @@ public class Messages extends NLS {
 
 	public static String Cant_write_in_destination;
 
+	public static String Help_Add_JRE_IU;
+
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/bundles/org.eclipse.equinox.p2.director.app/src/org/eclipse/equinox/internal/p2/director/app/messages.properties
+++ b/bundles/org.eclipse.equinox.p2.director.app/src/org/eclipse/equinox/internal/p2/director/app/messages.properties
@@ -89,3 +89,4 @@ Cannot_set_iu_profile_property_iu_does_not_exist=Unable to set IU profile proper
 Unmatched_iu_profile_property_key_value=Unmatched IU profile property key/value pair: {0}.
 Bad_format=Bad format ({0}) in IU profile properties file: {1}.
 Cant_write_in_destination=The operation you've requested can not be performed because the folder {0} is read only.
+Help_Add_JRE_IU=Include a default JRE installable unit as an extra IU. This IU satisfies JRE dependencies in the case that the content metadata does not otherwise provide an IU for that purpose.

--- a/bundles/org.eclipse.equinox.p2.publisher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.publisher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.publisher;singleton:=true
-Bundle-Version: 1.9.100.qualifier
+Bundle-Version: 1.9.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.publisher.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -20,7 +20,8 @@ Export-Package: org.eclipse.equinox.internal.p2.publisher;
  org.eclipse.equinox.p2.publisher.actions;
   x-friends:="org.eclipse.equinox.p2.updatesite,
    org.eclipse.equinox.p2.directorywatcher,
-   org.eclipse.equinox.p2.publisher.eclipse",
+   org.eclipse.equinox.p2.publisher.eclipse,
+   org.eclipse.equinox.p2.director.app",
  org.eclipse.equinox.spi.p2.publisher;x-friends:="org.eclipse.equinox.p2.updatesite,org.eclipse.equinox.p2.publisher.eclipse"
 Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.osgi;bundle-version="3.8.0"


### PR DESCRIPTION
P2 Director Application fails to install some of the bundles which has requirements on Java-SE 21. The reason for this issue was missing java profile dependency during installation. This new option includes Jre IU as an extra installable Unit.

Fixes https://github.com/eclipse-equinox/p2/issues/484