### PR TITLE
VersionParser: make Exception message more meaningful

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/Messages.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/Messages.java
@@ -55,6 +55,8 @@ public class Messages extends NLS {
 
 	public static String enum_defined_more_then_once;
 
+	public static String expected_letter_at_position;
+	
 	public static String expected_orignal_after_colon_0;
 
 	public static String expected_orignal_after_slash_0;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionParser.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionParser.java
@@ -83,7 +83,7 @@ public abstract class VersionParser {
 		}
 
 		if (!isLetter(c)) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException(NLS.bind(Messages.expected_letter_at_position, pos, version));
 		}
 
 		if (version.startsWith(Version.RAW_PREFIX, pos)) {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/messages.properties
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/messages.properties
@@ -29,6 +29,7 @@ delimiter_can_not_have_pad_value=A delimiter cannot have a pad value
 delimiter_can_not_have_range=A delimiter cannot have a range
 EOS_after_escape=End of string was encountere after the escape character
 enum_defined_more_then_once=Enumeration was defined more then once
+expected_letter_at_position=Expected letter at position {0} in version: {1}
 expected_orignal_after_colon_0=An original version was expected after colon: {0}
 expected_orignal_after_slash_0=A format or colon was expected after slash: {0}
 expected_slash_after_raw_vector_0=A slash was expected after a raw version: {0}


### PR DESCRIPTION
This PR helps debugging when there was an invalid version string passed.

I wasted hours trying to figure out a failing build because an invalid version string was passed in a <plugin> definition of a p2 feature.xml But the Exception unfortunatelly does not tell what the wrong string was.


## Example

```
BUILD FAILED
java.lang.IllegalArgumentException
        at org.eclipse.equinox.internal.provisional.p2.core.VersionParser.parseInto(VersionParser.java:71)
        at org.eclipse.equinox.internal.provisional.p2.core.Version.create(Version.java:138)
        at org.eclipse.equinox.internal.provisional.p2.core.Version.parseVersion(Version.java:162)
        at org.eclipse.equinox.p2.publisher.eclipse.FeatureEntry.<init>(FeatureEntry.java:51)
        at org.eclipse.equinox.internal.p2.publisher.eclipse.FeatureManifestParser.processPlugin(FeatureManifestParser.java:211)
        at org.eclipse.equinox.internal.p2.publisher.eclipse.FeatureManifestParser.startElement(FeatureManifestParser.java:244)
```


because a feature.xml contained `version="@org.slf4j.api-version@"` which was because of another bug where a token replacement failed. 

```
<plugin
         id="org.slf4j.api"
         download-size="0"
         install-size="0"
         version="@org.slf4j.api-version@"
         unpack="false"/>
```

But it was very hard find this needle in the haystack.

After the change the Exception would have a message like this:

`Expected letter at position 0 in version: @org.slf4j.api-version@`

instead of no message. 
With this information I can then do a fulltext search in my codebase for the string `@org.slf4j.api-version@` to find the file to fix the problem.

