### PR TITLE
Add timeout to gathering host certificates #567

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.core;singleton:=true
-Bundle-Version: 2.12.200.qualifier
+Bundle-Version: 2.13.0.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.core.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/IProvisioningAgent.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/IProvisioningAgent.java
@@ -165,4 +165,32 @@ public interface IProvisioningAgent {
 		return Boolean.parseBoolean(getProperty(key, Boolean.toString(defaultValue)));
 	}
 
+	/**
+	 * Returns an agent bound property as an int, the default implementation
+	 * delegates to {@link IProvisioningAgent#getIntProperty(String, int)} with
+	 * <code>0</code> as the default.
+	 *
+	 * @since 2.13
+	 */
+	default int getIntProperty(String key) {
+		return getIntProperty(key, 0);
+	}
+
+	/**
+	 * Returns an agent bound property as an int, the default implementation
+	 * delegates to {@link IProvisioningAgent#getProperty(String)} with the given
+	 * default as a String and parses the result as by
+	 * {@link Boolean#parseBoolean(String)}.
+	 *
+	 * @since 2.13
+	 */
+	default int getIntProperty(String key, int defaultValue) {
+		String propertyValue = getProperty(key, Integer.toString(defaultValue));
+		try {
+			return Integer.parseInt(propertyValue);
+		} catch (NumberFormatException e) {
+			return defaultValue;
+		}
+	}
+
 }

--- a/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.engine;singleton:=true
-Bundle-Version: 2.10.300.qualifier
+Bundle-Version: 2.10.400.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.engine.EngineActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Messages.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Messages.java
@@ -25,6 +25,7 @@ public class Messages extends NLS {
 	public static String ActionManager_Required_Touchpoint_Not_Found;
 
 	public static String AuthorityChecker_UntrustedAuthorities;
+	public static String AuthorityChecker_GatherCertificatesFailure;
 
 	public static String actions_not_found;
 	private static final String BUNDLE_NAME = "org.eclipse.equinox.internal.p2.engine.messages"; //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/messages.properties
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/messages.properties
@@ -15,6 +15,7 @@
 ActionManager_Exception_Creating_Action_Extension=Error creating action with id: {0}.
 ActionManager_Required_Touchpoint_Not_Found=The required {0} touchpoint for the {1} action is not included in the installation manager configuration.
 AuthorityChecker_UntrustedAuthorities=One or more authorities is not trusted. Cannot proceed with installation.
+AuthorityChecker_GatherCertificatesFailure=Obtaining a host certificate resulted in an exception. This host will be ignored.
 action_syntax_error=Invalid action syntax: {0}.
 download_artifact=Downloading artifacts
 download_no_repository=No artifact repository available.

--- a/bundles/org.eclipse.equinox.p2.ui.sdk/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.sdk;singleton:=true
-Bundle-Version: 1.3.300.qualifier
+Bundle-Version: 1.3.400.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.sdk.ProvSDKUIActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.ui.sdk/src/org/eclipse/equinox/internal/p2/ui/sdk/TrustPreferencePage.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk/src/org/eclipse/equinox/internal/p2/ui/sdk/TrustPreferencePage.java
@@ -115,7 +115,7 @@ public class TrustPreferencePage extends PreferencePage implements IWorkbenchPre
 					}
 				});
 
-				var certificates = AuthorityChecker.getCertificates(uris, monitor);
+				var certificates = authorityChecker.getCertificates(uris, monitor);
 				authorityCertificates.putAll(certificates);
 
 				if (!parent.isDisposed()) {

--- a/features/org.eclipse.equinox.p2.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.core.feature"
       label="%featureName"
-      version="1.7.400.qualifier"
+      version="1.7.500.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.discovery.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.discovery.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.discovery.feature"
       label="%featureName"
-      version="1.3.600.qualifier"
+      version="1.3.700.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.rcp.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.rcp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.rcp.feature"
       label="%featureName"
-      version="1.4.2600.qualifier"
+      version="1.4.2700.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.server.p2/feature.xml
+++ b/features/org.eclipse.equinox.server.p2/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.p2"
       label="%featureName"
-      version="1.12.1500.qualifier"
+      version="1.12.1600.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
As explained in #567, it is currently possible that Eclipse waits infinitely for a host certificate in case the server accepting the request but not responding after that. This issue [caused the plugin installation of a Stack Overflow user to get stuck](https://stackoverflow.com/q/79193830/10871900).

This PR adds a timeout and retrying using the properties `org.eclipse.equinox.p2.engine.requestTimeout` and `org.eclipse.equinox.p2.engine.requestRetries`.

### How to test
- Create a server that accepts incoming connections but never responds, e.g. `nc -l 8080 -k` on Linux or using Java code similar to the following (not using TLS for simplicity):
  ```java
  try(ServerSocket servSock = new ServerSocket(8080)){
      while(true){
          try(Socket sock = servSock.accept();
              BufferedReader br = new BufferedReader(new InputStreamReader(sock.getInputStream()))){
              br.lines().forEach(System.out::println);
          }
      }
  }
  ```
- In the Eclipse application, go to `Preferences` > `Install/Update` > `Trust` > `Authorities`
- Change `http` to `Allow`
- Click `Add`
- Enter `http://localhost:8080`

Without this change, Eclipse sends one HTTP request to this server, never closes the request and [the thread is blocked forever](https://github.com/eclipse-equinox/p2/blob/65348d689980d1e11708f934f1767f056e62907d/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/AuthorityChecker.java#L266).

With this change, it sends multiple (by default 3) requests to the server and then skips the host.

### Other changes

I also added a warning log when gathering certificates throws an exception. I made sure the current thread is reinterrupted when an `InterruptedException` is thrown (and not logging anything since that seems unnecessary).

### Notes

Since I didn't find a property that I felt was actually applicable to reuse for the timeout and retry count, I created new ones. I decided on a default of 2 retries (i.e. 3 requests in total) with a timeout (not the connection timeout but the timeout of [the request](https://docs.oracle.com/en/java/javase/21/docs/api/java.net.http/java/net/http/HttpRequest.Builder.html#timeout(java.time.Duration)), i.e. when waiting for a response after connecting) of 5 seconds. I didn't include a backoff time between requests but I could still add that if wanted.