### PR TITLE
remove unnecessary casts

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/SPIMetadataRepositoryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/SPIMetadataRepositoryTest.java
@@ -875,8 +875,8 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 		assertEquals(unit.getTouchpointData().size(), 1);
 		assertEquals(((IRequiredCapability) unit.getRequirements().iterator().next()).getNamespace(), spiRequiredCapability.getNamespace());
 		assertEquals(((IRequiredCapability) unit.getRequirements().iterator().next()).getName(), spiRequiredCapability.getName());
-		assertEquals(((IRequiredCapability) unit.getRequirements().iterator().next()).getMin(), spiRequiredCapability.getMin());
-		assertEquals(((IRequiredCapability) unit.getRequirements().iterator().next()).getMax(), spiRequiredCapability.getMax());
+		assertEquals(unit.getRequirements().iterator().next().getMin(), spiRequiredCapability.getMin());
+		assertEquals(unit.getRequirements().iterator().next().getMax(), spiRequiredCapability.getMax());
 		assertEquals(unit.getProvidedCapabilities().iterator().next(), spiProvidedCapability);
 		assertEquals(unit.getTouchpointData().iterator().next(), spiTouchpointData);
 		assertEquals(unit.getTouchpointType(), spiTouchpointType);

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.discovery;singleton:=true
-Bundle-Version: 1.3.300.qualifier
+Bundle-Version: 1.3.400.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/ControlListViewer.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/ControlListViewer.java
@@ -200,7 +200,7 @@ public abstract class ControlListViewer extends StructuredViewer {
 
 		// Update with the new elements to prevent flash
 		for (Control element : existingChildren) {
-			((ControlListItem<?>) element).dispose();
+			element.dispose();
 		}
 
 		for (int i = 0; i < infos.length; i++) {

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.importexport;singleton:=true
-Bundle-Version: 1.4.400.qualifier
+Bundle-Version: 1.4.500.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ExportWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ExportWizard.java
@@ -55,7 +55,7 @@ public class ExportWizard extends AbstractWizard implements IExportWizard {
 
 	@Override
 	public boolean performFinish() {
-		File file = new File(((ExportPage) mainPage).getDestinationValue());
+		File file = new File(mainPage.getDestinationValue());
 		if (file.exists()) {
 			if (!MessageDialog.openConfirm(this.getShell(), Messages.ExportWizard_ConfirmDialogTitle,
 					NLS.bind(Messages.ExportWizard_OverwriteConfirm, file.getAbsolutePath())))

--- a/features/org.eclipse.equinox.p2.discovery.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.discovery.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.discovery.feature"
       label="%featureName"
-      version="1.3.400.qualifier"
+      version="1.3.500.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.user.ui/feature.xml
+++ b/features/org.eclipse.equinox.p2.user.ui/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.user.ui"
       label="%featureName"
-      version="2.4.2400.qualifier"
+      version="2.4.2500.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
When https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2471 is merged, ecj will signal more casts as unnecessary.

With this PR I suggest to remove affected casts before new warnings will show up in the build.