### PR TITLE
Don't assume an artifact download fails because it can't be found

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/DownloadManager.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/DownloadManager.java
@@ -172,6 +172,7 @@ public class DownloadManager {
 		for (IArtifactRequest request : requestsToProcess) {
 			IStatus failed = request.getResult();
 			if (failed != null && !failed.isOK()) {
+				result.add(failed);
 				IArtifactKey key = request.getArtifactKey();
 				IInstallableUnit unit = getUnit(key);
 				if (unit != null) {
@@ -181,9 +182,7 @@ public class DownloadManager {
 									Arrays.stream(repositories).map(repo -> repo.getLocation()).filter(Objects::nonNull)
 											.map(URI::toString).collect(Collectors.joining(System.lineSeparator(),
 													System.lineSeparator(), "")) }))); //$NON-NLS-1$
-					continue;
 				}
-				result.add(failed);
 			}
 		}
 		return result;


### PR DESCRIPTION
- Ensure that the original failure status is included in the final result of DownloadManager.overallStatus.