### PR TITLE
Propagate Exceptions in P2 tests to have more meaningful failures

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/engine/SurrogateProfileHandlerTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/engine/SurrogateProfileHandlerTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.equinox.p2.tests.engine;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -97,7 +98,7 @@ public class SurrogateProfileHandlerTest extends AbstractProvisioningTest {
 		assertEquals(2, queryResultSize(surrogateProfile.available(QueryUtil.createIUAnyQuery(), null)));
 	}
 
-	public void testDropletsCanDetectFeatureGroup() throws ProvisionException {
+	public void testDropletsCanDetectFeatureGroup() throws ProvisionException, IOException {
 		// Droplet containing 'org.foo.bar', 'org.foo.bar.feature.feature.jar' and 'org.foo.bar.feature.feature.group'
 		File fragTestData = getTestData("0.1", "/testData/testRepos/foo-droplet");
 		File fragDir = getTempFolder();

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/BaseChange.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/BaseChange.java
@@ -8,12 +8,13 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
- * Contributors: 
+ *
+ * Contributors:
  *     Ericsson AB - initial API and implementation
  ******************************************************************************/
 package org.eclipse.equinox.p2.tests.sharedinstall;
 
+import java.io.IOException;
 import java.util.Properties;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -32,7 +33,7 @@ public class BaseChange extends AbstractSharedInstallTest {
 		super(name);
 	}
 
-	public void testBaseChange() {
+	public void testBaseChange() throws IOException {
 		assertInitialized();
 		setupReadOnlyInstall();
 		System.out.println(readOnlyBase);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/BaseChangeExtendedConfigured.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/BaseChangeExtendedConfigured.java
@@ -129,7 +129,7 @@ public class BaseChangeExtendedConfigured extends BaseChange {
 		setReadOnly(extensions, true);
 	}
 
-	public void testBaseWithExtensionsChange() {
+	public void testBaseWithExtensionsChange() throws IOException {
 		assertInitialized();
 		setupReadOnlyInstall();
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/BaseChangeExtendedConflicts.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/BaseChangeExtendedConflicts.java
@@ -17,7 +17,10 @@ package org.eclipse.equinox.p2.tests.sharedinstall;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.eclipse.equinox.internal.p2.updatesite.Activator;
@@ -126,7 +129,7 @@ public class BaseChangeExtendedConflicts extends BaseChange {
 		setReadOnly(extFolder, true);
 	}
 
-	public void testBundlesSpecifiedMultipleTimes() {
+	public void testBundlesSpecifiedMultipleTimes() throws IOException {
 		assertInitialized();
 		setupReadOnlyInstall();
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/BaseChangeWithoutUserChange.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/BaseChangeWithoutUserChange.java
@@ -8,12 +8,13 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
- * Contributors: 
+ *
+ * Contributors:
  *     Ericsson AB - initial API and implementation
  ******************************************************************************/
 package org.eclipse.equinox.p2.tests.sharedinstall;
 
+import java.io.IOException;
 import java.util.Properties;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -32,7 +33,7 @@ public class BaseChangeWithoutUserChange extends AbstractSharedInstallTest {
 		super(name);
 	}
 
-	public void testBaseChangeWithoutUserChange() {
+	public void testBaseChangeWithoutUserChange() throws IOException {
 		assertInitialized();
 		setupReadOnlyInstall();
 		System.out.println(readOnlyBase);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/Cancellation.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/Cancellation.java
@@ -8,12 +8,13 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
- * Contributors: 
+ *
+ * Contributors:
  *     Ericsson AB - initial API and implementation
  ******************************************************************************/
 package org.eclipse.equinox.p2.tests.sharedinstall;
 
+import java.io.IOException;
 import java.util.Properties;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -32,7 +33,7 @@ public class Cancellation extends AbstractSharedInstallTest {
 		super(name);
 	}
 
-	public void testCancellation() {
+	public void testCancellation() throws IOException {
 		assertInitialized();
 		setupReadOnlyInstall();
 		System.out.println(readOnlyBase);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/DoubleBaseChange.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/DoubleBaseChange.java
@@ -8,12 +8,13 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
- * Contributors: 
+ *
+ * Contributors:
  *     Ericsson AB - initial API and implementation
  ******************************************************************************/
 package org.eclipse.equinox.p2.tests.sharedinstall;
 
+import java.io.IOException;
 import java.util.Properties;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -32,7 +33,7 @@ public class DoubleBaseChange extends AbstractSharedInstallTest {
 		super(name);
 	}
 
-	public void testTwoChanges() {
+	public void testTwoChanges() throws IOException {
 		assertInitialized();
 		setupReadOnlyInstall();
 		System.out.println(readOnlyBase);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/InitialSharedInstall.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/InitialSharedInstall.java
@@ -16,6 +16,7 @@ package org.eclipse.equinox.p2.tests.sharedinstall;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.io.IOException;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.eclipse.equinox.p2.tests.reconciler.dropins.ReconcilerTestSuite;
@@ -45,7 +46,7 @@ public class InitialSharedInstall extends AbstractSharedInstallTest {
 		super(name);
 	}
 
-	public void setupRun() {
+	public void setupRun() throws IOException {
 		cleanupDotEclipseFolder();
 		assertInitialized();
 		replaceDotEclipseProductFile(new File(output, getRootFolder()), "p2.automated.test", "1.0.0");

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/InitialSharedInstallRealTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/InitialSharedInstallRealTest.java
@@ -8,13 +8,14 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
- * Contributors: 
+ *
+ * Contributors:
  *     Ericsson AB - initial API and implementation
  ******************************************************************************/
 package org.eclipse.equinox.p2.tests.sharedinstall;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Properties;
 
 //See InitialSharedInstall
@@ -24,7 +25,7 @@ public class InitialSharedInstallRealTest extends AbstractSharedInstallTest {
 		super(name);
 	}
 
-	public void testImportFromPreviousInstall() {
+	public void testImportFromPreviousInstall() throws IOException {
 		assertInitialized();
 		replaceDotEclipseProductFile(new File(output, getRootFolder()), "p2.automated.test", "1.0.1");
 		installVerifierInBase();

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/InstallInUserSpace.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/InstallInUserSpace.java
@@ -8,12 +8,13 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
- * Contributors: 
+ *
+ * Contributors:
  *     Ericsson AB - initial API and implementation
  ******************************************************************************/
 package org.eclipse.equinox.p2.tests.sharedinstall;
 
+import java.io.IOException;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.eclipse.equinox.p2.engine.IProfile;
@@ -32,7 +33,7 @@ public class InstallInUserSpace extends AbstractSharedInstallTest {
 		super(name);
 	}
 
-	public void testInstallInUserSpace() {
+	public void testInstallInUserSpace() throws IOException {
 		assertInitialized();
 		setupReadOnlyInstall();
 		System.out.println(readOnlyBase);
@@ -40,7 +41,7 @@ public class InstallInUserSpace extends AbstractSharedInstallTest {
 
 		installFeature1AndVerifierInUser();
 		assertTrue(isInUserBundlesInfo("p2TestBundle1"));
-		assertTrue(isInUserBundlesInfo("org.eclipse.swt")); //this verifies that we have the bundles from the base installed in the user bundles.info 
+		assertTrue(isInUserBundlesInfo("org.eclipse.swt")); //this verifies that we have the bundles from the base installed in the user bundles.info
 
 		assertTrue(getUserBundleInfoTimestamp().exists());
 		assertTrue(getConfigIniTimestamp().exists());

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/MultipleChanges.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/MultipleChanges.java
@@ -8,12 +8,13 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
- * Contributors: 
+ *
+ * Contributors:
  *     Ericsson AB - initial API and implementation
  ******************************************************************************/
 package org.eclipse.equinox.p2.tests.sharedinstall;
 
+import java.io.IOException;
 import java.util.Properties;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -32,7 +33,7 @@ public class MultipleChanges extends AbstractSharedInstallTest {
 		super(name);
 	}
 
-	public void testMultipleChangesWithExecution() {
+	public void testMultipleChangesWithExecution() throws IOException {
 		assertInitialized();
 		setupReadOnlyInstall();
 		System.out.println(readOnlyBase);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/TestInitialRun.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/sharedinstall/TestInitialRun.java
@@ -8,12 +8,13 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
- * Contributors: 
+ *
+ * Contributors:
  *     Ericsson AB - initial API and implementation
  ******************************************************************************/
 package org.eclipse.equinox.p2.tests.sharedinstall;
 
+import java.io.IOException;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.eclipse.equinox.p2.engine.IProfile;
@@ -32,7 +33,7 @@ public class TestInitialRun extends AbstractSharedInstallTest {
 		super(name);
 	}
 
-	public void testInitialRun() {
+	public void testInitialRun() throws IOException {
 		assertInitialized();
 		setupReadOnlyInstall();
 		System.out.println(readOnlyBase);


### PR DESCRIPTION
Failure messages, and I quote, `oh shit` are not really helpful.
Hopefully this helps to identify why some P2 tests are currently failing.