### PR TITLE
Create reproducible properties files

### DIFF
--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Import-Package: org.eclipse.equinox.frameworkadmin;version="[2.0.0,3.0.0)",
  org.osgi.framework.startlevel;version="1.0.0",
  org.osgi.service.log;version="1.3.0",
  org.osgi.service.startlevel;version="1.0.0",
- org.osgi.util.tracker;version="1.3.0"
+ org.osgi.util.tracker;version="1.3.0",
+ org.eclipse.equinox.internal.p2.core.helpers
 Export-Package: org.eclipse.equinox.internal.frameworkadmin.equinox;x-friends:="org.eclipse.equinox.p2.publisher,org.eclipse.equinox.p2.publisher.eclipse,org.eclipse.equinox.simpleconfigurator.manipulator",
  org.eclipse.equinox.internal.frameworkadmin.equinox.utils;x-friends:="org.eclipse.equinox.p2.publisher.eclipse"
 Require-Bundle: org.eclipse.equinox.common;bundle-version="3.18.0"

--- a/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EquinoxFwConfigFileParser.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.equinox/src/org/eclipse/equinox/internal/frameworkadmin/equinox/EquinoxFwConfigFileParser.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
 import org.eclipse.equinox.internal.frameworkadmin.equinox.utils.FileUtils;
 import org.eclipse.equinox.internal.frameworkadmin.utils.Utils;
+import org.eclipse.equinox.internal.p2.core.helpers.ReproducibleHelper;
 import org.eclipse.equinox.internal.provisional.frameworkadmin.*;
 import org.eclipse.osgi.util.NLS;
 import org.osgi.framework.BundleContext;
@@ -544,7 +545,7 @@ public class EquinoxFwConfigFileParser {
 	private void saveProperties(File outputFile, Properties configProps) throws IOException {
 		String header = "This configuration file was written by: " + this.getClass().getName(); //$NON-NLS-1$
 		try (FileOutputStream out = new FileOutputStream(outputFile)) {
-			configProps.store(out, header);
+			ReproducibleHelper.storeProperties(configProps, out, header);
 			Log.info(NLS.bind(Messages.log_propertiesSaved, outputFile));
 		}
 	}

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/CollectionUtils.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/CollectionUtils.java
@@ -242,6 +242,6 @@ public class CollectionUtils {
 	public static void storeProperties(Map<String, String> properties, OutputStream stream, String comment) throws IOException {
 		Properties props = new Properties();
 		props.putAll(properties);
-		props.store(stream, comment);
+		ReproducibleHelper.storeProperties(props, stream, comment);
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/ReproducibleHelper.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/ReproducibleHelper.java
@@ -1,0 +1,52 @@
+/**
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.equinox.internal.p2.core.helpers;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Utility methods for reproducible builds.
+ */
+public final class ReproducibleHelper {
+	private ReproducibleHelper() {
+	}
+
+    /**
+     * Writes the property list to the output stream in a reproducible way. The java.util.Properties
+     * class writes the lines in a non-reproducible order, adds a non-reproducible timestamp and
+     * uses platform-dependent new line characters.
+     *
+     * @param properties
+     *            the properties object to write to the output stream.
+     * @param out
+     *            an output stream.
+     * @param comments
+     *            a description of the property list.
+     * @throws IOException
+     *             if writing the property list to the specified output stream throws an
+     *             IOException.
+     */
+    public static void storeProperties(Properties properties, OutputStream out, String comments) throws IOException {
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        properties.store(baos, comments);
+        final String originalContent = baos.toString(StandardCharsets.ISO_8859_1);
+        // Keep the comment lines if any
+        final long commentLinesNb = (comments != null) ? comments.lines().count() : 0;
+        final Stream<String> commentLinesStream = originalContent.lines().limit(commentLinesNb);
+        // Drop the timestamp comment, order the lines and use a system-independent new line
+        final String contentFixed = Stream
+                .concat(commentLinesStream, originalContent.lines().skip(commentLinesNb + 1).sorted())
+                .collect(Collectors.joining("\n", "", "\n"));
+        out.write(contentFixed.getBytes(StandardCharsets.ISO_8859_1));
+    }
+}

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/SimpleProfileRegistry.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/SimpleProfileRegistry.java
@@ -1059,7 +1059,7 @@ public class SimpleProfileRegistry implements IProfileRegistry, IAgentService {
 		Properties prunedProperties = properties;
 		try (OutputStream output = new BufferedOutputStream(new FileOutputStream(file));) {
 			prunedProperties = pruneStateProperties(id, properties);
-			prunedProperties.store(output, null);
+			ReproducibleHelper.storeProperties(prunedProperties, output, null);
 			output.flush();
 		} catch (IOException e) {
 			return new Status(IStatus.ERROR, EngineActivator.ID, Messages.SimpleProfileRegistry_States_Error_Writing_File, e);

--- a/bundles/org.eclipse.equinox.p2.reconciler.dropins/src/org/eclipse/equinox/internal/p2/reconciler/dropins/Activator.java
+++ b/bundles/org.eclipse.equinox.p2.reconciler.dropins/src/org/eclipse/equinox/internal/p2/reconciler/dropins/Activator.java
@@ -196,7 +196,7 @@ public class Activator implements BundleActivator {
 				try (OutputStream os = new BufferedOutputStream(new FileOutputStream(configIni))) {
 					String externalForm = PathUtil.makeRelative(parentConfiguration.toURL().toExternalForm(), getOSGiInstallArea()).replace('\\', '/');
 					props.put("osgi.sharedConfiguration.area", externalForm); //$NON-NLS-1$
-					props.store(os, "Linked configuration"); //$NON-NLS-1$
+					ReproducibleHelper.storeProperties(props, os, "Linked configuration"); //$NON-NLS-1$
 				}
 			} catch (IOException e) {
 				LogHelper.log(new Status(IStatus.ERROR, ID, "Unable to create linked configuration location.", e)); //$NON-NLS-1$
@@ -410,7 +410,7 @@ public class Activator implements BundleActivator {
 		trace("Writing out timestamps to file : " + file.getAbsolutePath()); //$NON-NLS-1$
 		file.delete();
 		try (OutputStream output = new BufferedOutputStream(new FileOutputStream(file))) {
-			timestamps.store(output, null);
+			ReproducibleHelper.storeProperties(timestamps, output, null);
 			if (Tracing.DEBUG_RECONCILER) {
 				for (Object key : timestamps.keySet()) {
 					Object value = timestamps.get(key);

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/XZCompressor.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/XZCompressor.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Properties;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
+import org.eclipse.equinox.internal.p2.core.helpers.ReproducibleHelper;
 import org.eclipse.equinox.internal.p2.metadata.repository.Messages;
 import org.eclipse.osgi.util.NLS;
 import org.tukaani.xz.*;
@@ -165,8 +166,7 @@ public class XZCompressor {
 		}
 		p2Index.setProperty("version", "1"); //$NON-NLS-1$//$NON-NLS-2$
 		try (OutputStream output = new FileOutputStream(new File(repoFolder, "p2.index"));) { //$NON-NLS-1$
-			// $NON-NLS-1$
-			p2Index.store(output, null);
+			ReproducibleHelper.storeProperties(p2Index, output, null);
 		}
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/touchpoint/eclipse/actions/AddJVMArgumentAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/touchpoint/eclipse/actions/AddJVMArgumentAction.java
@@ -18,6 +18,7 @@ import java.io.*;
 import java.util.*;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.equinox.internal.p2.core.helpers.ReproducibleHelper;
 import org.eclipse.equinox.internal.p2.touchpoint.eclipse.*;
 import org.eclipse.equinox.internal.provisional.frameworkadmin.LauncherData;
 import org.eclipse.equinox.internal.provisional.frameworkadmin.Manipulator;
@@ -285,7 +286,7 @@ public class AddJVMArgumentAction extends ProvisioningAction {
 		try {
 			try {
 				out = new FileOutputStream(file);
-				args.store(out, null);
+				ReproducibleHelper.storeProperties(args, out, null);
 			} finally {
 				if (out != null)
 					out.close();

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/NativePackageExtractionApplication.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/NativePackageExtractionApplication.java
@@ -19,6 +19,7 @@ import java.util.*;
 import org.eclipse.core.runtime.*;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
+import org.eclipse.equinox.internal.p2.core.helpers.ReproducibleHelper;
 import org.eclipse.equinox.internal.p2.touchpoint.natives.actions.ActionConstants;
 import org.eclipse.equinox.internal.p2.touchpoint.natives.actions.CheckAndPromptNativePackage;
 import org.eclipse.equinox.p2.core.*;
@@ -124,7 +125,8 @@ public class NativePackageExtractionApplication implements IApplication {
 
 	private void persistInformation() throws CoreException {
 		try (BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(resultFile))) {
-			extractedData.store(os, "Data extracted from eclipse located at " + installation); //$NON-NLS-1$
+			ReproducibleHelper.storeProperties(extractedData, os,
+					"Data extracted from eclipse located at " + installation); //$NON-NLS-1$
 		} catch (IOException e) {
 			throw new CoreException(new Status(IStatus.ERROR, Activator.ID,
 					Messages.NativePackageExtractionApplication_PersistencePb + resultFile.getAbsolutePath(), e));

--- a/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Import-Package: org.eclipse.equinox.frameworkadmin;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.internal.provisional.frameworkadmin,
  org.eclipse.equinox.internal.simpleconfigurator,
  org.eclipse.equinox.internal.simpleconfigurator.utils,
- org.osgi.framework;version="1.3.0"
+ org.osgi.framework;version="1.3.0",
+ org.eclipse.equinox.internal.p2.core.helpers
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.equinox.internal.simpleconfigurator.manipulator;x-friends:="org.eclipse.equinox.p2.touchpoint.eclipse",
  org.eclipse.equinox.simpleconfigurator.manipulator;version="2.0.0"

--- a/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/src/org/eclipse/equinox/internal/simpleconfigurator/manipulator/SimpleConfiguratorManipulatorImpl.java
+++ b/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/src/org/eclipse/equinox/internal/simpleconfigurator/manipulator/SimpleConfiguratorManipulatorImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.equinox.frameworkadmin.BundleInfo;
 import org.eclipse.equinox.internal.frameworkadmin.equinox.ParserUtils;
 import org.eclipse.equinox.internal.frameworkadmin.utils.Utils;
+import org.eclipse.equinox.internal.p2.core.helpers.ReproducibleHelper;
 import org.eclipse.equinox.internal.provisional.configuratormanipulator.ConfiguratorManipulator;
 import org.eclipse.equinox.internal.provisional.frameworkadmin.*;
 import org.eclipse.equinox.internal.simpleconfigurator.SimpleConfiguratorImpl;
@@ -463,7 +464,7 @@ public class SimpleConfiguratorManipulatorImpl implements SimpleConfiguratorMani
 			try {
 				File outputFile = new File(outputFolder, SimpleConfiguratorImpl.BASE_TIMESTAMP_FILE_BUNDLESINFO);
 				os = new BufferedOutputStream(new FileOutputStream(outputFile));
-				timestampToPersist.store(os, "Written by " + this.getClass()); //$NON-NLS-1$
+				ReproducibleHelper.storeProperties(timestampToPersist, os, "Written by " + this.getClass()); //$NON-NLS-1$
 			} finally {
 				if (os != null)
 					os.close();


### PR DESCRIPTION
There is an ongoing effort to make Tycho produce reproducible artifacts. Some non-reproducible bits come from equinox-p2. This PR makes the properties files created by equinox-p2 reproducible (remove the timestamp and sort the lines).