### PR TITLE
Improve message if artifact can not be downloaded from any repository

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.engine;singleton:=true
-Bundle-Version: 2.10.100.qualifier
+Bundle-Version: 2.10.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.engine.EngineActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Messages.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Messages.java
@@ -46,6 +46,8 @@ public class Messages extends NLS {
 	public static String committing;
 	public static String download_artifact;
 	public static String download_no_repository;
+
+	public static String DownloadManager_cant_find_artifact;
 	public static String Engine_Operation_Canceled_By_User;
 
 	public static String EngineActivator_0;

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/messages.properties
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/messages.properties
@@ -108,6 +108,7 @@ CertificateChecker_SignedContentError=Error with signed content.
 CertificateChecker_SignedContentIOError=Error reading signed content.
 CertificateChecker_UnsignedNotAllowed=Installing unsigned artifacts is not permitted: {0}
 CertificateChecker_UnsignedRejected=Unsigned content is rejected. Installation cannot proceed.
+DownloadManager_cant_find_artifact=Can't download artifact {0} required by {1} from any of the following repositories: {2}
 
 Phase_Collect_Error=An error occurred while collecting items to be installed
 Phase_Configure_Error=An error occurred while configuring the installed items

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/Collect.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/Collect.java
@@ -89,9 +89,9 @@ public class Collect extends InstallableUnitPhase {
 			agent = (IProvisioningAgent) parameters.get(PARM_AGENT);
 		}
 
+		@SuppressWarnings("unchecked")
+		Set<IInstallableUnit> ius = (Set<IInstallableUnit>) parameters.get(PARM_IUS);
 		if (Boolean.parseBoolean(context.getProperty(ProvisioningContext.CHECK_AUTHORITIES))) {
-			@SuppressWarnings("unchecked")
-			Set<IInstallableUnit> ius = (Set<IInstallableUnit>) parameters.get(PARM_IUS);
 			IStatus authorityStatus = new AuthorityChecker(agent, context, ius, artifactRequests.stream()
 						.flatMap(Arrays::stream).map(IArtifactRequest::getArtifactKey).collect(Collectors.toList()),
 						profile).start(monitor);
@@ -111,7 +111,7 @@ public class Collect extends InstallableUnitPhase {
 		}
 
 		List<IArtifactRequest> totalArtifactRequests = new ArrayList<>(artifactRequests.size());
-		DownloadManager dm = new DownloadManager(context, agent);
+		DownloadManager dm = new DownloadManager(context, ius, agent);
 		for (IArtifactRequest[] requests : artifactRequests) {
 			for (IArtifactRequest request : requests) {
 				dm.add(request);


### PR DESCRIPTION
There are rare cases where one gets a message that an artifact can not be downloaded from any repository, this has two pitfalls:

1) You don't get an idea what repositories are actually contacted 2) Its hard to find out who actually requires this artifact

This now enhances an IArtifactRequest by a method to set a "context iu" why this artifact is requested. If the information is given, it searches through the available IUs and gives additional information why it is required and what repositories are queried.