### PR TITLE
Fix version-ranges to have exclusive upper-bounds

### DIFF
--- a/bundles/org.eclipse.equinox.simpleconfigurator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/META-INF/MANIFEST.MF
@@ -8,16 +8,16 @@ Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.equinox.internal.simpleconfigurator.Activator
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.osgi.framework.console;version="1.0.0";resolution:=optional,
- org.eclipse.osgi.report.resolution;version="[1.0.0,2.0.0]",
+ org.eclipse.osgi.report.resolution;version="[1.0.0,2.0.0)",
  org.eclipse.osgi.service.datalocation;version="1.0.0";resolution:=optional,
  org.osgi.framework;version="1.3.0",
- org.osgi.framework.hooks.resolver;version="[1.0.0,2.0.0]",
+ org.osgi.framework.hooks.resolver;version="[1.0.0,2.0.0)",
  org.osgi.framework.namespace;version="1.0.0",
  org.osgi.framework.startlevel;version="1.0.0",
  org.osgi.framework.wiring;version="1.2.0",
  org.osgi.resource;version="1.0.0",
  org.osgi.service.packageadmin;version="1.2.0",
- org.osgi.service.resolver;version="[1.1.0,2.0.0]",
+ org.osgi.service.resolver;version="[1.1.0,2.0.0)",
  org.osgi.service.startlevel;version="1.0.0",
  org.osgi.util.tracker;version="1.3.0"
 Export-Package: org.eclipse.equinox.internal.provisional.configurator;


### PR DESCRIPTION
This was introduced due to a bug in PDE where the auto-mated suggestion unintentionally made the upper-bound inclusive.
See https://github.com/eclipse-pde/eclipse.pde/pull/1212