### PR TITLE
Support empty lower and upper bounds in P2 VersionRange

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/OSGiRangeTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/OSGiRangeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2010 Cloudsmith Inc. and others.
+ * Copyright (c) 2009, 2024 Cloudsmith Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -27,6 +27,10 @@ import org.junit.Test;
  * Tests ranges of versions specified with osgi (default) version format.
  */
 public class OSGiRangeTest extends VersionTesting {
+
+	private static Version ONE = Version.parseVersion("1");
+	private static Version TWO = Version.parseVersion("2");
+
 	@Test
 	public void testSingleVersionRange() {
 		VersionRange range;
@@ -98,6 +102,35 @@ public class OSGiRangeTest extends VersionTesting {
 		assertEquals("[1.0.0.abcdef,2.0.0.abcdef)", v.toString());
 		v = new VersionRange("(1.0.0.abcdef,2.0.0.abcdef)");
 		assertEquals("(1.0.0.abcdef,2.0.0.abcdef)", v.toString());
+	}
+
+	@Test
+	public void testEmptyRange() {
+		assertBounds("", true, Version.emptyVersion, Version.MAX_VERSION, true);
+	}
+
+	@Test
+	public void testExplicitLowerAndUpperBound() {
+		assertBounds("[1,2)", true, ONE, TWO, false);
+		assertBounds("[1,2]", true, ONE, TWO, true);
+	}
+
+	@Test
+	public void testNoLowerBound() {
+		assertBounds("(,1)", true, Version.emptyVersion, ONE, false);
+		assertBounds("[,1)", true, Version.emptyVersion, ONE, false);
+	}
+
+	@Test
+	public void testNoUpperBound() {
+		assertBounds("[1,)", true, ONE, Version.MAX_VERSION, true);
+		assertBounds("[1,]", true, ONE, Version.MAX_VERSION, true);
+	}
+
+	@Test
+	public void testNoLowerAndUpperBound() {
+		assertBounds("(,)", true, Version.emptyVersion, Version.MAX_VERSION, true);
+		assertBounds("[,]", true, Version.emptyVersion, Version.MAX_VERSION, true);
 	}
 
 	/**

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/RawRangeTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/RawRangeTest.java
@@ -25,6 +25,10 @@ import org.junit.Test;
  * Tests version ranges specified using raw.
  */
 public class RawRangeTest extends VersionTesting {
+
+	private static Version ONE = Version.parseVersion("raw:1");
+	private static Version TWO = Version.parseVersion("raw:2");
+
 	@Test
 	public void testEmptyRange() {
 		VersionRange range = new VersionRange("raw:''");
@@ -110,6 +114,30 @@ public class RawRangeTest extends VersionTesting {
 		assertIncludedInRange("1.3", upperBound, "raw:1.9.9.'x'");
 		assertNotIncludedInRange("1.4", upperBound, "raw:2.0");
 		assertNotIncludedInRange("1.5", upperBound, "raw:2.1");
+	}
+
+	@Test
+	public void testExplicitLowerAndUpperBound() {
+		assertBounds("raw:[1,2)", true, ONE, TWO, false);
+		assertBounds("raw:[1,2]", true, ONE, TWO, true);
+	}
+
+	@Test
+	public void testNoLowerBound() {
+		assertBounds("raw:(,1)", true, Version.emptyVersion, ONE, false);
+		assertBounds("raw:[,1)", true, Version.emptyVersion, ONE, false);
+	}
+
+	@Test
+	public void testNoUpperBound() {
+		assertBounds("raw:[1,)", true, ONE, Version.MAX_VERSION, true);
+		assertBounds("raw:[1,]", true, ONE, Version.MAX_VERSION, true);
+	}
+
+	@Test
+	public void testNoLowerAndUpperBound() {
+		assertBounds("raw:(,)", true, Version.emptyVersion, Version.MAX_VERSION, true);
+		assertBounds("raw:[,]", true, Version.emptyVersion, Version.MAX_VERSION, true);
 	}
 
 	@Test

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/VersionTesting.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/omniVersion/VersionTesting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 Cloudsmith Inc. and others.
+ * Copyright (c) 2009, 2024 Cloudsmith Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,6 +33,7 @@ import org.eclipse.equinox.p2.metadata.VersionRange;
  * Base class for version testing. Adds useful assert methods.
  */
 public class VersionTesting {
+
 	/**
 	 * Asserts that the versionString version is included in the range.
 	 */
@@ -45,6 +46,15 @@ public class VersionTesting {
 	 */
 	public void assertNotIncludedInRange(String message, VersionRange range, String versionString) {
 		assertFalse(message, range.isIncluded(Version.parseVersion(versionString)));
+	}
+
+	public void assertBounds(String rangeSpecification, boolean includeMin, Version lowerBound, Version upperBound,
+			boolean includeMax) {
+		VersionRange range = new VersionRange(rangeSpecification);
+		assertEquals(includeMin, range.getIncludeMinimum());
+		assertEquals(includeMax, range.getIncludeMaximum());
+		assertEquals(lowerBound, range.getMinimum());
+		assertEquals(upperBound, range.getMaximum());
 	}
 
 	/**


### PR DESCRIPTION
This enables support for version range specifications where the lower or upper bound is not specified and the delimiting bracket is directly next to the separating colon. For example `[1,)` or `(,1]` but also `(,)` can then be parsed successfully.

The type of supported brackets for an empty or unspecified bound is something that's not inherently obvious. From a mathematical perspective an empty bound can be considered equivalent to infinity. And in math may not say inclusive infinity. From that perspective only `[1,infinity)` respectively `[1,)` would be permitted, but not `[1,]`. But technically infinity has a specific value for P2 versions, i.e. `Version.MAX_VERSION`. So if one really wants to cover all possible values, the upper bound still has to be inclusive, i.e. `]`. For the lower bound the situation is similar, where `0.0.0` or the 'empty'-version is the smallest one possible.

Alternatively we could treat no lower bound simply as a synonym for `0.0.0` and no upper bound as synonym for `Version.MAX_VERSION` and consider the bounds as specified?