### PR TITLE
Correct improper usage of the SubMonitor

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.artifact.repository;singleton:=true
-Bundle-Version: 1.5.500.qualifier
+Bundle-Version: 1.5.600.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.artifact.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/DownloadJob.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/DownloadJob.java
@@ -56,17 +56,12 @@ public class DownloadJob extends Job {
 			if (masterMonitor.isCanceled())
 				return Status.CANCEL_STATUS;
 			// process the actual request
-			SubMonitor subMonitor = SubMonitor.convert(masterMonitor, 1);
-			subMonitor.beginTask("", 1); //$NON-NLS-1$
-			try {
-				IStatus status = repository.getArtifact(request, subMonitor);
-				if (!status.isOK()) {
-					synchronized (overallStatus) {
-						overallStatus.add(status);
-					}
+			SubMonitor subMonitor = SubMonitor.convert(masterMonitor.slice(1), 1);
+			IStatus status = repository.getArtifact(request, subMonitor);
+			if (!status.isOK()) {
+				synchronized (overallStatus) {
+					overallStatus.add(status);
 				}
-			} finally {
-				subMonitor.done();
 			}
 		} while (true);
 

--- a/bundles/org.eclipse.equinox.p2.discovery.compatibility/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.discovery.compatibility/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.p2.discovery.compatibility;singleton:=true
-Bundle-Version: 1.3.500.qualifier
+Bundle-Version: 1.3.600.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",

--- a/bundles/org.eclipse.equinox.p2.discovery.compatibility/src/org/eclipse/equinox/internal/p2/discovery/compatibility/BundleDiscoveryStrategy.java
+++ b/bundles/org.eclipse.equinox.p2.discovery.compatibility/src/org/eclipse/equinox/internal/p2/discovery/compatibility/BundleDiscoveryStrategy.java
@@ -42,13 +42,11 @@ public class BundleDiscoveryStrategy extends AbstractDiscoveryStrategy {
 		}
 		IExtensionPoint extensionPoint = getExtensionRegistry().getExtensionPoint(ConnectorDiscoveryExtensionReader.EXTENSION_POINT_ID);
 		IExtension[] extensions = extensionPoint.getExtensions();
-		monitor.beginTask(Messages.BundleDiscoveryStrategy_task_loading_local_extensions, extensions.length == 0 ? 1 : extensions.length);
-		try {
-			if (extensions.length > 0) {
-				processExtensions(SubMonitor.convert(monitor, extensions.length), extensions);
-			}
-		} finally {
-			monitor.done();
+		SubMonitor subMonitor = SubMonitor.convert(monitor,
+				Messages.BundleDiscoveryStrategy_task_loading_local_extensions,
+				extensions.length == 0 ? 1 : extensions.length);
+		if (extensions.length > 0) {
+			processExtensions(subMonitor.newChild(extensions.length), extensions);
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.p2.discovery/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.p2.discovery;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",

--- a/bundles/org.eclipse.equinox.p2.transport.ecf/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.transport.ecf
-Bundle-Version: 1.4.300.qualifier
+Bundle-Version: 1.4.400.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ecf;bundle-version="3.1.0",
  org.eclipse.ecf.filetransfer;bundle-version="4.0.0",

--- a/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/FileReader.java
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/FileReader.java
@@ -47,7 +47,7 @@ public final class FileReader extends FileTransferJob implements IFileTransferLi
 	 */
 	static class SuppressBlockedMonitor extends ProgressMonitorWrapper {
 		public SuppressBlockedMonitor(IProgressMonitor monitor, int ticks) {
-			super(SubMonitor.convert(monitor, ticks));
+			super(monitor.slice(ticks));
 		}
 
 		@Override

--- a/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui;singleton:=true
-Bundle-Version: 2.8.600.qualifier
+Bundle-Version: 2.8.700.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.ProvUIActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/query/QueryableUpdates.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/query/QueryableUpdates.java
@@ -43,24 +43,21 @@ public class QueryableUpdates implements IQueryable<IInstallableUnit> {
 		if (monitor == null)
 			monitor = new NullProgressMonitor();
 		int totalWork = 2000;
-		monitor.beginTask(ProvUIMessages.QueryableUpdates_UpdateListProgress, totalWork);
+		SubMonitor subMonitor = SubMonitor.convert(monitor, ProvUIMessages.QueryableUpdates_UpdateListProgress,
+				totalWork);
 		IPlanner planner = ui.getSession().getProvisioningAgent().getService(IPlanner.class);
 		try {
 			Set<IInstallableUnit> allUpdates = new HashSet<>();
 			for (IInstallableUnit unit : iusToUpdate) {
-				if (monitor.isCanceled())
-					return Collector.emptyCollector();
 				IQueryResult<IInstallableUnit> updates = planner.updatesFor(unit,
 						new ProvisioningContext(ui.getSession().getProvisioningAgent()),
-						SubMonitor.convert(monitor, totalWork / 2 / iusToUpdate.length));
+						subMonitor.split(totalWork / 2 / iusToUpdate.length));
 				allUpdates.addAll(updates.toUnmodifiableSet());
 			}
 			return query.perform(allUpdates.iterator());
 		} catch (OperationCanceledException e) {
 			// Nothing more to do, return result
 			return Collector.emptyCollector();
-		} finally {
-			monitor.done();
 		}
 	}
 }


### PR DESCRIPTION
From the documentation:
> Since it is illegal to call beginTask on the same IProgressMonitor
> more than once, the same instance of IProgressMonitor must not be
> passed to convert more than once.

The proper way is to replace calls to IProgressMonitor.beginTask(...) with SubMonitor.convert(...), keep the SubMonitor as a local variable and use that from now on.

This amends commit 9009085b72e9507fdc4b7d0adb87883adefc5637.