### PR TITLE
Record Package Attributes and Directives on exported packages

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/BundlesActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/BundlesActionTest.java
@@ -516,6 +516,27 @@ public class BundlesActionTest extends ActionTest {
 		assertThat(ius.size(), is(1));
 	}
 
+	public void testPackageAttributes() throws Exception {
+		File testData = new File(TestActivator.getTestDataFolder(), "pkgAttributes");
+		IInstallableUnit iu = BundlesAction.createBundleIU(BundlesAction.createBundleDescription(testData), null,
+				new PublisherInfo());
+		IProvidedCapability capability = iu.getProvidedCapabilities().stream()
+				.filter(provided -> provided.getNamespace().equals(PublisherHelper.CAPABILITY_NS_JAVA_PACKAGE))
+				.findFirst().orElseThrow(() -> new AssertionError("no package found!"));
+		Map<String, Object> properties = capability.getProperties();
+		assertEquals(String.valueOf(properties), "org.eclipse.core.runtime",
+				properties.get(PublisherHelper.CAPABILITY_NS_JAVA_PACKAGE));
+		assertEquals(String.valueOf(properties), "split",
+				properties.get(BundlesAction.PACKAGE_ATTRIBUTE_PROPERTY_PREFIX + "common"));
+		Object object = properties.get(BundlesAction.PACKAGE_DIRECTIVE_PROPERTY_PREFIX + "mandatory");
+		if (object instanceof List<?> list) {
+			assertTrue(list.contains("common"));
+		} else {
+			fail("Not a list: " + object);
+		}
+
+	}
+
 	public void testMultiRequired() throws Exception {
 		File testData = new File(TestActivator.getTestDataFolder(), "requireMultiple");
 		IInstallableUnit iu = BundlesAction.createBundleIU(BundlesAction.createBundleDescription(testData), null,

--- a/bundles/org.eclipse.equinox.p2.tests/testData/pkgAttributes/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests/testData/pkgAttributes/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: pkg.attr
+Bundle-SymbolicName: pkg.attr
+Bundle-Version: 1.0.0
+Export-Package: org.eclipse.core.runtime;common=split;version="3.7.0";mandatory:=common


### PR DESCRIPTION
Currently P2 lacks support for package attributes and directives that can lead to wrong selection of providers. One issue is that the information on exported packages are not recorded at all in the P2 metadata and therefore can not be used in slicer or planner operations.

As a first step this now records the information on the provider side by transforming attributes and directives into properties of the package capability.