### PR TITLE
[Build] Specify options for the build JVM only in Jenkins pipeline

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,2 +1,0 @@
--XX:+PrintFlagsFinal
--Xmx2g

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,15 +14,18 @@ pipeline {
 	}
 	stages {
 		stage('Build') {
+			environment {
+				MAVEN_OPTS ='-XX:+PrintFlagsFinal -Xmx2g'
+			}
 			steps {
-				wrap([$class: 'Xvnc', useXauthority: true]) {
+				xvnc(useXauthority: true) {
 					sh """
 					mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Pbree-libs -Papi-check -Pjavadoc \
 						-Dcompare-version-with-baselines.skip=false \
 						-Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true \
 						-Dproject.build.sourceEncoding=UTF-8 \
-						-T1C
+						-T 1C
 					"""
 				}
 			}


### PR DESCRIPTION
The options where introduced for all builds of the p2 repo via https://github.com/eclipse-equinox/p2/pull/464

Having it enabled can cause problems in GitHub workflows that are sensitive to the printout.