### PR TITLE
Simplify URI to string conversion and avoid URIUtil.toURL()

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/BlobStore.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/BlobStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -121,7 +121,7 @@ public class BlobStore {
 	}
 
 	public InputStream getBlob(byte[] uuid) throws IOException {
-		return URIUtil.toURL(fileFor(uuid)).openStream();
+		return fileFor(uuid).toURL().openStream();
 	}
 
 	/**

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/MetadataRepositoryIO.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/MetadataRepositoryIO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2022 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,6 @@ package org.eclipse.equinox.internal.p2.metadata.repository;
 
 import java.io.*;
 import java.lang.reflect.Constructor;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.Set;
@@ -166,14 +165,9 @@ public class MetadataRepositoryIO {
 		private void writeRepositoryReference(IRepositoryReference reference) {
 			start(REPOSITORY_REFERENCE_ELEMENT);
 			attribute(URI_ATTRIBUTE, reference.getLocation().toString());
-
-			try {
-				// we write the URL attribute for backwards compatibility with 3.4.x
-				// this attribute should be removed if we make a breaking format change.
-				attribute(URL_ATTRIBUTE, URIUtil.toURL(reference.getLocation()).toExternalForm());
-			} catch (MalformedURLException e) {
-				attribute(URL_ATTRIBUTE, reference.getLocation().toString());
-			}
+			// we write the URL attribute for backwards compatibility with 3.4.x
+			// this attribute should be removed if we make a breaking format change.
+			attribute(URL_ATTRIBUTE, reference.getLocation().toString());
 
 			attribute(TYPE_ATTRIBUTE, Integer.toString(reference.getType()));
 			attribute(OPTIONS_ATTRIBUTE, Integer.toString(reference.getOptions()));

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/io/MetadataWriter.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/io/MetadataWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2007, 2017 IBM Corporation and others.
+ *  Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *     Genuitec, LLC - added license support
@@ -15,9 +15,9 @@
 package org.eclipse.equinox.internal.p2.metadata.repository.io;
 
 import java.io.OutputStream;
-import java.net.MalformedURLException;
 import java.util.*;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
 import org.eclipse.equinox.internal.p2.metadata.RequiredCapability;
 import org.eclipse.equinox.internal.p2.metadata.RequiredPropertiesMatch;
@@ -396,7 +396,7 @@ public class MetadataWriter extends XMLWriter implements XMLConstants {
 
 	private void writeLicenses(Collection<ILicense> licenses) {
 		if (licenses != null && licenses.size() > 0) {
-			// In the future there may be more than one license, so we write this 
+			// In the future there may be more than one license, so we write this
 			// as a collection of one.
 			// See bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=216911
 			start(LICENSES_ELEMENT);
@@ -408,14 +408,9 @@ public class MetadataWriter extends XMLWriter implements XMLConstants {
 				start(LICENSE_ELEMENT);
 				if (license.getLocation() != null) {
 					attribute(URI_ATTRIBUTE, license.getLocation().toString());
-
-					try {
-						// we write the URL attribute for backwards compatibility with 3.4.x
-						// this attribute should be removed if we make a breaking format change.
-						attribute(URL_ATTRIBUTE, URIUtil.toURL(license.getLocation()).toExternalForm());
-					} catch (MalformedURLException e) {
-						attribute(URL_ATTRIBUTE, license.getLocation().toString());
-					}
+					// we write the URL attribute for backwards compatibility with 3.4.x
+					// this attribute should be removed if we make a breaking format change.
+					attribute(URL_ATTRIBUTE, license.getLocation().toString());
 				}
 				cdata(license.getBody(), true);
 				end(LICENSE_ELEMENT);
@@ -430,13 +425,9 @@ public class MetadataWriter extends XMLWriter implements XMLConstants {
 			try {
 				if (copyright.getLocation() != null) {
 					attribute(URI_ATTRIBUTE, copyright.getLocation().toString());
-					try {
-						// we write the URL attribute for backwards compatibility with 3.4.x
-						// this attribute should be removed if we make a breaking format change.
-						attribute(URL_ATTRIBUTE, URIUtil.toURL(copyright.getLocation()).toExternalForm());
-					} catch (MalformedURLException e) {
-						attribute(URL_ATTRIBUTE, copyright.getLocation().toString());
-					}
+					// we write the URL attribute for backwards compatibility with 3.4.x
+					// this attribute should be removed if we make a breaking format change.
+					attribute(URL_ATTRIBUTE, copyright.getLocation().toString());
 				}
 			} catch (IllegalStateException ise) {
 				LogHelper.log(new Status(IStatus.INFO, Constants.ID, "Error writing the copyright URL: " + copyright.getLocation())); //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/UpdateSingleIUPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/UpdateSingleIUPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.equinox.internal.p2.ui.dialogs;
 
-import java.net.MalformedURLException;
 import org.eclipse.core.runtime.*;
 import org.eclipse.equinox.internal.p2.ui.ProvUIMessages;
 import org.eclipse.equinox.internal.p2.ui.viewers.IUDetailsLabelProvider;
@@ -37,7 +36,8 @@ public class UpdateSingleIUPage extends ProvisioningWizardPage {
 		super("UpdateSingleIUPage", ui, null); //$NON-NLS-1$
 		setTitle(ProvUIMessages.UpdateAction_UpdatesAvailableTitle);
 		IProduct product = Platform.getProduct();
-		String productName = product != null && product.getName() != null ? product.getName() : ProvUIMessages.ApplicationInRestartDialog;
+		String productName = product != null && product.getName() != null ? product.getName()
+				: ProvUIMessages.ApplicationInRestartDialog;
 		setDescription(NLS.bind(ProvUIMessages.UpdateSingleIUPage_SingleUpdateDescription, productName));
 		Assert.isNotNull(operation);
 		Assert.isTrue(operation.hasResolved());
@@ -51,11 +51,7 @@ public class UpdateSingleIUPage extends ProvisioningWizardPage {
 		IInstallableUnit updateIU = getUpdate().replacement;
 		String url = null;
 		if (updateIU.getUpdateDescriptor().getLocation() != null) {
-			try {
-				url = URIUtil.toURL(updateIU.getUpdateDescriptor().getLocation()).toExternalForm();
-			} catch (MalformedURLException e) {
-				// ignore and null URL will be ignored below
-			}
+			url = updateIU.getUpdateDescriptor().getLocation().toString();
 		}
 		if (url != null) {
 			Browser browser = null;


### PR DESCRIPTION
Calling `new URL(uri.toString()).toExternalForm())` instead of `uri.toString()` does not seem to have a benefit.

And `BlobStore.fileFor()` should return an absolute URI and therefore `URI.toURL()` should be save too.