### PR TITLE
Updated bundles with comparator errors

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.publisher.eclipse;singleton:=true
-Bundle-Version: 1.6.300.qualifier
+Bundle-Version: 1.6.400.qualifier
 Bundle-Activator: org.eclipse.pde.internal.publishing.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.p2.publisher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.publisher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.publisher;singleton:=true
-Bundle-Version: 1.9.300.qualifier
+Bundle-Version: 1.9.400.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.publisher.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.publisher/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.publisher/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/features/org.eclipse.equinox.p2.extras.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.extras.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.extras.feature"
       label="%featureName"
-      version="1.4.2600.qualifier"
+      version="1.4.2700.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.sdk/feature.xml
+++ b/features/org.eclipse.equinox.p2.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.sdk"
       label="%featureName"
-      version="3.11.2600.qualifier"
+      version="3.11.2700.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.user.ui/feature.xml
+++ b/features/org.eclipse.equinox.p2.user.ui/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.user.ui"
       label="%featureName"
-      version="2.4.2600.qualifier"
+      version="2.4.2700.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Changes to ecj are for handling of switch on String.

See: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595