### PR TITLE
[Build] Fix archiving of log files in Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,23 +15,24 @@ pipeline {
 	stages {
 		stage('Build') {
 			steps {
-				wrap([$class: 'Xvnc', useXauthority: true]) {
+				xvnc(useXauthority: true) {
 					sh """
 					mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Pbree-libs -Papi-check -Pjavadoc \
 						-Dcompare-version-with-baselines.skip=false \
-						-Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true \
-						-Dproject.build.sourceEncoding=UTF-8 \
-						-T1C
+						-Dmaven.test.failure.ignore=true \
+						-T 1C
 					"""
 				}
 			}
 			post {
 				always {
-					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log', allowEmptyArchive: true
+					archiveArtifacts artifacts: '*.log,**/target/**/*.log', allowEmptyArchive: true
 					junit '**/target/surefire-reports/TEST-*.xml'
 					discoverGitReferenceBuild referenceJob: 'p2/master'
-					recordIssues publishAllIssues:false, ignoreQualityGate:true, tool: eclipse(name: 'Compiler and API Tools', pattern: '**/target/compilelogs/*.xml'), qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]
+					recordIssues(publishAllIssues:false, ignoreQualityGate:true,
+						tool: eclipse(name: 'Compiler and API Tools', pattern: '**/target/compilelogs/*.xml'),
+						qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]])
 					recordIssues tools: [javaDoc(), mavenConsole()]
 				}
 			}


### PR DESCRIPTION
and other minor clean-ups of the Jenkinsfile.
Remove explicit declaration of properties that are already defined in the `eclipse-platform-parent/pom.xml` or that are not considered by any plugin (i.e. `maven.test.error.ignore`).