### PR TITLE
Improve warning message with no digest found

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/RawMirrorRequest.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/RawMirrorRequest.java
@@ -94,7 +94,8 @@ public class RawMirrorRequest extends MirrorRequest {
 					IArtifactDescriptor.DOWNLOAD_CHECKSUM, Collections.emptySet());
 			if (steps.isEmpty()) {
 				LogHelper.log(new Status(IStatus.WARNING, Activator.ID,
-						NLS.bind(Messages.noDigestAlgorithmToVerifyDownload, artifactDescriptor.getArtifactKey())));
+						NLS.bind(Messages.noDigestAlgorithmToVerifyDownload, artifactDescriptor.getArtifactKey(),
+								artifactDescriptor.getRepository().getLocation())));
 			}
 			ProcessingStep[] stepArray = steps.toArray(new ProcessingStep[steps.size()]);
 			// TODO should probably be using createAndLink here

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/messages.properties
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/messages.properties
@@ -66,4 +66,4 @@ retryRequest=Download of {0} failed on repository {1}. Retrying.
 error_copying_local_file=An error occurred copying file {0}.
 
 onlyInsecureDigestAlgorithmUsed = The digest algorithms ({0}) used to verify {1} have severely compromised security. Please report this concern to the artifact provider.
-noDigestAlgorithmToVerifyDownload = No digest algorithm is available to verify download of {0}.
+noDigestAlgorithmToVerifyDownload = No digest algorithm is available to verify download of {0} from repository {1}.

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
@@ -491,7 +491,8 @@ public class SimpleArtifactRepository extends AbstractArtifactRepository impleme
 		addChecksumVerifiers(descriptor, downloadChecksumSteps, skipChecksums, IArtifactDescriptor.DOWNLOAD_CHECKSUM);
 		if (downloadChecksumSteps.isEmpty() && !isLocal()) {
 			LogHelper.log(new Status(IStatus.WARNING, Activator.ID,
-					NLS.bind(Messages.noDigestAlgorithmToVerifyDownload, descriptor.getArtifactKey())));
+					NLS.bind(Messages.noDigestAlgorithmToVerifyDownload, descriptor.getArtifactKey(),
+							descriptor.getRepository().getLocation())));
 		}
 		steps.addAll(downloadChecksumSteps);
 


### PR DESCRIPTION
Currently the message only mentions the artifact to download but not where it originates from, this makes it very hard to analyze and fix the issue (actually one needs to to run a debugger).

This enhances the message a tiny little bit to mention the artifact descriptors repository URL.