### PR TITLE
Ensure that AbstractRepository.properties cannot be replaced

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/spi/AbstractRepository.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/spi/AbstractRepository.java
@@ -35,7 +35,7 @@ public abstract class AbstractRepository<T> extends PlatformObject implements IR
 	private String description;
 	private transient URI location;
 	private String name;
-	private Map<String, String> properties = new OrderedProperties();
+	private final Map<String, String> properties = new OrderedProperties();
 	private String provider;
 	private String type;
 	private String version;
@@ -111,7 +111,7 @@ public abstract class AbstractRepository<T> extends PlatformObject implements IR
 	}
 
 	@Override
-	public String getProperty(String key) {
+	public synchronized String getProperty(String key) {
 		return properties.get(key);
 	}
 
@@ -236,7 +236,8 @@ public abstract class AbstractRepository<T> extends PlatformObject implements IR
 	 * @param properties the repository provider
 	 */
 	protected synchronized void setProperties(Map<String, String> properties) {
-		this.properties = properties;
+		this.properties.clear();
+		this.properties.putAll(properties);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/MirrorRequestTest2.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/MirrorRequestTest2.java
@@ -125,7 +125,7 @@ public class MirrorRequestTest2 extends AbstractTestServerClientCase {
 		}
 
 		@Override
-		public String getProperty(String key) {
+		public synchronized String getProperty(String key) {
 			return getProperties().get(key);
 		}
 


### PR DESCRIPTION
- Make AbstractRepository.properties final.
- Modify AbstractRepository.setProperties to do a clear and a putAll.
- Make the only method that accesses AbstractRepository.properties without synchronization, AbstractRepository.getProperty(String), also be synchronized.

https://github.com/eclipse-tycho/tycho/issues/4709