### PR TITLE
Always use full-named o.e.equinox.launcher artifact

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/EquinoxExecutableAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/EquinoxExecutableAction.java
@@ -143,9 +143,7 @@ public class EquinoxExecutableAction extends AbstractPublisherAction {
 			String ws = config[0];
 			String os = config[1];
 			String arch = config[2];
-			String launcherFragment = EquinoxLauncherCUAction.ORG_ECLIPSE_EQUINOX_LAUNCHER + '.' + ws + '.' + os;
-			if (!(Constants.OS_MACOSX.equals(os) && !Constants.ARCH_X86_64.equals(arch)))
-				launcherFragment += '.' + arch;
+			String launcherFragment = EquinoxLauncherCUAction.ORG_ECLIPSE_EQUINOX_LAUNCHER + '.' + ws + '.' + os + '.' + arch;
 			iu.setRequirements(new IRequirement[] {MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, launcherFragment, VersionRange.emptyRange, filter, false, false)});
 		}
 		result.addIU(MetadataFactory.createInstallableUnit(iu), IPublisherResult.ROOT);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/EquinoxExecutableActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/EquinoxExecutableActionTest.java
@@ -195,7 +195,8 @@ public class EquinoxExecutableActionTest extends ActionTest {
 				assertTrue(providedCapabilities.size() == 2);
 
 				Collection<IRequirement> requiredCapability = possibleExec.getRequirements();
-				verifyRequirement(requiredCapability, IInstallableUnit.NAMESPACE_IU_ID, "org.eclipse.equinox.launcher." + (idBase.equals("mac") || idBase.equals("macCocoa") ? confSpec.substring(0, confSpec.lastIndexOf(".")) : confSpec), VersionRange.emptyRange); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				verifyRequirement(requiredCapability, IInstallableUnit.NAMESPACE_IU_ID,
+						"org.eclipse.equinox.launcher." + confSpec, VersionRange.emptyRange); //$NON-NLS-1$
 				assertTrue(requiredCapability.size() == 1);
 
 				try {


### PR DESCRIPTION
For for Mac OS X there was no equinox-launcher fragment for CARBON with full name, i.e. with <ws>.<os>.<arch> suffix, but only a org.eclipse.equinox.launcher.carbon.macosx fragment. But since Eclipse 4.2, released 2012, CARBON is not supported anymore at all [1]. Therefore the code adjust to that special naming schema, which also imposed difficulties or new supported architectures on Macos should be removed.

See also https://github.com/eclipse-equinox/equinox/pull/622

[1] - https://download.eclipse.org/eclipse/updates/4.2/R-4.2-201206081400