### PR TITLE
Migration to more consistent property name for provided service

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/.settings/.api_filters
+++ b/bundles/org.eclipse.equinox.p2.core/.settings/.api_filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.equinox.p2.core" version="2">
+    <resource path="src/org/eclipse/equinox/p2/core/spi/IAgentServiceFactory.java" type="org.eclipse.equinox.p2.core.spi.IAgentServiceFactory">
+        <filter id="403767336">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.core.spi.IAgentServiceFactory"/>
+                <message_argument value="PROP_AGENT_SERVICE_NAME"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/EventBusComponent.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/EventBusComponent.java
@@ -21,7 +21,7 @@ import org.osgi.service.component.annotations.Component;
 /**
  * Factory for creating {@link IProvisioningEventBus} instances.
  */
-@Component(service = IAgentServiceFactory.class, property = IAgentServiceFactory.PROP_CREATED_SERVICE_NAME + "="
+@Component(service = IAgentServiceFactory.class, property = IAgentServiceFactory.PROP_AGENT_SERVICE_NAME + "="
 		+ IProvisioningEventBus.SERVICE_NAME, name = "org.eclipse.equinox.p2.core.eventbus")
 public class EventBusComponent implements IAgentServiceFactory {
 	@Override

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/spi/IAgentServiceFactory.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/spi/IAgentServiceFactory.java
@@ -25,12 +25,24 @@ public interface IAgentServiceFactory {
 	/**
 	 * The service name for the factory service.
 	 */
-	public static final String SERVICE_NAME = IAgentServiceFactory.class.getName();
+	String SERVICE_NAME = IAgentServiceFactory.class.getName();
 
 	/**
-	 * The service property specifying the name of the service created by this factory.
+	 * The service property specifying the name of the service created by this
+	 * factory.
+	 *
+	 * @deprecated use {@link #PROP_AGENT_SERVICE_NAME} instead
 	 */
-	public static final String PROP_CREATED_SERVICE_NAME = "p2.agent.servicename"; //$NON-NLS-1$
+	@Deprecated()
+	String PROP_CREATED_SERVICE_NAME = "p2.agent.servicename"; //$NON-NLS-1$
+
+	/**
+	 * The service property specifying the name of the service created by this
+	 * factory.
+	 *
+	 * @since 2.13
+	 */
+	String PROP_AGENT_SERVICE_NAME = "p2.agent.service.name"; //$NON-NLS-1$
 
 	/**
 	 * Instantiates a service instance for the given provisioning agent.
@@ -38,5 +50,5 @@ public interface IAgentServiceFactory {
 	 * @param agent The agent this service will belong to
 	 * @return The created service
 	 */
-	public Object createService(IProvisioningAgent agent);
+	Object createService(IProvisioningAgent agent);
 }

--- a/bundles/org.eclipse.equinox.p2.tests.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.tests.ui
-Bundle-Version: 1.4.400.qualifier
+Bundle-Version: 1.4.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",


### PR DESCRIPTION
Currently we use the property `p2.agent.servicename` to identify the provided service, but the constant is named `PROP_CREATED_SERVICE_NAME`. So beside the inconsistency of created <> agent it shows that the "name" part should actually be an own segment (like in AgentServiceFactory). This also affects the naming of component property types

Because of this we introduce here a new constant `PROP_AGENT_SERVICE_NAME` with the value 'p2.agent.service.name' and deprecate the old constant while remain support for both properties.