### PR TITLE
MT hardening FileInfoReader #568

### DIFF
--- a/bundles/org.eclipse.equinox.p2.transport.ecf/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.transport.ecf
-Bundle-Version: 1.4.300.qualifier
+Bundle-Version: 1.4.400.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ecf;bundle-version="3.1.0",
  org.eclipse.ecf.filetransfer;bundle-version="4.0.0",


### PR DESCRIPTION
The value of the barrier (true/false) was never read. It was only checked for !=null. The value had been read in waitOnSelf() without any multithreading semantics like synchronize/volatile. Instead now we use a thread safe AtomicBoolean. The synchronization blocks are still used for wait()/notifyAll()

https://github.com/eclipse-equinox/p2/issues/568