### PR TITLE
Set up workflow for automated version increments in pull-requests 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,5 @@ on:
     branches: [ master ]
 
 jobs:
-  check-freeze-period:
-    if: github.event_name == 'pull_request'
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/verifyFreezePeriod.yml@master
-  check-merge-commits:
-    if: github.event_name == 'pull_request'
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkMergeCommits.yml@master
   build:
     uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/mavenBuild.yml@master
-

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,6 +10,10 @@ on:
     branches: [ master ]
 
 jobs:
+  check-freeze-period:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/verifyFreezePeriod.yml@master
+  check-merge-commits:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkMergeCommits.yml@master
   check-versions:
     uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkVersions.yml@master
     with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,17 @@
+# Fast running checks for pull-requests
+
+name: Pull-Request Checks
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  check-versions:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkVersions.yml@master
+    with:
+      botName: Eclipse Equinox Bot
+      botMail: equinox-bot@eclipse.org

--- a/.github/workflows/version-increments.yml
+++ b/.github/workflows/version-increments.yml
@@ -1,0 +1,14 @@
+name: Publish Version Check Results
+
+on:
+  workflow_run:
+    workflows: [ 'Pull-Request Checks' ]
+    types: [ completed ]
+
+jobs:
+  publish-version-check-results:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/publishVersionCheckResults.yml@master
+    with:
+      botGithubId: eclipse-equinox-bot
+    secrets:
+      githubBotPAT: ${{ secrets.EQUINOX_BOT_PAT }}


### PR DESCRIPTION
Set up for this repository the workflow for automated version increments in pull-requests added via https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2352

Before this can work complete, the EF infra team has to add the required PAT of the Platform-bot to this repo as described in the linked PR and requested in
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5020#note_2825941