### PR TITLE
Cache loaded repos in ProvisioningContext

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/p2/engine/ProvisioningContext.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/p2/engine/ProvisioningContext.java
@@ -219,8 +219,8 @@ public class ProvisioningContext {
 
 			// Clear out the list of remembered artifact repositories
 			referencedArtifactRepositories = new HashMap<>();
-			for (URI repositorie : repositories) {
-				loadMetadataRepository(repoManager, repositorie, loadedRepos, shouldFollowReferences(), sub.split(1));
+			for (URI repository : repositories) {
+				loadMetadataRepository(repoManager, repository, loadedRepos, shouldFollowReferences(), sub.split(1));
 			}
 		}
 		return new HashSet<>(loadedRepos.values());

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/engine/ProvisioningContextTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/engine/ProvisioningContextTest.java
@@ -22,7 +22,10 @@ import org.eclipse.equinox.p2.engine.ProvisioningContext;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.metadata.expression.ExpressionUtil;
 import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
-import org.eclipse.equinox.p2.query.*;
+import org.eclipse.equinox.p2.query.ExpressionMatchQuery;
+import org.eclipse.equinox.p2.query.IQuery;
+import org.eclipse.equinox.p2.query.IQueryable;
+import org.eclipse.equinox.p2.query.QueryUtil;
 import org.eclipse.equinox.p2.repository.IRepository;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRepository;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
@@ -199,6 +202,12 @@ public class ProvisioningContextTest extends AbstractProvisioningTest {
 		context.setArtifactRepositories(new URI[0]);
 		IProvisioningPlan plan = getPlanner(getAgent()).getProvisioningPlan(request, context, getMonitor());
 		assertFalse("resolve should fail with missing requirements", plan.getStatus().isOK());
+		// we need to create a new context as the planner is calling
+		// ProvisioningContext.getMetadata(IProgressMonitor) and after that call
+		// repositories are fixed as per API...
+		context = new ProvisioningContext(getAgent());
+		context.setMetadataRepositories(new URI[] { repoA.getLocation() });
+		context.setArtifactRepositories(new URI[0]);
 		context.setProperty(ProvisioningContext.FOLLOW_REPOSITORY_REFERENCES, "true");
 		plan = getPlanner(getAgent()).getProvisioningPlan(request, context, getMonitor());
 		assertTrue("resolve should pass", plan.getStatus().isOK());


### PR DESCRIPTION
Currently if fetching updates the provision context is queried multiple times leading to the repositories loaded multiple times, even though this is usually faster as repo are cached this still produces unnecessary workload, especially if there is one failed repository it will be tried to be loaded over and over again.

This now caches the repositories loaded on first access to speed that up.