### PR TITLE
Adapt to equinox.security.win32 renaming and adjust arch requirements

### DIFF
--- a/features/org.eclipse.equinox.p2.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.core.feature/feature.xml
@@ -116,13 +116,11 @@
    <plugin
          id="org.eclipse.equinox.security.linux"
          os="linux"
-         arch="x86_64"
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.security.win32.x86_64"
+         id="org.eclipse.equinox.security.win32"
          os="win32"
-         arch="x86_64"
          version="0.0.0"/>
 
    <plugin


### PR DESCRIPTION
Adjustments corresponding to https://github.com/eclipse-equinox/equinox/pull/564.