### PR TITLE
Improve progress reporting for download jobs

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/Messages.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/Messages.java
@@ -18,6 +18,9 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.equinox.internal.p2.artifact.repository.messages"; //$NON-NLS-1$
 
+	public static String DownloadJob_initial;
+	public static String DownloadJob_current_artifact;
+
 	public static String artifact_not_found;
 	public static String available_already_in;
 	public static String no_location;

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/messages.properties
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/messages.properties
@@ -67,3 +67,5 @@ error_copying_local_file=An error occurred copying file {0}.
 
 onlyInsecureDigestAlgorithmUsed = The digest algorithms ({0}) used to verify {1} have severely compromised security. Please report this concern to the artifact provider.
 noDigestAlgorithmToVerifyDownload = No digest algorithm is available to verify download of {0} from repository {1}.
+DownloadJob_initial=Downloading Software
+DownloadJob_current_artifact=Downloading {0}

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/DownloadJob.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/DownloadJob.java
@@ -15,26 +15,33 @@
 package org.eclipse.equinox.internal.p2.artifact.repository.simple;
 
 import java.util.LinkedList;
+import java.util.function.Consumer;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.equinox.internal.p2.artifact.repository.Messages;
+import org.eclipse.equinox.p2.metadata.IArtifactKey;
 import org.eclipse.equinox.p2.repository.artifact.IArtifactRequest;
 
 public class DownloadJob extends Job {
+	private static final int SUB_TICKS = 1000;
+
 	static final Object FAMILY = new Object();
 
 	private final LinkedList<IArtifactRequest> requestsPending;
 	private final SimpleArtifactRepository repository;
-	private final IProgressMonitor masterMonitor;
-	private final MultiStatus overallStatus;
+
+	private Consumer<IStatus> resultConsumer;
+
+	private Consumer<String> messageConsumer;
 
 	DownloadJob(String name, SimpleArtifactRepository repository, LinkedList<IArtifactRequest> requestsPending,
-			IProgressMonitor masterMonitor, MultiStatus overallStatus) {
+			Consumer<IStatus> resultConsumer, Consumer<String> messageConsumer) {
 		super(name);
+		this.resultConsumer = resultConsumer;
+		this.messageConsumer = messageConsumer;
 		setSystem(true);
 		this.repository = repository;
 		this.requestsPending = requestsPending;
-		this.masterMonitor = masterMonitor;
-		this.overallStatus = overallStatus;
 	}
 
 	@Override
@@ -44,28 +51,97 @@ public class DownloadJob extends Job {
 
 	@Override
 	protected IStatus run(IProgressMonitor jobMonitor) {
-		jobMonitor.beginTask("Downloading software", IProgressMonitor.UNKNOWN); //$NON-NLS-1$
+		SubMonitor monitor = SubMonitor.convert(jobMonitor, Messages.DownloadJob_initial, 1_000_000);
 		do {
-			// get the request we are going to process
 			IArtifactRequest request;
 			synchronized (requestsPending) {
-				if (requestsPending.isEmpty())
-					break;
+				int totalDownloadWork = requestsPending.size();
+				if (totalDownloadWork == 0) {
+					return Status.OK_STATUS;
+				}
+				monitor.setWorkRemaining(totalDownloadWork * SUB_TICKS);
 				request = requestsPending.removeFirst();
 			}
-			if (masterMonitor.isCanceled())
-				return Status.CANCEL_STATUS;
-			// process the actual request
-			SubMonitor subMonitor = SubMonitor.convert(masterMonitor.slice(1), 1);
-			IStatus status = repository.getArtifact(request, subMonitor);
-			if (!status.isOK()) {
-				synchronized (overallStatus) {
-					overallStatus.add(status);
-				}
-			}
-		} while (true);
+			IArtifactKey key = request.getArtifactKey();
+			String currentArtifact = String.format("%s %s", key.getId(), key.getVersion()); //$NON-NLS-1$
+			monitor.setTaskName(currentArtifact);
+			SubMonitor split = monitor.split(SUB_TICKS, SubMonitor.SUPPRESS_NONE);
+			IStatus status = repository.getArtifact(request, new IProgressMonitor() {
 
-		jobMonitor.done();
-		return Status.OK_STATUS;
+				private volatile boolean canceled;
+				private String taskName;
+				private String subTaskName;
+				private String lastMessage;
+
+				@Override
+				public void worked(int work) {
+					split.worked(work);
+				}
+
+				@Override
+				public void subTask(String name) {
+					this.subTaskName = name;
+					if (messageConsumer != null) {
+						messageConsumer.accept(name);
+					}
+					updateTaskName();
+				}
+
+				@Override
+				public void setTaskName(String name) {
+					this.taskName = name;
+					updateTaskName();
+				}
+
+				@Override
+				public void setCanceled(boolean canceled) {
+					this.canceled = canceled;
+				}
+
+				@Override
+				public boolean isCanceled() {
+					return canceled;
+				}
+
+				@Override
+				public void internalWorked(double work) {
+					split.internalWorked(work);
+				}
+
+				@Override
+				public void done() {
+					split.done();
+
+				}
+
+				@Override
+				public void beginTask(String name, int totalWork) {
+					monitor.beginTask(name, totalWork);
+					this.taskName = name;
+					updateTaskName();
+				}
+
+				private void updateTaskName() {
+					StringBuilder sb = new StringBuilder();
+					if (taskName != null && !taskName.isBlank()) {
+						sb.append(taskName);
+					}
+					if (subTaskName != null && !subTaskName.isBlank()) {
+						if (sb.length() > 0) {
+							sb.append(" - "); //$NON-NLS-1$
+						}
+						sb.append(subTaskName);
+					}
+					String message = sb.toString();
+					if (message.length() > 0 && !message.equals(lastMessage)) {
+						lastMessage = message;
+						monitor.subTask(message);
+					}
+				}
+			});
+			resultConsumer.accept(status);
+		} while (!monitor.isCanceled());
+		return Status.CANCEL_STATUS;
 	}
+
 }

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/CompositeArtifactRepositoryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/CompositeArtifactRepositoryTest.java
@@ -595,7 +595,8 @@ public class CompositeArtifactRepositoryTest extends AbstractProvisioningTest {
 	}
 
 	public void testGetArtifactsWithErrorInChild() throws Exception {
-		repositoryURI = getTestData("1", "/testData/artifactRepo/composite/errorInChild").toURI();
+		File testData = getTestData("1", "/testData/artifactRepo/composite/errorInChild");
+		repositoryURI = testData.toURI();
 		IArtifactRepository repo = getArtifactRepositoryManager().loadRepository(repositoryURI, null);
 
 		IArtifactRequest[] requests = new IArtifactRequest[] {new ArtifactRequest(new ArtifactKey("osgi.bundle", "plugin", Version.parseVersion("1.0.0")), null) {
@@ -611,8 +612,10 @@ public class CompositeArtifactRepositoryTest extends AbstractProvisioningTest {
 		assertThat(status, is(statusWithMessageWhich(containsString("while reading artifacts from child repositories"))));
 
 		// bug 391400: status should point to repository with problem
-		String brokenChildURI = repositoryURI.toString() + "child";
-		assertThat(Arrays.asList(status.getChildren()), hasItem(statusWithMessageWhich(containsString(brokenChildURI))));
+		assertThat(Arrays.asList(status.getChildren()),
+				hasItem(statusWithMessageWhich(containsString("An error occurred copying file"))));
+		assertThat(Arrays.asList(status.getChildren()),
+				hasItem(statusWithMessageWhich(containsString(testData.getAbsolutePath()))));
 	}
 
 	public void testLoadingRepositoryRemote() {


### PR DESCRIPTION
Currently the reporting of progress for download jobs has some flaws:

1) it concurrently updates a shared monitor but these are usually not made for concurrent use
2) the jobs own monitor does not really reflect progress 3) Messages are not externalized

This now refactor this part in the following way:
- create a submonitor from the job so we can update the remaning work
- assign some subticks to each download to report progress on the job
- set the current artifact behind downloaded as the message
- report messages from downstream as sub task to the job
- add two consumers for the caller of the job to get notified about messages and status