### PR TITLE
back-port PR #421: Do not use PackageAdmin for refresh bundles

### DIFF
--- a/bundles/org.eclipse.equinox.simpleconfigurator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.equinox.simpleconfigurator;singleton:=true
-Bundle-Version: 1.5.200.qualifier
+Bundle-Version: 1.5.201.qualifier
 Bundle-Name: %bundleName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
Currently there are two ways to refresh packages, one using the deprecated PackageAdmin and one using the FrameworkWiring.

This do the following:
- always use FrameworkWiring
- use collections over arrays
- remove some redundant checks and copy of collections