### PR TITLE
Ensure a single instance of the variable *session*.

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatePlugin.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatePlugin.java
@@ -184,12 +184,10 @@ public class AutomaticUpdatePlugin extends AbstractUIPlugin {
 		reg.put(id, desc);
 	}
 
-	public ProvisioningSession getSession() {
+	public synchronized ProvisioningSession getSession() {
 		if (session == null) {
-			synchronized (this) {
-				IProvisioningAgent agent = ServiceHelper.getService(getContext(), IProvisioningAgent.class);
-				session = new ProvisioningSession(agent);
-			}
+			IProvisioningAgent agent = ServiceHelper.getService(getContext(), IProvisioningAgent.class);
+			session = new ProvisioningSession(agent);
 		}
 		return session;
 	}


### PR DESCRIPTION
`AutomaticUpdatePlugin.getSession()` changed to a synchronized method.