### PR TITLE
Add component property type for agent service name property

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/EventBusComponent.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/EventBusComponent.java
@@ -15,14 +15,15 @@ package org.eclipse.equinox.internal.p2.core;
 
 import org.eclipse.equinox.internal.provisional.p2.core.eventbus.IProvisioningEventBus;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
+import org.eclipse.equinox.p2.core.spi.AgentServiceName;
 import org.eclipse.equinox.p2.core.spi.IAgentServiceFactory;
 import org.osgi.service.component.annotations.Component;
 
 /**
  * Factory for creating {@link IProvisioningEventBus} instances.
  */
-@Component(service = IAgentServiceFactory.class, property = IAgentServiceFactory.PROP_AGENT_SERVICE_NAME + "="
-		+ IProvisioningEventBus.SERVICE_NAME, name = "org.eclipse.equinox.p2.core.eventbus")
+@Component(service = IAgentServiceFactory.class, name = "org.eclipse.equinox.p2.core.eventbus")
+@AgentServiceName(IProvisioningEventBus.class)
 public class EventBusComponent implements IAgentServiceFactory {
 	@Override
 	public Object createService(IProvisioningAgent agent) {

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/spi/AgentServiceName.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/spi/AgentServiceName.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.p2.core.spi;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.osgi.service.component.annotations.ComponentPropertyType;
+
+/**
+ * This component property type can be used to annotate a declarative service
+ * component that provides an {@link IAgentServiceFactory} to provides the
+ * required {@link IAgentServiceFactory#PROP_AGENT_SERVICE_NAME}.
+ *
+ * @since 2.13
+ */
+@Retention(CLASS)
+@Target(TYPE)
+@ComponentPropertyType
+public @interface AgentServiceName {
+
+	public static final String PREFIX_ = "p2."; //$NON-NLS-1$
+
+	Class<?> value();
+
+}


### PR DESCRIPTION
Component property types are much more expressive and convenient to use than string concatenations and less error prone on refactorings/reference searches.

This now adds a new component property type for the `p2.agent.service.name` and uses it at the place where it previously using the property constant to show usage.

I also checked for the case now that it produces the same component.xml output