### PR TITLE
Touch bundles affected by compiler changes

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 403352 - Update all parent versions to match our build stream
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2995


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2995