### PR TITLE
Revert "Use CI Friendly versions for the P2 maven build"

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.eclipse.platform</groupId>
 		<artifactId>rt.equinox.p2</artifactId>
-		<version>${releaseVersion}${qualifier}</version>
+		<version>4.34.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.platform</groupId>
     <artifactId>rt.equinox.p2</artifactId>
-    <version>${releaseVersion}${qualifier}</version>
+    <version>4.34.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>org.eclipse.equinox.p2.examples</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,16 +22,9 @@
   <groupId>org.eclipse.platform</groupId>
   <artifactId>rt.equinox.p2</artifactId>
   <packaging>pom</packaging>
-  <version>${releaseVersion}${qualifier}</version>
 
   <properties>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-equinox/p2.git</tycho.scmUrl>
-    <releaseVersion>4.34.0</releaseVersion>
-    <!-- Defines the default Qualifier if no format is given-->
-    <!-- can be overriden with -Dtycho.buildqualifier.format=yyyyMMddHHmm for a dynamic qualifier or -Dqualifier=abcd for a static value -->
-    <qualifier>-SNAPSHOT</qualifier>
-    <!-- disabled for now, should be enabled later! -->
-    <addMavenDescriptor>false</addMavenDescriptor>
     <failOnJavadocErrors>true</failOnJavadocErrors>
   </properties>
 


### PR DESCRIPTION
This reverts commit 612c5fa6fc41602aaa59624e36c06c58acaea863.

Using this pattern breaks the `Update to next release ` workflow:
- https://github.com/eclipse-equinox/p2/actions/runs/11973081501
- https://github.com/eclipse-tycho/tycho/pull/3900#issuecomment-2495468974

This reverts it to use versions the default way again. Once Tycho is fixed we can revert this again.
Or we just keep it then, since due more usage of tycho-pomless the number of locations to change is very low now and the `Update to next release ` workflow does it automatically any ways.