### PR TITLE
VersionRange for root features is too tight when expanded version given

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ProductAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ProductAction.java
@@ -276,7 +276,7 @@ public class ProductAction extends AbstractPublisherAction {
 		return null;
 	}
 
-	protected class RootFeatureAdvice implements IFilterAdvice {
+	protected class RootFeatureAdvice implements IFilterAdvice, IVersionRangeAdvice {
 
 		private final Collection<IVersionedId> rootFeatures;
 
@@ -321,6 +321,22 @@ public class ProductAction extends AbstractPublisherAction {
 				return null;
 			}
 			return parameter.toString();
+		}
+
+		@Override
+		public Optional<VersionRange> getVersionRange(String namespace, String fid) {
+			if (NS_FEATURE.equals(namespace)) {
+				for (IVersionedId featureId : rootFeatures) {
+					if (fid.equals(featureId.getId())) {
+						Version fversion = featureId.getVersion();
+						if (fversion == null || Version.emptyVersion.equals(fversion)) {
+							return Optional.of(VersionRange.emptyRange);
+						}
+						return Optional.of(new VersionRange(fversion, true, Version.MAX_VERSION, true));
+					}
+				}
+			}
+			return Optional.empty();
 		}
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/AbstractPublisherAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/AbstractPublisherAction.java
@@ -212,15 +212,19 @@ public abstract class AbstractPublisherAction implements IPublisherAction {
 				result.add(MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, iu.getId(), range,
 						iu.getFilter() == null ? null : iu.getFilter(), false, false));
 			} else {
-				Version version = next.getVersion();
-				VersionRange range = (version == null || Version.emptyVersion.equals(version)) ? VersionRange.emptyRange
-						: new VersionRange(version, true, version, true);
+				VersionRange range = getVersionRange(next);
 				IMatchExpression<IInstallableUnit> filter = getFilterAdvice(next);
 				result.add(MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, next.getId(), range,
 						filter, false, false));
 			}
 		}
 		return result;
+	}
+
+	protected VersionRange getVersionRange(IVersionedId versionedId) {
+		Version version = versionedId.getVersion();
+		return (version == null || Version.emptyVersion.equals(version)) ? VersionRange.emptyRange
+				: new VersionRange(version, true, version, true);
 	}
 
 	private IMatchExpression<IInstallableUnit> getFilterAdvice(IVersionedId name) {

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/IVersionRangeAdvice.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/IVersionRangeAdvice.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the Eclipse Public License 2.0 which accompanies this distribution, and is
+ * available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Christoph Läubrich - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.equinox.p2.publisher.actions;
+
+import java.util.Optional;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.VersionRange;
+import org.eclipse.equinox.p2.publisher.IPublisherAdvice;
+import org.eclipse.equinox.spi.p2.publisher.PublisherHelper;
+
+public interface IVersionRangeAdvice extends IPublisherAdvice {
+
+	public static final String NS_FEATURE = PublisherHelper.NAMESPACE_ECLIPSE_TYPE + "." //$NON-NLS-1$
+			+ PublisherHelper.TYPE_ECLIPSE_FEATURE;
+	public static final String NS_IU = IInstallableUnit.NAMESPACE_IU_ID;
+
+	/**
+	 * Returns the {@link VersionRange} for the given id in the given namespace.
+	 *
+	 * @param namespace the namespace in which to look for advice
+	 * @param id        the id for the item in the given namespace
+	 * @return an {@link Optional} describing the {@link VersionRange} found.
+	 */
+	public Optional<VersionRange> getVersionRange(String namespace, String id);
+
+}

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/RootIUAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/RootIUAction.java
@@ -172,6 +172,15 @@ public class RootIUAction extends AbstractPublisherAction {
 		return root;
 	}
 
+	@Override
+	protected VersionRange getVersionRange(IVersionedId versionedId) {
+		String namespace = versionedId.getId().endsWith(".feature.group") ? IVersionRangeAdvice.NS_FEATURE //$NON-NLS-1$
+				: IVersionRangeAdvice.NS_IU;
+		return info.getAdvice(null, true, versionedId.getId(), versionedId.getVersion(), IVersionRangeAdvice.class)
+				.stream().flatMap(advice -> advice.getVersionRange(namespace, versionedId.getId()).stream()).findFirst()
+				.orElseGet(() -> super.getVersionRange(versionedId));
+	}
+
 	private Version getVersionAdvice(String iuID) {
 		if (versionAdvice == null) {
 			versionAdvice = info.getAdvice(null, true, null, null, IVersionAdvice.class);


### PR DESCRIPTION
Currently the (disabled by default) requirement for a root feature uses an exact version range when the feature version is expanded (e.g. Tycho) but the purpose of a root feature is that it can be updated what such a strict range makes it impossible (if activated).

This now adds a new IVersionRangeAdvice that allows to modify the result of a product included requirements version range.