### PR TITLE
Add support for bundle URL types in macOS launcher in product files

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/BrandingIron.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/BrandingIron.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2005, 2012 IBM Corporation and others.
+ *  Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -11,16 +11,19 @@
  *  Contributors:
  * 	IBM Corporation - initial API and implementation
  * 	Code 9 - Additional function and fixes
+ * 	SAP SE - support macOS bundle URL types
  *******************************************************************************/
 package org.eclipse.equinox.internal.p2.publisher.eclipse;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.util.List;
 import javax.xml.transform.TransformerException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
 import org.eclipse.equinox.p2.metadata.Version;
+import org.eclipse.equinox.p2.publisher.eclipse.IMacOsBundleUrlType;
 import org.eclipse.pde.internal.publishing.Activator;
 import org.eclipse.pde.internal.publishing.Utils;
 import org.eclipse.pde.internal.swt.tools.IconExe;
@@ -38,6 +41,7 @@ public class BrandingIron {
 	private boolean brandIcons = true;
 	private String id;
 	private Version version;
+	private List<IMacOsBundleUrlType> macOsBundleUrlTypes = List.of();
 
 	public BrandingIron() {
 	}
@@ -58,6 +62,10 @@ public class BrandingIron {
 
 	public void setIcons(String[] value) {
 		icons = (value == null || value.length == 0) ? null : value;
+	}
+
+	public void setMacOsBundleUrlTypes(List<IMacOsBundleUrlType> value) {
+		macOsBundleUrlTypes = value;
 	}
 
 	public void setIcons(String value) {
@@ -560,6 +568,10 @@ public class BrandingIron {
 
 		if (iconName.length() > 0) {
 			infoPListEditor.setKey(InfoPListEditor.ICON_KEY, iconName);
+		}
+
+		for (IMacOsBundleUrlType macOsBundleUrlType : macOsBundleUrlTypes) {
+			infoPListEditor.addCfBundleUrlType(macOsBundleUrlType.getScheme(), macOsBundleUrlType.getName());
 		}
 
 		File target = new File(targetRoot, "Info.plist"); //$NON-NLS-1$ ;

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/IProductDescriptor.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/IProductDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2014 Code 9 and others.
+ * Copyright (c) 2008, 2024 Code 9 and others.
  *
  * This
  * program and the accompanying materials are made available under the terms of
@@ -14,6 +14,7 @@
  *   EclipseSource - ongoing development
  *   SAP AG - ongoing development
  *   Rapicorp - additional features
+ *   SAP SE - support macOS bundle URL types
  ******************************************************************************/
 package org.eclipse.equinox.internal.p2.publisher.eclipse;
 
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
+import org.eclipse.equinox.p2.publisher.eclipse.IMacOsBundleUrlType;
 import org.eclipse.equinox.p2.repository.IRepositoryReference;
 
 /**
@@ -206,5 +208,15 @@ public interface IProductDescriptor {
 	 * @return the VM for this OS, null if none is set
 	 */
 	public String getVM(String os);
+
+	/**
+	 * Returns a list of URI schemes handled by the product.
+	 * <p>
+	 * Currently, these are only evaluated on macOS, since they need to be placed in
+	 * the Information Property List file (<code>Info.plist</code>).
+	 */
+	public default List<IMacOsBundleUrlType> getMacOsBundleUrlTypes() {
+		return List.of();
+	}
 
 }

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/MacOsBundleUrlType.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/MacOsBundleUrlType.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    SAP SE - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.publisher.eclipse;
+
+import org.eclipse.equinox.p2.publisher.eclipse.IMacOsBundleUrlType;
+
+record MacOsBundleUrlType(String scheme, String name) implements IMacOsBundleUrlType {
+
+	@Override
+	public String getScheme() {
+		return scheme();
+	}
+
+	@Override
+	public String getName() {
+		return name();
+	}
+}

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/EquinoxExecutableAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/EquinoxExecutableAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 Code 9 and others.
+ * Copyright (c) 2008, 2024 Code 9 and others.
  *
  * This
  * program and the accompanying materials are made available under the terms of
@@ -13,6 +13,7 @@
  *   Code 9 - initial API and implementation
  *   IBM - ongoing development
  *   Pascal Rapicault - Support for bundled macosx http://bugs.eclipse.org/57349
+ *   SAP SE - support macOS bundle URL types
  ******************************************************************************/
 package org.eclipse.equinox.p2.publisher.eclipse;
 
@@ -254,6 +255,7 @@ public class EquinoxExecutableAction extends AbstractPublisherAction {
 		iron.setId(idBase);
 		iron.setVersion(version);
 		iron.setIcons(advice.getIcons());
+		iron.setMacOsBundleUrlTypes(advice.getMacOsBundleUrlTypes());
 		String name = advice.getExecutableName();
 		if (name == null)
 			name = "eclipse"; //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/IBrandingAdvice.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/IBrandingAdvice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2011 EclipseSource and others.
+ * Copyright (c) 2009, 2024 EclipseSource and others.
  *
  * This
  * program and the accompanying materials are made available under the terms of
@@ -11,9 +11,11 @@
  * 
  * Contributors: 
  *   EclipseSource - initial API and implementation
+ *   SAP SE - support macOS bundle URL types
  ******************************************************************************/
 package org.eclipse.equinox.p2.publisher.eclipse;
 
+import java.util.List;
 import org.eclipse.equinox.p2.publisher.IPublisherAdvice;
 
 /**
@@ -42,4 +44,16 @@ public interface IBrandingAdvice extends IPublisherAdvice {
 	 * @return the name of the branded launcher or <code>null</code> if none.
 	 */
 	public String getExecutableName();
+
+	/**
+	 * Returns the list of URL schemes / names to be handled by the macOS app
+	 * bundle.
+	 * <p>
+	 * They will be stored in the Information Property List file
+	 * (<code>Info.plist</code>) of the app bundle.
+	 *
+	 * @return the the list of URL schemes / names to be handled by the macOS app
+	 *         bundle
+	 */
+	public List<IMacOsBundleUrlType> getMacOsBundleUrlTypes();
 }

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/IMacOsBundleUrlType.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/IMacOsBundleUrlType.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2024 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    SAP SE - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.p2.publisher.eclipse;
+
+public interface IMacOsBundleUrlType {
+
+	String getScheme();
+
+	String getName();
+
+}

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ProductFileAdvice.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ProductFileAdvice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 Code 9 and others.
+ * Copyright (c) 2008, 2024 Code 9 and others.
  *
  * This
  * program and the accompanying materials are made available under the terms of
@@ -15,6 +15,7 @@
  *   IBM Corporation - ongoing development
  *   Rapicorp - additional features
  *   Christoph Läubrich - Bug 574952 p2 should distinguish between "product plugins" and "configuration plugins" (gently sponsored by Compart AG)
+ *   SAP SE - support macOS bundle URL types
  ******************************************************************************/
 package org.eclipse.equinox.p2.publisher.eclipse;
 
@@ -173,6 +174,11 @@ public class ProductFileAdvice extends AbstractAdvice
 	@Override
 	public String getLicenseText() {
 		return product.getLicenseText();
+	}
+
+	@Override
+	public List<IMacOsBundleUrlType> getMacOsBundleUrlTypes() {
+		return product.getMacOsBundleUrlTypes();
 	}
 
 	/**

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ProductFileAdviceTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ProductFileAdviceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2009, 2017 EclipseSource and others.
+* Copyright (c) 2009, 2024 EclipseSource and others.
  *
  * This
 * program and the accompanying materials are made available under the terms of
@@ -12,14 +12,17 @@
 * Contributors:
 *   EclipseSource - initial API and implementation
 *   IBM Corporation - on-going maintenance
+*   SAP SE - support macOS bundle URL types
 ******************************************************************************/
 package org.eclipse.equinox.p2.tests.publisher.actions;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
 import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductFile;
+import org.eclipse.equinox.p2.publisher.eclipse.IMacOsBundleUrlType;
 import org.eclipse.equinox.p2.publisher.eclipse.ProductFileAdvice;
 import org.eclipse.equinox.p2.tests.AbstractProvisioningTest;
 import org.eclipse.equinox.p2.tests.TestData;
@@ -196,6 +199,19 @@ public class ProductFileAdviceTest extends AbstractProvisioningTest {
 		absolutePath = new File(productFile2.getLocation().getParentFile(), "icon.bmp").getAbsolutePath();
 		assertEquals("2.0", 1, icons.length);
 		assertEquals("2.1", absolutePath, icons[0]);
+	}
+
+	/**
+	 * Test method for
+	 * {@link org.eclipse.equinox.p2.publisher.eclipse.ProductFileAdvice#getMacOsBundleUrlTypes()}.
+	 */
+	public void testgetMacOsBundleUrlTypes() {
+		List<IMacOsBundleUrlType> macOsBundleUrlTypes = productFileAdvice2.getMacOsBundleUrlTypes();
+		assertEquals(2, macOsBundleUrlTypes.size());
+		assertEquals("eclipse+command", macOsBundleUrlTypes.get(0).getScheme());
+		assertEquals("Eclipse Command", macOsBundleUrlTypes.get(0).getName());
+		assertEquals("vendor", macOsBundleUrlTypes.get(1).getScheme());
+		assertEquals("Vendor Application", macOsBundleUrlTypes.get(1).getName());
 	}
 
 	public void testSimpleConfiguratorConfigURL() throws Exception {

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ProductFileTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ProductFileTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2009, 2017 EclipseSource and others.
+* Copyright (c) 2009, 2024 EclipseSource and others.
  *
  * This
 * program and the accompanying materials are made available under the terms of
@@ -11,6 +11,7 @@
 *
 * Contributors:
 *   EclipseSource - initial API and implementation
+*   SAP SE - support macOS bundle URL types
 ******************************************************************************/
 package org.eclipse.equinox.p2.tests.publisher.actions;
 
@@ -31,6 +32,7 @@ import org.eclipse.equinox.internal.p2.publisher.eclipse.ProductFile;
 import org.eclipse.equinox.p2.metadata.IVersionedId;
 import org.eclipse.equinox.p2.metadata.Version;
 import org.eclipse.equinox.p2.metadata.VersionedId;
+import org.eclipse.equinox.p2.publisher.eclipse.IMacOsBundleUrlType;
 import org.eclipse.equinox.p2.tests.TestData;
 import org.junit.Before;
 import org.junit.Test;
@@ -302,5 +304,18 @@ public class ProductFileTest {
 		assertEquals("org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/OSGi%Minimum-1.2", product.getVM(Platform.OS_WIN32));
 		assertEquals("org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-9", product.getVM(Platform.OS_LINUX));
 		assertNull(product.getVM(Platform.OS_MACOSX));
+	}
+
+	@Test
+	public void testGetMacOsBundleUrlTypes() throws Exception {
+		String productWithMacOsBundleUrlTypes = TestData
+				.getFile("ProductActionTest", "productWithMacOsBundleUrlTypes.product").toString();
+		ProductFile product = new ProductFile(productWithMacOsBundleUrlTypes);
+		List<IMacOsBundleUrlType> macOsBundleUrlTypes = product.getMacOsBundleUrlTypes();
+		assertEquals(2, macOsBundleUrlTypes.size());
+		assertEquals("eclipse+command", macOsBundleUrlTypes.get(0).getScheme());
+		assertEquals("Eclipse Command", macOsBundleUrlTypes.get(0).getName());
+		assertEquals("vendor", macOsBundleUrlTypes.get(1).getScheme());
+		assertEquals("Vendor Application", macOsBundleUrlTypes.get(1).getName());
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.tests/testData/ProductActionTest/productFileActionTest.product
+++ b/bundles/org.eclipse.equinox.p2.tests/testData/ProductActionTest/productFileActionTest.product
@@ -20,6 +20,12 @@
          <bmp
             winSmallLow="icon.bmp"/>
       </win>
+      <macosx>
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="vendor" name="Vendor Application"/>
+         </bundleUrlTypes>
+      </macosx>
    </launcher>
 
    <vm>

--- a/bundles/org.eclipse.equinox.p2.tests/testData/ProductActionTest/productWithMacOsBundleUrlTypes.product
+++ b/bundles/org.eclipse.equinox.p2.tests/testData/ProductActionTest/productWithMacOsBundleUrlTypes.product
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="Product With Handled URL Schemes" uid="licenseIU.product" useFeatures="false" includeLaunchers="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
+      </vmArgsMac>
+   </launcherArgs>
+
+   <launcher>
+      <win useIco="false">
+         <bmp/>
+      </win>
+      <macosx>
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="vendor" name="Vendor Application"/>
+         </bundleUrlTypes>
+      </macosx>
+   </launcher>
+
+   <license>
+        <url>http://www.example.com</url>
+        <text>
+   This is the liCenSE.
+         </text>
+   </license>
+
+   <plugins>
+   </plugins>
+
+
+</product>


### PR DESCRIPTION
Adds CFBundleURLTypes entries to the Info.plist dictionary.

Contributes to
https://github.com/eclipse-platform/eclipse.platform.ui/issues/1901.