### PR TITLE
Ensure unique artifactIds for pomless aggregation modules

### DIFF
--- a/bundles/build.properties
+++ b/bundles/build.properties
@@ -1,0 +1,1 @@
+pom.model.artifactId = p2-bundles

--- a/features/build.properties
+++ b/features/build.properties
@@ -1,0 +1,1 @@
+pom.model.artifactId = p2-features


### PR DESCRIPTION
Relates to
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2950