### PR TITLE
[Build] Reuse 'releaseVersion' property from eclipse-platform-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,9 @@
 
   <properties>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-equinox/p2.git</tycho.scmUrl>
-    <releaseVersion>4.35.0</releaseVersion>
     <!-- Defines the default Qualifier if no format is given-->
     <!-- can be overriden with -Dtycho.buildqualifier.format=yyyyMMddHHmm for a dynamic qualifier or -Dqualifier=abcd for a static value -->
-    <qualifier>-SNAPSHOT</qualifier>
+    <qualifier>.0-SNAPSHOT</qualifier>
     <!-- disabled for now, should be enabled later! -->
     <addMavenDescriptor>false</addMavenDescriptor>
     <failOnJavadocErrors>true</failOnJavadocErrors>


### PR DESCRIPTION
Don't redefine the `releaseVersion` from the `eclipse-platform-parent/pom.xml` with a slightly different value.

This reduces the number of required changes in the preparation of new release-cycles and unblocks
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2799