### PR TITLE
Add a way to skip reference repositories

### DIFF
--- a/bundles/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.director/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.director;singleton:=true
-Bundle-Version: 2.6.400.qualifier
+Bundle-Version: 2.7.0.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.director.DirectorActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/p2/planner/IPlanner.java
+++ b/bundles/org.eclipse.equinox.p2.director/src/org/eclipse/equinox/p2/planner/IPlanner.java
@@ -41,12 +41,17 @@ public interface IPlanner {
 	 * satisfy the given profile change request.
 	 *
 	 * @param profileChangeRequest the request to be evaluated
-	 * @param context the context in which the request is processed
-	 * @param monitor a monitor on which planning
+	 * @param context              the context in which the request is processed
+	 * @param includeReferences    whether to consider repository references
+	 * @param monitor              a monitor on which planning
 	 * @return the plan representing the system that needs to be
+	 * @since 2.7
 	 */
-	public IProvisioningPlan getProvisioningPlan(IProfileChangeRequest profileChangeRequest, ProvisioningContext context, IProgressMonitor monitor);
+	public IProvisioningPlan getProvisioningPlan(IProfileChangeRequest profileChangeRequest, ProvisioningContext context, boolean includeReferences, IProgressMonitor monitor);
 
+	public default IProvisioningPlan getProvisioningPlan(IProfileChangeRequest profileChangeRequest, ProvisioningContext context, IProgressMonitor monitor) {
+		return getProvisioningPlan(profileChangeRequest, context, true, monitor);
+	}
 	public IProvisioningPlan getDiffPlan(IProfile currentProfile, IProfile targetProfile, IProgressMonitor monitor);
 
 	public IProfileChangeRequest createChangeRequest(IProfile profileToChange);

--- a/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.engine;singleton:=true
-Bundle-Version: 2.10.100.qualifier
+Bundle-Version: 2.11.0.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.engine.EngineActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/p2/engine/ProvisioningContext.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/p2/engine/ProvisioningContext.java
@@ -109,6 +109,7 @@ public class ProvisioningContext {
 
 	private static final String FOLLOW_ARTIFACT_REPOSITORY_REFERENCES = "org.eclipse.equinox.p2.director.followArtifactRepositoryReferences"; //$NON-NLS-1$
 
+
 	/**
 	 * Creates a new provisioning context that includes all available metadata and
 	 * artifact repositories available to the specified provisioning agent.
@@ -116,11 +117,22 @@ public class ProvisioningContext {
 	 * @param agent the provisioning agent from which to obtain any necessary services.
 	 */
 	public ProvisioningContext(IProvisioningAgent agent) {
+		this(agent, true);
+	}
+
+	/**
+	 * @see #ProvisioningContext(IProvisioningAgent)
+	 *
+	 * @param followArtifactRepositoryReferences whether to follow artifact repository references
+	 * 
+	 * @since 2.11
+	 */
+	public ProvisioningContext(IProvisioningAgent agent, boolean followArtifactRepositoryReferences) {
 		this.agent = agent;
 		// null repos means look at them all
 		metadataRepositories = null;
 		artifactRepositories = null;
-		setProperty(FOLLOW_ARTIFACT_REPOSITORY_REFERENCES, Boolean.TRUE.toString());
+		setProperty(FOLLOW_ARTIFACT_REPOSITORY_REFERENCES, Boolean.toString(followArtifactRepositoryReferences));
 	}
 
 	/**


### PR DESCRIPTION
This goes hand in hand with the [PR](https://github.com/eclipse-pde/eclipse.pde/pull/1253/files) in PDE. If there's a way to achieve this without editing the public API in `IPlanner`, I would much prefer it.

Seeing how `FOLLOW_ARTIFACT_REPOSITORY_REFERENCES` was _always_ hardcoded to `true` in `ProvisioningContext`, I feel like someone wanted to implement something similar at some point, but didn't get around to it.

For versioning, I just followed the quick fixes, I hope this is correct.