### PR TITLE
Remove org.tukaani.xz from org.eclipse.equinox.p2.core.feature

### DIFF
--- a/features/org.eclipse.equinox.p2.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.core.feature/feature.xml
@@ -124,10 +124,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.tukaani.xz"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.concurrent"
          version="0.0.0"/>
 


### PR DESCRIPTION
- There's no reason to lock in a specific version via the feature.