### PR TITLE
Update for release 4.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.34.0-SNAPSHOT</version>
+    <version>4.35.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
 
   <properties>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-equinox/p2.git</tycho.scmUrl>
-    <releaseVersion>4.34.0</releaseVersion>
+    <releaseVersion>4.35.0</releaseVersion>
     <!-- Defines the default Qualifier if no format is given-->
     <!-- can be overriden with -Dtycho.buildqualifier.format=yyyyMMddHHmm for a dynamic qualifier or -Dqualifier=abcd for a static value -->
     <qualifier>-SNAPSHOT</qualifier>


### PR DESCRIPTION
As suggested in https://github.com/eclipse-equinox/p2/pull/573, this applies the changes necessary for release preparation manually, that cannot be done automatically at the moment due to a bug in Tycho. See
- https://github.com/eclipse-tycho/tycho/pull/3900#issuecomment-2495468974