### PR TITLE
Add SVGs to org.eclipse.equinox.p2.ui bundles

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui.admin.rcp/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.admin.rcp/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.equinox.internal.p2.ui.admin.rcp;x-internal:=true
 Automatic-Module-Name: org.eclipse.equinox.p2.ui.admin.rcp
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.equinox.p2.ui.admin.rcp/icons/view/provision.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.admin.rcp/icons/view/provision.svg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="profile_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17410">
+      <stop
+         style="stop-color:#e0ebf6;stop-opacity:1;"
+         offset="0"
+         id="stop17412" />
+      <stop
+         style="stop-color:#f3f5f6;stop-opacity:1"
+         offset="1"
+         id="stop17414" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17159">
+      <stop
+         style="stop-color:#ffeece;stop-opacity:1"
+         offset="0"
+         id="stop17161" />
+      <stop
+         style="stop-color:#e1eaba;stop-opacity:1"
+         offset="1"
+         id="stop17163" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17410"
+       id="linearGradient17441"
+       gradientUnits="userSpaceOnUse"
+       x1="-9.733428"
+       y1="12.635066"
+       x2="-3.9386158"
+       y2="6.8402538" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17159"
+       id="linearGradient17443"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.59076155,0.59076155,-0.59076155,0.59076155,17.040411,1049.6082)"
+       x1="-20.742412"
+       y1="7.9916593"
+       x2="-10.422931"
+       y2="7.9916593" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.063994"
+     inkscape:cx="8.506094"
+     inkscape:cy="7.4696588"
+     inkscape:document-units="px"
+     inkscape:current-layer="g17418"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5126" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline;fill:none"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="matrix(0.8261236,0,0,0.8261236,1.7832208,183.40446)">
+      <g
+         transform="matrix(1.2065384,0,0,1.2065384,-22.98457,-221.37405)"
+         id="g17594"
+         style="fill:none">
+        <g
+           id="g17418"
+           transform="matrix(0.96836657,0,0,0.96836657,20.738144,33.659982)">
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:url(#linearGradient17441);fill-opacity:1;stroke:#3f7fbf;stroke-width:0.5091278;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-5"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(1.0450409,-1.0450409,1.0450409,1.0450409,2.1256839,1029.9689)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14"
+             d="m 11.53513,1045.8134 c 0.07294,0.9455 0.07325,1.9032 9.05e-4,2.8489 l -2.3011454,-1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2"
+             d="m -1.0914354,1048.6741 c -0.07294,-0.9455 -0.07325,-1.9032 -9.07e-4,-2.849 l 2.301146,1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3"
+             d="m 6.6521976,1053.557 c -0.9455,0.073 -1.9032,0.073 -2.8489,9e-4 l 1.4186,-2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2"
+             d="m 3.7914976,1040.9305 c 0.9455,-0.073 1.9032,-0.073 2.849,-9e-4 l -1.4186,2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-2"
+             d="m 10.697423,1050.6965 c -0.616993,0.7202 -1.2939698,1.3976 -2.013837,2.0151 l -0.6240538,-2.6302 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-1"
+             d="m -0.2537278,1043.791 c 0.61699309,-0.7202 1.2939701,-1.3976 2.0139059,-2.0152 l 0.6240542,2.6303 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3-6"
+             d="m 1.7691159,1052.7193 c -0.7201883,-0.6169 -1.39738442,-1.2941 -2.0151129,-2.0138 l 2.6302251,-0.6241 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2-8"
+             d="m 8.6745793,1041.7682 c 0.7201883,0.6169 1.3973847,1.2941 2.0151837,2.0139 l -2.6302252,0.624 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:#1d4984;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-76"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(0.31739531,-0.31739531,0.31739531,0.31739531,4.2814936,1041.9971)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4"
+             d="m 11.535129,1046.4091 c 0.07294,0.5517 0.07325,1.1106 9.06e-4,1.6624 l -2.3011454,-0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5"
+             d="m -1.0914359,1048.0784 c -0.072942,-0.5517 -0.073247,-1.1106 -9.07e-4,-1.6625 l 2.3011463,0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51"
+             d="m 6.0564977,1053.557 c -0.5517,0.073 -1.1106,0.073 -1.6624,9e-4 l 0.8278,-2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7"
+             d="m 4.3871977,1040.9305 c 0.5517,-0.073 1.1106,-0.073 1.6624,-9e-4 l -0.8277,2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-1"
+             d="m 10.276129,1051.1178 c -0.3385343,0.4417 -0.7335171,0.8371 -1.1748536,1.1761 l -1.0418139,-2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-1"
+             d="m 0.16742503,1043.3698 c 0.33853445,-0.4416 0.73351722,-0.8371 1.17492367,-1.1762 l 1.0418137,2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51-5"
+             d="m 1.3478924,1052.2981 c -0.44172887,-0.3385 -0.83693085,-0.7337 -1.17612997,-1.1749 l 2.21246567,-1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7-2"
+             d="m 9.0958029,1042.1894 c 0.4417296,0.3385 0.8369322,0.7337 1.1761311,1.1749 l -2.2123961,1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:none;stroke:#3f7fbf;stroke-width:0.7180745;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(1.0202099,-1.0202099,1.0202099,1.0202099,2.1992508,1030.3794)" />
+          <path
+             sodipodi:nodetypes="cccccssc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-7"
+             d="m 6.0190516,1046.4513 -4.6356786,-3.9985 -1.80221867,-0.8517 0.85667548,1.7973 4.00338379,4.6307 c 0.2002055,0.2002 0.4771321,0.3237 0.7840021,0.3237 0.61367,0 1.1076548,-0.494 1.1076828,-1.1077 -5.64e-5,-0.3068 -0.1127546,-0.5927 -0.3138469,-0.7938 z"
+             style="color:#000000;fill:url(#linearGradient17443);fill-opacity:1;stroke:#4d607b;stroke-width:0.80260861;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <image
+             y="1038.406"
+             x="14.021823"
+             id="image4444"
+             xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAjhJREFU
+OI2lk09Ik3EYxz+LaFArCGHgQHxFUXBDAqGIDluxi4Qh1WHRYa8QhB0shru4gwtch5TBIOgSbBKh
+F20EHqrBu6A/iAkxVNiYNDVUxnRQ4weCvk+H5WzUpXwuv9/l+/D9PM/3sYgIR6ljR1IDxw8+Ho8u
+94fv4uywU9oThp9/o1FlUA4XJzcWsXZ2MXy5ifbmVsvvDSwHCC/ffJL45CwAAX8baBoNykZoLEkk
+2MdCsUIiDZoGCd1Ta1JDcHbYAXgVvUF0Ik85Z6VFcwLQojm5ef4CYR123qXQE2n5o0FpTwj427gW
+mGY62kd8cpa3778Q8LdhCohA9GGK634vhQLkVlekDsETTktYh3LOSnxylhfjV7k9VEUaD/djb3DU
+uJOf50gXqig1B40qQ4Oy4b54jv5bVfGzcS8A3oEpitsbmAKmQLfdxu5yph5BOVyExpLogxHOnsgC
+cGcoxZPHbi65TuMdmMIU0AcjhMaSKIerKhQRRARfMCaZpXnZLCvZ2lGSLeSlqWdUfMGYNPWMyszr
+j7K5o2SrrCSzNC++YExE5NCBtbOLhWKFfRP2BU6dcZB66uPD4g9iD67g7LBjCuybsFCsYO3sqneQ
+LeTFPWKI8dWQXj0kayUlayUl67/etZKSXj0kccMQ94gh2UK+3kF7c6tF0w5XdTCwe0OR6hpNCIx4
+mZlIoWnUElmLMlTXooMk0gBzdNttAHwvLh0m0e2tS6Llb9eYW12RR8Y6u8v/cAv/Wz8BBiUqWhPx
+5/kAAAAASUVORK5CYII=
+"
+             style="image-rendering:optimizeSpeed"
+             preserveAspectRatio="none"
+             height="16.576546"
+             width="16.576546" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.admin.rcp/icons/view/pview.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.admin.rcp/icons/view/pview.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="pview.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4401">
+      <stop
+         style="stop-color:#e8b0b0;stop-opacity:1"
+         offset="0"
+         id="stop4403" />
+      <stop
+         style="stop-color:#f8e0d8;stop-opacity:1"
+         offset="1"
+         id="stop4405" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4401"
+       id="linearGradient4407"
+       x1="17.129925"
+       y1="1048.7664"
+       x2="17.129925"
+       y2="1043.5862"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-14.504477,3.3173086e-5)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.843748"
+     inkscape:cx="22.781629"
+     inkscape:cy="6.4035159"
+     inkscape:document-units="px"
+     inkscape:current-layer="g17418"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5126" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline;fill:none"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="matrix(0.8261236,0,0,0.8261236,1.7832208,183.40446)">
+      <g
+         transform="matrix(1.2065384,0,0,1.2065384,-22.98457,-221.37405)"
+         id="g17594"
+         style="fill:none">
+        <g
+           id="g17418"
+           transform="matrix(0.96836657,0,0,0.96836657,20.738144,33.659982)">
+          <path
+             id="path4413-3-7"
+             style="display:inline;fill:none;fill-rule:evenodd;stroke:#d8e0f8;stroke-width:3.10810208;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 10.913721,1040.9961 -8.8862273,0 m 6.8141595,10.3604 -7.2522385,0 m 0.5180168,10e-5 c -2.86092939,0 -5.1801706,-2.3193 -5.18017,-5.1802 -6e-7,-2.8609 2.31924061,-5.1802 5.18017,-5.1802"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccccsc" />
+          <image
+             y="1038.406"
+             x="12.985788"
+             id="image4396"
+             xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAPhJREFU
+OI29k6FyAyEURe92MlM+AVdZyyesjNxPWFcbWRm5n4BL5NZRV4mM3DriiCoSSdWt2NlNStMtreid
+eQMPhsNw3wMkkYdsNUvzG2R6en5lyTipIsf8eHpnvd3nvG/1tnuoAGA1UTfmALttiwGznE+Urabz
+icEb2h7cd6DtweANr3l0Gfh8WDC6jsk7RtfR9uJHyGziYBso9QghGgCAEGM+2GbxBatpEgIgsAZS
+PO/GGiEsWzADpARS7AFc3mggZSFA1QYH20DJBKQ1IF4wBA1Vm2VCXgWjxyoYXVaFimRxH9zf3Vb5
+2q86ceq+q4C/6stn+nfAB+oyDmzKDjeuAAAAAElFTkSuQmCC
+"
+             style="image-rendering:optimizeSpeed"
+             preserveAspectRatio="none"
+             height="16.576546"
+             width="16.576546" />
+          <circle
+             style="opacity:1;fill:url(#linearGradient4407);fill-opacity:1;stroke:#a08800;stroke-width:1.03603411;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             id="path4399"
+             cx="2.1074314"
+             cy="1046.1763"
+             r="3.1081023" />
+          <path
+             id="path4413-3"
+             style="display:inline;fill:none;fill-rule:evenodd;stroke:#186098;stroke-width:1.03603411px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 10.91372,1040.9961 -8.8862269,0 m 6.8141598,10.3604 -7.2522388,0 m 0.5180168,10e-5 c -2.86092942,0 -5.1801707,-2.3193 -5.18017,-5.1802 -7e-7,-2.8609 2.31924058,-5.1802 5.18017,-5.1802"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccccsc" />
+          <path
+             style="fill:none;fill-rule:evenodd;stroke:#186098;stroke-width:1.03603411px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 2.1074311,1038.406 0,2.0721"
+             id="path4432"
+             inkscape:connector-curvature="0" />
+          <path
+             style="display:inline;fill:none;fill-rule:evenodd;stroke:#186098;stroke-width:1.03603411px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 10.395704,1038.406 0,2.0721"
+             id="path4432-4"
+             inkscape:connector-curvature="0" />
+          <path
+             style="display:inline;fill:none;fill-rule:evenodd;stroke:#186098;stroke-width:1.03603411px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 6.2515674,1038.406 0,2.0721"
+             id="path4432-5"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.admin.rcp/plugin.xml
+++ b/bundles/org.eclipse.equinox.p2.ui.admin.rcp/plugin.xml
@@ -25,7 +25,7 @@
                value="%aboutText"/>
          <property
                name="windowImages"
-               value="platform:/plugin/org.eclipse.equinox.p2.ui.admin/icons/view/provision.png"/>
+               value="platform:/plugin/org.eclipse.equinox.p2.ui.admin/icons/view/provision.svg"/>
 
     </product>
     </extension>
@@ -34,7 +34,7 @@
          point="org.eclipse.ui.views">
       <view
             name="%Views.Progress"
-            icon="$nl$/icons/view/pview.png"
+            icon="$nl$/icons/view/pview.svg"
             category="org.eclipse.ui"
             class="org.eclipse.ui.internal.progress.ProgressView"
             id="org.eclipse.ui.views.ProgressView">

--- a/bundles/org.eclipse.equinox.p2.ui.admin/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/META-INF/MANIFEST.MF
@@ -38,3 +38,4 @@ Import-Package: org.eclipse.equinox.internal.p2.core.helpers,
  org.eclipse.osgi.util;version="1.1.0",
  org.osgi.framework;version="1.3.0"
 Automatic-Module-Name: org.eclipse.equinox.p2.ui.admin
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.equinox.p2.ui.admin/icons/obj/artifact_repo_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/icons/obj/artifact_repo_obj.svg
@@ -1,0 +1,444 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="artifact_repo_obj.svg"
+   inkscape:export-filename="/Users/d026503/Documents/Icons/sapgui_obj/sapgui_obj.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4457">
+      <stop
+         style="stop-color:#efbf59;stop-opacity:1"
+         offset="0"
+         id="stop4459" />
+      <stop
+         id="stop4461"
+         offset="0.17353664"
+         style="stop-color:#f0c83b;stop-opacity:1" />
+      <stop
+         id="stop4463"
+         offset="0.34707329"
+         style="stop-color:#fdfabf;stop-opacity:1" />
+      <stop
+         id="stop4465"
+         offset="0.5"
+         style="stop-color:#fbf0a1;stop-opacity:1" />
+      <stop
+         style="stop-color:#f6e057;stop-opacity:1"
+         offset="0.63836575"
+         id="stop4467" />
+      <stop
+         id="stop4469"
+         offset="0.81918287"
+         style="stop-color:#f2b11f;stop-opacity:1" />
+      <stop
+         style="stop-color:#f6a81d;stop-opacity:1"
+         offset="1"
+         id="stop4471" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4371">
+      <stop
+         style="stop-color:#a6661f;stop-opacity:1"
+         offset="0"
+         id="stop4373" />
+      <stop
+         style="stop-color:#d2a40f;stop-opacity:1"
+         offset="1"
+         id="stop4375" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4355">
+      <stop
+         id="stop4357"
+         offset="0"
+         style="stop-color:#fadd5a;stop-opacity:1" />
+      <stop
+         style="stop-color:#efbf59;stop-opacity:1"
+         offset="0.17353664"
+         id="stop4359" />
+      <stop
+         style="stop-color:#f9e1b6;stop-opacity:1"
+         offset="0.34707329"
+         id="stop4361" />
+      <stop
+         style="stop-color:#faeed1;stop-opacity:1"
+         offset="0.5"
+         id="stop4363" />
+      <stop
+         id="stop4365"
+         offset="0.63836575"
+         style="stop-color:#ffff7a;stop-opacity:1" />
+      <stop
+         style="stop-color:#fee134;stop-opacity:1"
+         offset="0.81918287"
+         id="stop4367" />
+      <stop
+         id="stop4369"
+         offset="1"
+         style="stop-color:#fb9a09;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4347">
+      <stop
+         style="stop-color:#e6970d;stop-opacity:1"
+         offset="0"
+         id="stop4349" />
+      <stop
+         style="stop-color:#c4870c;stop-opacity:1"
+         offset="1"
+         id="stop4351" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4294">
+      <stop
+         id="stop4296"
+         offset="0"
+         style="stop-color:#eacc8c;stop-opacity:1" />
+      <stop
+         style="stop-color:#efe1c9;stop-opacity:1"
+         offset="0.17353664"
+         id="stop4298" />
+      <stop
+         style="stop-color:#f3f3f5;stop-opacity:1"
+         offset="0.34707329"
+         id="stop4300" />
+      <stop
+         style="stop-color:#f3f3f5;stop-opacity:1"
+         offset="0.5"
+         id="stop4302" />
+      <stop
+         id="stop4304"
+         offset="0.63836575"
+         style="stop-color:#e9e9cb;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7e1b4;stop-opacity:1"
+         offset="0.81918287"
+         id="stop4306" />
+      <stop
+         id="stop4308"
+         offset="1"
+         style="stop-color:#e7cf9a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-2-6-1-7">
+      <stop
+         id="stop11150-7-5-9-3-8-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-4-35-5-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-30-1-1-4">
+      <stop
+         id="stop11150-9-6-9-5-6-9"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-7-6-3-3-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-7-5-6-8">
+      <stop
+         id="stop11150-7-8-3-8-7-0-6"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-6-3-2-5-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507-2">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509-4" />
+      <stop
+         id="stop10511-2"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513-9"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515-0"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517-9"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519-2" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4794-9">
+      <stop
+         style="stop-color:#3a9ed6;stop-opacity:1"
+         offset="0"
+         id="stop4796-8" />
+      <stop
+         id="stop4802-2"
+         offset="0.38869566"
+         style="stop-color:#2692d1;stop-opacity:1" />
+      <stop
+         style="stop-color:#3a9ed6;stop-opacity:1"
+         offset="1"
+         id="stop4798-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4695-9">
+      <stop
+         style="stop-color:#ffc42e;stop-opacity:1"
+         offset="0"
+         id="stop4697-8" />
+      <stop
+         id="stop4719-3"
+         offset="0.17353664"
+         style="stop-color:#ffcd49;stop-opacity:1" />
+      <stop
+         id="stop4713-8"
+         offset="0.34707329"
+         style="stop-color:#ffe66d;stop-opacity:1" />
+      <stop
+         id="stop4711-6"
+         offset="0.5"
+         style="stop-color:#fff1ae;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe56c;stop-opacity:1"
+         offset="0.63836575"
+         id="stop4715-9" />
+      <stop
+         id="stop4717-8"
+         offset="0.81918287"
+         style="stop-color:#fdd771;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffc42e;stop-opacity:1"
+         offset="1"
+         id="stop4699-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4347"
+       id="linearGradient4353-6-8"
+       x1="-8.1449289"
+       y1="1055.5972"
+       x2="-8.0524807"
+       y2="1052.5642"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1578466,0,0,1.2556724,17.730739,-284.16504)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4371"
+       id="linearGradient4377-6-9"
+       x1="3.5805521"
+       y1="1063.3384"
+       x2="3.4927168"
+       y2="1052.5967"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1431743,0,0,1.3001921,3.9273029,-331.06196)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4457"
+       id="linearGradient4331-6-9-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31514318,0,0,0.28028373,-207.40147,915.23296)"
+       x1="673.60974"
+       y1="460.61569"
+       x2="696.68384"
+       y2="460.61569" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="38.23371"
+     inkscape:cx="8.0000003"
+     inkscape:cy="8.4997792"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="false"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-bbox-edge-midpoints="false"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-others="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4304"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAU1JREFU
+OI2lk09LAlEUxX9vngxDplYE7foDLSIKKggKovoE0aK2fcE20SeQahFEbWZTS7WssHI0ZUyd91o4
+mfPHCenChffOPZxz7+NdobXmP5GKA6/PD3XnsQQpiepqvFaHTqNLbm2RrYMzMcgV4Q7yp7t6Z66K
+yi0g54/QboVO7Y52tYhRLHH7Ncv+8UVfxAi7mw0FhgDPjW25dvmaPEKtbPCsykxuW5itKzznBbd8
+T7NQRdp1srnVZAHtQXZlCXN6E2mtY0xUQGSQY0WMdAlugvzICCKCaD/9ugi+WVTgh6ABBIigQDhi
+BMKIGk3AEIOw9s+yX5fyjxFA8Pu2nk9JBcvJAqCV8N2V7y7jaMCQr+zYNqlMHdOq4zkfuE8PNAtv
+SPuT2ruV3MHU8sxQNwB3Ix24R3YBesukHQchQGuFanu9HLfYO8knL9Oo8Q0Ap4CWom9IWwAAAABJ
+RU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <g
+       style="display:inline;fill:#ffffff;stroke:#ffffff"
+       transform="matrix(0.33025864,0,0,0.33025864,-148.65244,917.1459)"
+       id="g14104" />
+    <g
+       mask="none"
+       id="g6258"
+       style="display:inline"
+       transform="matrix(0.33025864,0,0,0.33025864,-148.65244,917.1459)" />
+    <path
+       sodipodi:nodetypes="sccsccs"
+       inkscape:connector-curvature="0"
+       id="path3868-1-3-3-4-1"
+       d="M 8.4823509,1037.8068 C 5.9921973,1037.8068 4,1038.477 4,1039.3136 l 0,10.0447 c 0,0.8367 1.9921973,1.507 4.4823509,1.507 2.4901581,0 4.5176491,-0.6703 4.5176491,-1.507 l 0,-10.0447 c 0,-0.8366 -2.027491,-1.5068 -4.5176491,-1.5068 z"
+       style="display:inline;fill:url(#linearGradient4331-6-9-0);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="sccsccs"
+       inkscape:connector-curvature="0"
+       id="path3868-1-4-6-9-1"
+       d="m 8.4843081,1037.8612 c -2.2140523,0 -3.985361,0.6672 -3.985361,1.4999 l 0,10.0016 c 0,0.8331 1.7713087,1.5006 3.985361,1.5006 2.2140559,0 4.0167459,-0.6675 4.0167459,-1.5006 l 0,-10.0016 c 0,-0.8327 -1.80269,-1.4999 -4.0167459,-1.4999 z"
+       style="display:inline;fill:none;stroke:url(#linearGradient4377-6-9);stroke-width:0.99789387;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <ellipse
+       ry="1.4424163"
+       rx="3.9424307"
+       cy="1039.3622"
+       cx="8.5"
+       id="path3868-67-2-9"
+       style="display:inline;fill:none;stroke:url(#linearGradient4353-6-8);stroke-width:1.11513841;stroke-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2" />
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.admin/icons/obj/iu_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/icons/obj/iu_obj.svg
@@ -1,0 +1,557 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#c48a4e;stop-opacity:1;" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#ad6c24;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-148.40713,-87.106181)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955"
+       id="linearGradient3945"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-147.48911,-87.252829)" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4284"
+       id="linearGradient10790-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33571488,0,0,0.59088033,417.52974,47.073021)"
+       x1="305"
+       y1="513.87781"
+       x2="305"
+       y2="545.35248" />
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         id="stop4286"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:0" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999967"
+         id="stop4288" />
+      <stop
+         id="stop4290"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10790-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,214.53218,-155.02652)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-9"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-0"
+       id="linearGradient10792-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,214.53218,-155.02652)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-0">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10786-1"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818"
+       gradientTransform="matrix(1.0391435,0,0,0.59796602,202.46608,47.009545)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-9"
+       id="linearGradient10782-3"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,217.58019,-158.92057)" />
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-3" />
+      <stop
+         id="stop10422-8"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-3"
+       id="linearGradient10784-2"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,217.58019,-158.92057)" />
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         id="stop10434-4"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-2" />
+      <stop
+         id="stop10438-9"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-90"
+       id="linearGradient10778-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="matrix(1.0765606,0,0,1.061954,190.65652,-195.98554)" />
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-0" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-96"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-8"
+       id="linearGradient10774-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.062525,0,0,1.0891236,202.52576,-210.40158)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         id="stop10750-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-8" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-8" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-7"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient10770-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0387443,0,0,1.1623096,210.44163,-248.72525)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-7" />
+      <stop
+         id="stop10456-4-1-5-3"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-4" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="54.508621"
+     inkscape:cx="15.113239"
+     inkscape:cy="6.9688496"
+     inkscape:document-units="px"
+     inkscape:current-layer="g13862"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <rect
+         ry="3.1069043"
+         rx="3.1069043"
+         y="347.32736"
+         x="473.10382"
+         height="19.677061"
+         width="17.753738"
+         id="rect13693-3"
+         style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="rect13693"
+         d="m 472.68093,354.495 33.22969,0 c 1.72122,0 3.1069,1.38903 3.1069,3.11442 l 0,13.39945 c 0,1.72538 -1.44501,2.66525 -3.1069,3.11442 l -33.22969,8.9812 c -1.66188,0.44917 -3.1069,-1.38903 -3.1069,-3.11442 l 0,-22.38065 c 0,-1.72539 1.38568,-3.11442 3.1069,-3.11442 z"
+         style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path13797"
+         d="m 471.31191,354.49499 23.78261,0"
+         style="fill:none;stroke:url(#linearGradient3945);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         id="g4301"
+         transform="translate(-38.76348,19.301383)">
+        <rect
+           ry="0"
+           rx="0"
+           y="354.94647"
+           x="539.2395"
+           height="10.826942"
+           width="21.018066"
+           id="rect10007-0-74-2-7-6"
+           style="display:inline;fill:url(#linearGradient10770-6);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8-8"
+           d="m 548.23888,354.95116 0,3.5838 12.01134,0 0,-3.5838 -12.01134,0 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7"
+           d="m 549.43361,354.93037 0,10.8213 3.63939,0 0,-10.8213 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1-8"
+           d="m 560.22222,362.10479 -12.03934,0.1111 0.0351,3.58381 12.03934,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="351.43616"
+           x="538.01801"
+           height="17.791901"
+           width="11.41908"
+           id="rect10007-0-74-2-7"
+           style="display:inline;fill:url(#linearGradient10774-5);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1"
+           d="m 549.5198,365.72372 -12.03934,0.1111 0.035,3.5838 12.03935,-0.1111 -0.0351,-3.5838 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8"
+           d="m 549.48481,351.36054 -12.03935,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="347.8541"
+           x="530.58051"
+           height="24.955921"
+           width="11.811058"
+           id="rect10007-0-74-2"
+           style="display:inline;fill:url(#linearGradient10778-6);fill-opacity:1;stroke:none;stroke-width:1.50161433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="351.36792"
+           x="517.27734"
+           height="17.908186"
+           width="13.428176"
+           id="rect10007-0"
+           style="display:inline;fill:#5079bc;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="355.63754"
+           x="507.31067"
+           height="9.2635088"
+           width="10.776635"
+           id="rect10007-0-7"
+           style="display:inline;fill:url(#linearGradient10782-3);fill-opacity:1;stroke:url(#linearGradient10784-2);stroke-width:1.48636866;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="354.87964"
+           x="517.32654"
+           height="10.763388"
+           width="13.378973"
+           id="rect10007-0-74"
+           style="display:inline;fill:url(#linearGradient10786-1);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313"
+           d="m 542.3172,347.76957 -12.03935,0.1111 0.035,3.5838 12.03935,-0.11109 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5"
+           d="m 542.33819,369.2724 -12.03934,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           y="342.42676"
+           x="522.66992"
+           height="35.783813"
+           width="10.700533"
+           id="rect10007-6"
+           style="display:inline;fill:url(#linearGradient10790-8);fill-opacity:1;stroke:url(#linearGradient10792-6);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           ry="5.3502665" />
+        <rect
+           y="350.21646"
+           x="520.87805"
+           height="19.98802"
+           width="3.5889285"
+           id="rect10007-6-6"
+           style="display:inline;fill:url(#linearGradient10790-8-2);fill-opacity:1;stroke:none;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7-8"
+           d="m 542.3442,354.94937 0,10.78725 3.5848,0 0,-10.78725 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:0.64640886;fill-rule:evenodd;stroke:none;stroke-width:0.97351193px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <image
+           y="326.2341"
+           x="560.24866"
+           id="image4280"
+           xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAeJJREFU
+OI2Nk09IFFEcxz9vWTfbtFQkWCg2IZcuG8RiDihdiqAIEeoYE3jx0KVAuglBhw5ueBCJLkEeRZDq
+EHboIBJLge2xf0JLRiEpO4szs81u8+vwZnbXJrUvPN7/z/u+33s/JSKEKuSNZgcwJgqK/SQiiAjP
+b2XkbwVj7FWUiFDIG5IzxwGoO1Wcio1bruBY22x9eB05tNVZPGy0dZwOajh4FEik9cT5UgRQyBsS
+QhoA6k5zRXs/5oMvAMzdPgbVT7uGIAZQ9wU8q1HM6XX6eoW+XsGcXtduEmnwKuBZen3rFWo1X28G
+6BoEyiTb4ygE8Fl+qK9zblw78Tx/JyB99hJ0ngHAnClrzqE2FApwGbq+CMDyo34AThiTOwF3V0dg
+Vcfgcu4IXzfKdHUkkAAg/i8U0J0e5VRumJX5CUrv7gkqAHTHA/sIqZ4UqZ5k4wS3ukHscFZ3kq9Q
+nRncAye5eOVG08HHH82gfN9yKL7/xmD2OErBtu3i/yzqSauEbL5BNj/z8skkEgJeTF1ofIzhm88k
+BmQzdRCwbQd+O4CwVlxirbjE6H2JfqRQK7MjamBsQSy7BiK4rsfT2TsAXJ2SSG5EAKEqdi14xn9v
+DKVas7FVA2MLAvD28bU9M3JXwP/qD5PM7CDw/+DMAAAAAElFTkSuQmCC
+"
+           style="image-rendering:optimizeSpeed"
+           preserveAspectRatio="none"
+           height="57.340881"
+           width="57.340881" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.admin/icons/obj/metadata_repo_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/icons/obj/metadata_repo_obj.svg
@@ -1,0 +1,1314 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="metadata_repo_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5641">
+      <stop
+         style="stop-color:#1e6cbe;stop-opacity:1;"
+         offset="0"
+         id="stop5643" />
+      <stop
+         style="stop-color:#104276;stop-opacity:1;"
+         offset="1"
+         id="stop5645" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5411">
+      <stop
+         style="stop-color:#72828e;stop-opacity:1;"
+         offset="0"
+         id="stop5413" />
+      <stop
+         style="stop-color:#003358;stop-opacity:1;"
+         offset="1"
+         id="stop5415" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5630">
+      <stop
+         style="stop-color:#d8bc68;stop-opacity:1;"
+         offset="0"
+         id="stop5632" />
+      <stop
+         style="stop-color:#fff0c2;stop-opacity:1;"
+         offset="1"
+         id="stop5634" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-5">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-5" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6799-4-3">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-8">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-6">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1-2">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6799-4-3-3">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-8" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-7">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-5" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-5-7">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-5-6" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-8-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-7">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-33" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-2-6">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-3-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-9-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-8-8">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7-9" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-0">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-1" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-6"
+       id="linearGradient5572"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972"
+       id="linearGradient4283"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146582"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972"
+       id="linearGradient4288"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146582"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972"
+       id="linearGradient4321"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146582"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1"
+       id="linearGradient4382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6238641,0,0,1.6285353,-5.817902,-657.26294)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3"
+       id="linearGradient4384"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6238641,0,0,1.6285353,-5.817902,-662.30115)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9"
+       id="linearGradient4390"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8-8"
+       id="linearGradient4392"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96301391,0,0,0.30750995,-1.0449584,-1044.537)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2"
+       id="linearGradient4394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-5">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-3" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-8-0">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7-7" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-0">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-8" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1-4"
+       id="linearGradient4382-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-4.9210482,-731.7352)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       id="linearGradient4972-4-1-4">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-7"
+       id="linearGradient4384-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-4.9210482,-736.99747)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       id="linearGradient6799-4-3-7">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-9" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1-9"
+       id="linearGradient4382-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-6.197689,-731.7678)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       id="linearGradient4972-4-1-9">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-9"
+       id="linearGradient4384-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-6.197689,-737.03007)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       id="linearGradient6799-4-3-9">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-7" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-74" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-1"
+       id="linearGradient4394-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3892048,0,0,0.27549241,-31.899058,-1052.4756)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-1">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-2" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8-8-07"
+       id="linearGradient4392-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0464198,0,0,0.30750995,-29.951794,-1049.0796)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-8-8-07">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-4"
+       id="linearGradient4390-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3930703,0,0,0.26192631,-31.957849,1053.1869)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-4">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-26" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1-5"
+       id="linearGradient4382-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.623864,0.69032316,0,1.6285353,32.3374,-665.37304)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       id="linearGradient4972-4-1-5">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-97" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-60" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-0"
+       id="linearGradient4384-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.623864,0.69032316,0,1.6285353,32.3374,-670.41122)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       id="linearGradient6799-4-3-0">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-90" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5411"
+       id="radialGradient5417"
+       cx="13.94572"
+       cy="1045.8255"
+       fx="13.94572"
+       fy="1045.8255"
+       r="10.779004"
+       gradientTransform="matrix(1,0,0,0.98529514,0,15.378714)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5411"
+       id="radialGradient5419"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8121447,-1.9541983,0.96980008,0.27977302,-1035.1855,788.68965)"
+       cx="16.494715"
+       cy="1050.2904"
+       fx="16.494715"
+       fy="1050.2904"
+       r="10.779004" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9"
+       id="linearGradient5426"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8-8"
+       id="linearGradient5428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96301391,0,0,0.30750995,-1.0449584,-1044.537)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2"
+       id="linearGradient5430"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6"
+       id="linearGradient5430-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-6">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-35" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-9" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5475"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-9"
+       id="linearGradient5426-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-80" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-66"
+       id="linearGradient5430-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-66">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-23" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-8" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5475-9"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-6-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-35-8" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-9-1" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5525"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-9-2"
+       id="linearGradient5426-4-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-9-2">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-80-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-6-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-66-1"
+       id="linearGradient5430-1-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-66-1">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-23-1" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5525-6"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-6-9-6">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-35-8-5" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-9-1-1" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5592"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5641"
+       id="linearGradient5647"
+       x1="30.45603"
+       y1="1028.9988"
+       x2="30.45603"
+       y2="1033.8717"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-12.948786,22.935422)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5641-4"
+       id="linearGradient5647-2"
+       x1="30.45603"
+       y1="1028.9988"
+       x2="30.45603"
+       y2="1033.8717"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-12.948786,22.935422)" />
+    <linearGradient
+       id="linearGradient5641-4">
+      <stop
+         style="stop-color:#1e6cbe;stop-opacity:1;"
+         offset="0"
+         id="stop5643-1" />
+      <stop
+         style="stop-color:#104276;stop-opacity:1;"
+         offset="1"
+         id="stop5645-2" />
+    </linearGradient>
+    <linearGradient
+       y2="1033.8717"
+       x2="30.45603"
+       y1="1028.9988"
+       x1="30.45603"
+       gradientTransform="matrix(0.71554797,0.15002359,0,0.70580829,-11.070338,316.74005)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5664"
+       xlink:href="#linearGradient5641-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9"
+       id="linearGradient5695"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2"
+       id="linearGradient5697"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6"
+       id="linearGradient5699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       y2="1033.8717"
+       x2="30.45603"
+       y1="1028.9988"
+       x1="30.45603"
+       gradientTransform="matrix(0.71554797,0.15002359,0,0.70580829,-11.070338,316.74005)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5664-4"
+       xlink:href="#linearGradient5641-4-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5641-4-8">
+      <stop
+         style="stop-color:#1e6cbe;stop-opacity:1;"
+         offset="0"
+         id="stop5643-1-4" />
+      <stop
+         style="stop-color:#104276;stop-opacity:1;"
+         offset="1"
+         id="stop5645-2-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4204"
+       id="linearGradient4210"
+       x1="-708.08484"
+       y1="754.58435"
+       x2="-708.08484"
+       y2="746.83435"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-24.426411,-8.1168654)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4204">
+      <stop
+         style="stop-color:#8e6aae;stop-opacity:1"
+         offset="0"
+         id="stop4206" />
+      <stop
+         style="stop-color:#b29cc6;stop-opacity:1"
+         offset="1"
+         id="stop4208" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4229"
+       id="linearGradient4235"
+       x1="44.955429"
+       y1="1040.4005"
+       x2="42.943558"
+       y2="1042.4124"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-34.995489,-0.00370887)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4229">
+      <stop
+         style="stop-color:#713e9d;stop-opacity:1;"
+         offset="0"
+         id="stop4231" />
+      <stop
+         style="stop-color:#f2aaf1;stop-opacity:1"
+         offset="1"
+         id="stop4233" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4276"
+       id="linearGradient4235-4"
+       x1="44.955429"
+       y1="1040.4005"
+       x2="41.838699"
+       y2="1043.5171"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,48.995489,-0.00370887)" />
+    <linearGradient
+       id="linearGradient4276"
+       inkscape:collect="always">
+      <stop
+         id="stop4278"
+         offset="0"
+         style="stop-color:#f2aaf1;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2aaf1;stop-opacity:1"
+         offset="0.44146144"
+         id="stop4282" />
+      <stop
+         id="stop4284"
+         offset="0.58899093"
+         style="stop-color:#f9f8d4;stop-opacity:1" />
+      <stop
+         id="stop4280"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.7372"
+       x2="12.520393"
+       y1="1044.7372"
+       x1="5.1146584"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4507"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.7372"
+       x2="12.520393"
+       y1="1044.7372"
+       x1="5.1146582"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4509"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.7372"
+       x2="12.520393"
+       y1="1044.7372"
+       x1="5.1146582"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4511"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.7372"
+       x2="12.520393"
+       y1="1044.7372"
+       x1="5.1146582"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4513"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.7372"
+       x2="12.520393"
+       y1="1044.7372"
+       x1="5.1146584"
+       gradientTransform="matrix(1.6238641,0,0,1.6285353,-5.817902,-657.26294)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4515"
+       xlink:href="#linearGradient4972-4-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1051.2535"
+       x2="5.926301"
+       y1="1042.1279"
+       x1="11.977677"
+       gradientTransform="matrix(1.6238641,0,0,1.6285353,-5.817902,-662.30115)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4517"
+       xlink:href="#linearGradient6799-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4519"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(0.96301391,0,0,0.30750995,-1.0449584,-1044.537)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4521"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4523"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.98529514,0,15.378714)"
+       r="10.779004"
+       fy="1045.8255"
+       fx="13.94572"
+       cy="1045.8255"
+       cx="13.94572"
+       id="radialGradient5417-3"
+       xlink:href="#linearGradient5411"
+       inkscape:collect="always" />
+    <radialGradient
+       r="10.779004"
+       fy="1050.2904"
+       fx="16.494715"
+       cy="1050.2904"
+       cx="16.494715"
+       gradientTransform="matrix(1.8121447,-1.9541983,0.96980008,0.27977302,-1035.1855,788.68965)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5419-5"
+       xlink:href="#linearGradient5411"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4527"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(0.96301391,0,0,0.30750995,-1.0449584,-1044.537)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4529"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4531"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8"
+       id="linearGradient4533"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8"
+       id="linearGradient4535"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8"
+       id="linearGradient4537"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       gradientTransform="translate(-12.948786,22.935422)"
+       gradientUnits="userSpaceOnUse"
+       y2="1033.8717"
+       x2="30.45603"
+       y1="1028.9988"
+       x1="30.45603"
+       id="linearGradient4539"
+       xlink:href="#linearGradient5641"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5641"
+       id="linearGradient4541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71554797,0.15002359,0,0.70580829,-11.070338,316.74005)"
+       x1="30.45603"
+       y1="1028.9988"
+       x2="30.45603"
+       y2="1033.8717" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4543"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4545"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4547"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5641"
+       id="linearGradient3174"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71554797,0.15002359,0,0.70580829,-11.070338,316.74004)"
+       x1="30.45603"
+       y1="1028.9988"
+       x2="30.45603"
+       y2="1033.8717" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4522"
+       x="-0.11748909"
+       width="1.2349782"
+       y="-0.21204029"
+       height="1.4240806">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.44291996"
+         id="feGaussianBlur4524" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#b4b4b4"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="36.46875"
+     inkscape:cx="19.230818"
+     inkscape:cy="9.338279"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4250" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-2"
+       inkscape:label="Layer 1"
+       transform="matrix(0.97206288,0,0,0.90809292,2.2543771,95.252775)">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="path5639"
+         d="m 8.4826024,1036.9266 4.1149606,0 0,14.45 -2.057481,-2.45 -2.0574796,2.5 c 0,0 -0.00585,-9.6999 0,-14.5 z"
+         style="display:inline;fill:#71baff;fill-opacity:1;stroke:url(#linearGradient3174);stroke-width:1.04048264px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <path
+       transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,0,0)"
+       style="display:inline;opacity:0.787;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter4522)"
+       d="m -734.87988,740.13159 4.58648,4.67284 c 0.21828,0.2224 1.69601,-1.64915 1.68708,-1.33766 l -0.0775,2.70571 c -0.009,0.3115 -0.44481,0.75193 -0.7564,0.7564 l -2.70571,0.0388 c -0.31159,0.004 1.01498,-1.15795 0.81415,-1.39624 l -4.11055,-4.87732 c -0.20082,-0.23828 0.34421,-0.7849 0.5625,-0.5625 z"
+       id="rect3394-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="fill:#8861aa;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 11.549897,1043.3622 7,1047.9652 l 0,-4.603 z"
+       id="path4212"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4235);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 11.549897,1043.3622 7.0095,1038.7593 7,1043.3622 Z"
+       id="path4212-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:#ad86cf;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 2.5,1043.3622 4.4905,4.6029 L 7,1043.3622 Z"
+       id="path4212-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4235-4);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 2.5,1043.3622 6.9905,1038.7593 7,1043.3622 Z"
+       id="path4212-4-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <image
+       y="1036.3622"
+       x="17"
+       id="image4424"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAa9JREFU
+OI2Nk0FIVFEUhr87OptoZniaG2EWwkAEbYJcuAlaTbQMwYVkhItmq7YJdBESgVCZCyGZAhUXwSCB
+SPiKliJBoxTTZiSDFi1UShkyeO/c0+LVa5x5j5kfDveeyz0f9/7nXqOqtKPM6ErTxqPnw6azreq/
+mhoZCufTSy8BSMRtdosVdYuVlseLBLjFig5kstT2Peoham0QauMB6/NlHchkSXWlyXU71PY91ubL
+OnuzH7E2CD8ANQFKTzf1Sk+OVFca+vfocxxy3Q7eUYLUzgH5851YEawV1PdPA5YeuprvvRgWk+4D
+CCCOQ+LkDJ+W33HtQhIRQbwAEHbh1+8ab3a/BMl7gB2q1eqp62WyHagq4gvWazhB4f4N8/XHx1i3
+k+dOuHz7Oq/Kx4j4iOc1ezA+M2I+f99qKvbOHpK+eonVDz8REawI6keYCDA5VzDbe2/D/Dj5jcm5
+grkz6wZ3F8EXQUWiAQDTC3fNVvU1h+zy4Nm4+bdurUXlfwuhzsRGzby4ZxrX1FoeL5YYuzXYGhCl
+J4slZGPCdOQfha8z9i9ESTYmTP0IYNr9znH6A74rx147b6JuAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient4210);stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3394"
+       width="6.6615601"
+       height="6.6615601"
+       x="-736.1416"
+       y="739.35547"
+       rx="0.56249994"
+       ry="0.56249994"
+       transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.admin/icons/obj/profile_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/icons/obj/profile_obj.svg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="profile_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17410">
+      <stop
+         style="stop-color:#e0ebf6;stop-opacity:1;"
+         offset="0"
+         id="stop17412" />
+      <stop
+         style="stop-color:#f3f5f6;stop-opacity:1"
+         offset="1"
+         id="stop17414" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17159">
+      <stop
+         style="stop-color:#ffeece;stop-opacity:1"
+         offset="0"
+         id="stop17161" />
+      <stop
+         style="stop-color:#e1eaba;stop-opacity:1"
+         offset="1"
+         id="stop17163" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17410"
+       id="linearGradient17441"
+       gradientUnits="userSpaceOnUse"
+       x1="-9.733428"
+       y1="12.635066"
+       x2="-3.9386158"
+       y2="6.8402538" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17159"
+       id="linearGradient17443"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.59076155,0.59076155,-0.59076155,0.59076155,17.040411,1049.6082)"
+       x1="-20.742412"
+       y1="7.9916593"
+       x2="-10.422931"
+       y2="7.9916593" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.063994"
+     inkscape:cx="8.506094"
+     inkscape:cy="7.4696588"
+     inkscape:document-units="px"
+     inkscape:current-layer="g17418"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5126" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline;fill:none"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="matrix(0.8261236,0,0,0.8261236,1.7832208,183.40446)">
+      <g
+         transform="matrix(1.2065384,0,0,1.2065384,-22.98457,-221.37405)"
+         id="g17594"
+         style="fill:none">
+        <g
+           id="g17418"
+           transform="matrix(0.96836657,0,0,0.96836657,20.738144,33.659982)">
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:url(#linearGradient17441);fill-opacity:1;stroke:#3f7fbf;stroke-width:0.5091278;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-5"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(1.0450409,-1.0450409,1.0450409,1.0450409,2.1256839,1029.9689)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14"
+             d="m 11.53513,1045.8134 c 0.07294,0.9455 0.07325,1.9032 9.05e-4,2.8489 l -2.3011454,-1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2"
+             d="m -1.0914354,1048.6741 c -0.07294,-0.9455 -0.07325,-1.9032 -9.07e-4,-2.849 l 2.301146,1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3"
+             d="m 6.6521976,1053.557 c -0.9455,0.073 -1.9032,0.073 -2.8489,9e-4 l 1.4186,-2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2"
+             d="m 3.7914976,1040.9305 c 0.9455,-0.073 1.9032,-0.073 2.849,-9e-4 l -1.4186,2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-2"
+             d="m 10.697423,1050.6965 c -0.616993,0.7202 -1.2939698,1.3976 -2.013837,2.0151 l -0.6240538,-2.6302 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-1"
+             d="m -0.2537278,1043.791 c 0.61699309,-0.7202 1.2939701,-1.3976 2.0139059,-2.0152 l 0.6240542,2.6303 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3-6"
+             d="m 1.7691159,1052.7193 c -0.7201883,-0.6169 -1.39738442,-1.2941 -2.0151129,-2.0138 l 2.6302251,-0.6241 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2-8"
+             d="m 8.6745793,1041.7682 c 0.7201883,0.6169 1.3973847,1.2941 2.0151837,2.0139 l -2.6302252,0.624 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:#1d4984;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-76"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(0.31739531,-0.31739531,0.31739531,0.31739531,4.2814936,1041.9971)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4"
+             d="m 11.535129,1046.4091 c 0.07294,0.5517 0.07325,1.1106 9.06e-4,1.6624 l -2.3011454,-0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5"
+             d="m -1.0914359,1048.0784 c -0.072942,-0.5517 -0.073247,-1.1106 -9.07e-4,-1.6625 l 2.3011463,0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51"
+             d="m 6.0564977,1053.557 c -0.5517,0.073 -1.1106,0.073 -1.6624,9e-4 l 0.8278,-2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7"
+             d="m 4.3871977,1040.9305 c 0.5517,-0.073 1.1106,-0.073 1.6624,-9e-4 l -0.8277,2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-1"
+             d="m 10.276129,1051.1178 c -0.3385343,0.4417 -0.7335171,0.8371 -1.1748536,1.1761 l -1.0418139,-2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-1"
+             d="m 0.16742503,1043.3698 c 0.33853445,-0.4416 0.73351722,-0.8371 1.17492367,-1.1762 l 1.0418137,2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51-5"
+             d="m 1.3478924,1052.2981 c -0.44172887,-0.3385 -0.83693085,-0.7337 -1.17612997,-1.1749 l 2.21246567,-1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7-2"
+             d="m 9.0958029,1042.1894 c 0.4417296,0.3385 0.8369322,0.7337 1.1761311,1.1749 l -2.2123961,1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:none;stroke:#3f7fbf;stroke-width:0.7180745;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(1.0202099,-1.0202099,1.0202099,1.0202099,2.1992508,1030.3794)" />
+          <path
+             sodipodi:nodetypes="cccccssc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-7"
+             d="m 6.0190516,1046.4513 -4.6356786,-3.9985 -1.80221867,-0.8517 0.85667548,1.7973 4.00338379,4.6307 c 0.2002055,0.2002 0.4771321,0.3237 0.7840021,0.3237 0.61367,0 1.1076548,-0.494 1.1076828,-1.1077 -5.64e-5,-0.3068 -0.1127546,-0.5927 -0.3138469,-0.7938 z"
+             style="color:#000000;fill:url(#linearGradient17443);fill-opacity:1;stroke:#4d607b;stroke-width:0.80260861;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <image
+             y="1038.406"
+             x="14.021823"
+             id="image4444"
+             xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAjhJREFU
+OI2lk09Ik3EYxz+LaFArCGHgQHxFUXBDAqGIDluxi4Qh1WHRYa8QhB0shru4gwtch5TBIOgSbBKh
+F20EHqrBu6A/iAkxVNiYNDVUxnRQ4weCvk+H5WzUpXwuv9/l+/D9PM/3sYgIR6ljR1IDxw8+Ho8u
+94fv4uywU9oThp9/o1FlUA4XJzcWsXZ2MXy5ifbmVsvvDSwHCC/ffJL45CwAAX8baBoNykZoLEkk
+2MdCsUIiDZoGCd1Ta1JDcHbYAXgVvUF0Ik85Z6VFcwLQojm5ef4CYR123qXQE2n5o0FpTwj427gW
+mGY62kd8cpa3778Q8LdhCohA9GGK634vhQLkVlekDsETTktYh3LOSnxylhfjV7k9VEUaD/djb3DU
+uJOf50gXqig1B40qQ4Oy4b54jv5bVfGzcS8A3oEpitsbmAKmQLfdxu5yph5BOVyExpLogxHOnsgC
+cGcoxZPHbi65TuMdmMIU0AcjhMaSKIerKhQRRARfMCaZpXnZLCvZ2lGSLeSlqWdUfMGYNPWMyszr
+j7K5o2SrrCSzNC++YExE5NCBtbOLhWKFfRP2BU6dcZB66uPD4g9iD67g7LBjCuybsFCsYO3sqneQ
+LeTFPWKI8dWQXj0kayUlayUl67/etZKSXj0kccMQ94gh2UK+3kF7c6tF0w5XdTCwe0OR6hpNCIx4
+mZlIoWnUElmLMlTXooMk0gBzdNttAHwvLh0m0e2tS6Llb9eYW12RR8Y6u8v/cAv/Wz8BBiUqWhPx
+5/kAAAAASUVORK5CYII=
+"
+             style="image-rendering:optimizeSpeed"
+             preserveAspectRatio="none"
+             height="16.576546"
+             width="16.576546" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.admin/icons/obj/uninstalled_iu.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/icons/obj/uninstalled_iu.svg
@@ -1,0 +1,769 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="uninstalled_iu.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#b6b6b6;stop-opacity:1" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#989898;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#b6b6b6;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-148.40713,-87.106181)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4284"
+       id="linearGradient10790-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33571488,0,0,0.59088033,378.76626,66.374404)"
+       x1="305"
+       y1="513.87781"
+       x2="305"
+       y2="545.35248" />
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         id="stop4286"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:0" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999967"
+         id="stop4288" />
+      <stop
+         id="stop4290"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10790-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,175.7687,-135.72514)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-9"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-0"
+       id="linearGradient10792-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,175.7687,-135.72514)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-0">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10786-1"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818"
+       gradientTransform="matrix(1.0391435,0,0,0.59796602,163.7026,66.310928)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-9"
+       id="linearGradient10782-3"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,178.81671,-139.61919)" />
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-3" />
+      <stop
+         id="stop10422-8"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-3"
+       id="linearGradient10784-2"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,178.81671,-139.61919)" />
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         id="stop10434-4"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-2" />
+      <stop
+         id="stop10438-9"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-90"
+       id="linearGradient10778-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="matrix(1.0765606,0,0,1.061954,151.89304,-176.68416)" />
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-0" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-96"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-8"
+       id="linearGradient10774-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.062525,0,0,1.0891236,163.76228,-191.1002)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         id="stop10750-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-8" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-8" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-7"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient10770-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0387443,0,0,1.1623096,171.67815,-229.42387)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-7" />
+      <stop
+         id="stop10456-4-1-5-3"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-4" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4485"
+       x="-0.100931"
+       y="-0.091065558"
+       width="1.201862"
+       height="1.1821311">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4487" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4489"
+       x="-0.045429614"
+       y="-0.062483285"
+       width="1.0908592"
+       height="1.1247113">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4491" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4493"
+       x="0"
+       y="-inf"
+       width="1"
+       height="inf">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4495" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4497"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4499" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4501"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4503" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4505"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4507" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4509"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4511" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4513"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4515" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4517"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4519" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4521"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4523" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4525"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4527" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4529"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4531" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4533"
+       x="-0.068962558"
+       y="-0.080227087"
+       width="1.1379251"
+       height="1.1604542">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4535" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4537"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4539" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4541"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4543" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4545"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4547" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4549"
+       x="-0.16745919"
+       y="-0.050075785"
+       width="1.3349184"
+       height="1.1001516">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4551" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4553"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4555" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4557"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4559" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4561"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4563" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.980741"
+     inkscape:cx="14.555666"
+     inkscape:cy="5.6786681"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <rect
+         ry="3.1069043"
+         rx="3.1069043"
+         y="347.32736"
+         x="473.10382"
+         height="19.677061"
+         width="17.753738"
+         id="rect13693-3"
+         style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4485)" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="rect13693"
+         d="m 472.68093,354.495 33.22969,0 c 1.72122,0 3.1069,1.38903 3.1069,3.11442 l 0,13.39945 c 0,1.72538 -1.44501,2.66525 -3.1069,3.11442 l -33.22969,8.9812 c -1.66188,0.44917 -3.1069,-1.38903 -3.1069,-3.11442 l 0,-22.38065 c 0,-1.72539 1.38568,-3.11442 3.1069,-3.11442 z"
+         style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4489)" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10770-6);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4497)"
+         id="rect10007-0-74-2-7-6"
+         width="21.018066"
+         height="10.826942"
+         x="500.47601"
+         y="374.24786"
+         rx="0"
+         ry="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4501)"
+         d="m 509.4754,374.25254 0,3.5838 12.01134,0 0,-3.5838 -12.01134,0 z"
+         id="path4313-8-8"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4505)"
+         d="m 510.67013,374.23175 0,10.8213 3.63939,0 0,-10.8213 z"
+         id="path4313-8-8-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4509)"
+         d="m 521.45874,381.40617 -12.03934,0.1111 0.0351,3.58381 12.03934,-0.1111 -0.0351,-3.58381 z"
+         id="path4313-5-1-8"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10774-5);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4513)"
+         id="rect10007-0-74-2-7"
+         width="11.41908"
+         height="17.791901"
+         x="499.25452"
+         y="370.73755"
+         rx="0"
+         ry="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4517)"
+         d="m 510.75632,385.0251 -12.03934,0.1111 0.035,3.5838 12.03935,-0.1111 -0.0351,-3.5838 z"
+         id="path4313-5-1"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4521)"
+         d="m 510.72133,370.66192 -12.03935,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+         id="path4313-8"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10778-6);fill-opacity:1;stroke:none;stroke-width:1.50161433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4525)"
+         id="rect10007-0-74-2"
+         width="11.811058"
+         height="24.955921"
+         x="491.81702"
+         y="367.15549"
+         rx="0"
+         ry="0" />
+      <rect
+         style="display:inline;fill:#5079bc;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4529)"
+         id="rect10007-0"
+         width="13.428176"
+         height="17.908186"
+         x="478.51385"
+         y="370.66931"
+         rx="0"
+         ry="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10782-3);fill-opacity:1;stroke:url(#linearGradient10784-2);stroke-width:1.48636866;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4533)"
+         id="rect10007-0-7"
+         width="10.776635"
+         height="9.2635088"
+         x="468.54718"
+         y="374.93893"
+         rx="0"
+         ry="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10786-1);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4537)"
+         id="rect10007-0-74"
+         width="13.378973"
+         height="10.763388"
+         x="478.56305"
+         y="374.18103"
+         rx="0"
+         ry="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4541)"
+         d="m 503.55372,367.07095 -12.03935,0.1111 0.035,3.5838 12.03935,-0.11109 -0.0351,-3.58381 z"
+         id="path4313"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4545)"
+         d="m 503.57471,388.57378 -12.03934,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+         id="path4313-5"
+         inkscape:connector-curvature="0" />
+      <rect
+         ry="5.3502665"
+         style="display:inline;fill:url(#linearGradient10790-8);fill-opacity:1;stroke:url(#linearGradient10792-6);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4549)"
+         id="rect10007-6"
+         width="10.700533"
+         height="35.783813"
+         x="483.90643"
+         y="361.72815"
+         inkscape:label="rect10007-6" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10790-8-2);fill-opacity:1;stroke:none;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4553)"
+         id="rect10007-6-6"
+         width="3.5889285"
+         height="19.98802"
+         x="482.11456"
+         y="369.51785" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:0.64640886;fill-rule:evenodd;stroke:none;stroke-width:0.97351193px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4557)"
+         d="m 503.58072,374.25075 0,10.78725 3.5848,0 0,-10.78725 z"
+         id="path4313-8-8-7-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.admin/icons/view/provision.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/icons/view/provision.svg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="profile_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17410">
+      <stop
+         style="stop-color:#e0ebf6;stop-opacity:1;"
+         offset="0"
+         id="stop17412" />
+      <stop
+         style="stop-color:#f3f5f6;stop-opacity:1"
+         offset="1"
+         id="stop17414" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17159">
+      <stop
+         style="stop-color:#ffeece;stop-opacity:1"
+         offset="0"
+         id="stop17161" />
+      <stop
+         style="stop-color:#e1eaba;stop-opacity:1"
+         offset="1"
+         id="stop17163" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17410"
+       id="linearGradient17441"
+       gradientUnits="userSpaceOnUse"
+       x1="-9.733428"
+       y1="12.635066"
+       x2="-3.9386158"
+       y2="6.8402538" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17159"
+       id="linearGradient17443"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.59076155,0.59076155,-0.59076155,0.59076155,17.040411,1049.6082)"
+       x1="-20.742412"
+       y1="7.9916593"
+       x2="-10.422931"
+       y2="7.9916593" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.063994"
+     inkscape:cx="8.506094"
+     inkscape:cy="7.4696588"
+     inkscape:document-units="px"
+     inkscape:current-layer="g17418"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5126" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline;fill:none"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="matrix(0.8261236,0,0,0.8261236,1.7832208,183.40446)">
+      <g
+         transform="matrix(1.2065384,0,0,1.2065384,-22.98457,-221.37405)"
+         id="g17594"
+         style="fill:none">
+        <g
+           id="g17418"
+           transform="matrix(0.96836657,0,0,0.96836657,20.738144,33.659982)">
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:url(#linearGradient17441);fill-opacity:1;stroke:#3f7fbf;stroke-width:0.5091278;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-5"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(1.0450409,-1.0450409,1.0450409,1.0450409,2.1256839,1029.9689)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14"
+             d="m 11.53513,1045.8134 c 0.07294,0.9455 0.07325,1.9032 9.05e-4,2.8489 l -2.3011454,-1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2"
+             d="m -1.0914354,1048.6741 c -0.07294,-0.9455 -0.07325,-1.9032 -9.07e-4,-2.849 l 2.301146,1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3"
+             d="m 6.6521976,1053.557 c -0.9455,0.073 -1.9032,0.073 -2.8489,9e-4 l 1.4186,-2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2"
+             d="m 3.7914976,1040.9305 c 0.9455,-0.073 1.9032,-0.073 2.849,-9e-4 l -1.4186,2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-2"
+             d="m 10.697423,1050.6965 c -0.616993,0.7202 -1.2939698,1.3976 -2.013837,2.0151 l -0.6240538,-2.6302 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-1"
+             d="m -0.2537278,1043.791 c 0.61699309,-0.7202 1.2939701,-1.3976 2.0139059,-2.0152 l 0.6240542,2.6303 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3-6"
+             d="m 1.7691159,1052.7193 c -0.7201883,-0.6169 -1.39738442,-1.2941 -2.0151129,-2.0138 l 2.6302251,-0.6241 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2-8"
+             d="m 8.6745793,1041.7682 c 0.7201883,0.6169 1.3973847,1.2941 2.0151837,2.0139 l -2.6302252,0.624 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:#1d4984;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-76"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(0.31739531,-0.31739531,0.31739531,0.31739531,4.2814936,1041.9971)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4"
+             d="m 11.535129,1046.4091 c 0.07294,0.5517 0.07325,1.1106 9.06e-4,1.6624 l -2.3011454,-0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5"
+             d="m -1.0914359,1048.0784 c -0.072942,-0.5517 -0.073247,-1.1106 -9.07e-4,-1.6625 l 2.3011463,0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51"
+             d="m 6.0564977,1053.557 c -0.5517,0.073 -1.1106,0.073 -1.6624,9e-4 l 0.8278,-2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7"
+             d="m 4.3871977,1040.9305 c 0.5517,-0.073 1.1106,-0.073 1.6624,-9e-4 l -0.8277,2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-1"
+             d="m 10.276129,1051.1178 c -0.3385343,0.4417 -0.7335171,0.8371 -1.1748536,1.1761 l -1.0418139,-2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-1"
+             d="m 0.16742503,1043.3698 c 0.33853445,-0.4416 0.73351722,-0.8371 1.17492367,-1.1762 l 1.0418137,2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51-5"
+             d="m 1.3478924,1052.2981 c -0.44172887,-0.3385 -0.83693085,-0.7337 -1.17612997,-1.1749 l 2.21246567,-1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7-2"
+             d="m 9.0958029,1042.1894 c 0.4417296,0.3385 0.8369322,0.7337 1.1761311,1.1749 l -2.2123961,1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:none;stroke:#3f7fbf;stroke-width:0.7180745;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(1.0202099,-1.0202099,1.0202099,1.0202099,2.1992508,1030.3794)" />
+          <path
+             sodipodi:nodetypes="cccccssc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-7"
+             d="m 6.0190516,1046.4513 -4.6356786,-3.9985 -1.80221867,-0.8517 0.85667548,1.7973 4.00338379,4.6307 c 0.2002055,0.2002 0.4771321,0.3237 0.7840021,0.3237 0.61367,0 1.1076548,-0.494 1.1076828,-1.1077 -5.64e-5,-0.3068 -0.1127546,-0.5927 -0.3138469,-0.7938 z"
+             style="color:#000000;fill:url(#linearGradient17443);fill-opacity:1;stroke:#4d607b;stroke-width:0.80260861;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <image
+             y="1038.406"
+             x="14.021823"
+             id="image4444"
+             xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAjhJREFU
+OI2lk09Ik3EYxz+LaFArCGHgQHxFUXBDAqGIDluxi4Qh1WHRYa8QhB0shru4gwtch5TBIOgSbBKh
+F20EHqrBu6A/iAkxVNiYNDVUxnRQ4weCvk+H5WzUpXwuv9/l+/D9PM/3sYgIR6ljR1IDxw8+Ho8u
+94fv4uywU9oThp9/o1FlUA4XJzcWsXZ2MXy5ifbmVsvvDSwHCC/ffJL45CwAAX8baBoNykZoLEkk
+2MdCsUIiDZoGCd1Ta1JDcHbYAXgVvUF0Ik85Z6VFcwLQojm5ef4CYR123qXQE2n5o0FpTwj427gW
+mGY62kd8cpa3778Q8LdhCohA9GGK634vhQLkVlekDsETTktYh3LOSnxylhfjV7k9VEUaD/djb3DU
+uJOf50gXqig1B40qQ4Oy4b54jv5bVfGzcS8A3oEpitsbmAKmQLfdxu5yph5BOVyExpLogxHOnsgC
+cGcoxZPHbi65TuMdmMIU0AcjhMaSKIerKhQRRARfMCaZpXnZLCvZ2lGSLeSlqWdUfMGYNPWMyszr
+j7K5o2SrrCSzNC++YExE5NCBtbOLhWKFfRP2BU6dcZB66uPD4g9iD67g7LBjCuybsFCsYO3sqneQ
+LeTFPWKI8dWQXj0kayUlayUl67/etZKSXj0kccMQ94gh2UK+3kF7c6tF0w5XdTCwe0OR6hpNCIx4
+mZlIoWnUElmLMlTXooMk0gBzdNttAHwvLh0m0e2tS6Llb9eYW12RR8Y6u8v/cAv/Wz8BBiUqWhPx
+5/kAAAAASUVORK5CYII=
+"
+             style="image-rendering:optimizeSpeed"
+             preserveAspectRatio="none"
+             height="16.576546"
+             width="16.576546" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.admin/plugin.xml
+++ b/bundles/org.eclipse.equinox.p2.ui.admin/plugin.xml
@@ -23,7 +23,7 @@
       </category>
       <view
             name="%MetadataRepositories.name"
-            icon="$nl$/icons/obj/metadata_repo_obj.png"
+            icon="$nl$/icons/obj/metadata_repo_obj.svg"
             category="org.eclipse.p2.ui.admin"
             class="org.eclipse.equinox.internal.p2.ui.admin.MetadataRepositoriesView"
             id="org.eclipse.p2.ui.admin.MetadataRepositoriesView">
@@ -33,7 +33,7 @@
          point="org.eclipse.ui.views">
      <view
             name="%ArtifactRepositories.name"
-            icon="$nl$/icons/obj/artifact_repo_obj.png"
+            icon="$nl$/icons/obj/artifact_repo_obj.svg"
             category="org.eclipse.p2.ui.admin"
             class="org.eclipse.equinox.internal.p2.ui.admin.ArtifactRepositoriesView"
             id="org.eclipse.p2.ui.admin.ArtifactRepositoriesView">
@@ -43,7 +43,7 @@
          point="org.eclipse.ui.views">
      <view
             name="%Profiles.name"
-            icon="$nl$/icons/obj/profile_obj.png"
+            icon="$nl$/icons/obj/profile_obj.svg"
             category="org.eclipse.p2.ui.admin"
             class="org.eclipse.equinox.internal.p2.ui.admin.ProfilesView"
             id="org.eclipse.p2.ui.admin.ProfilesView">
@@ -54,7 +54,7 @@
          point="org.eclipse.ui.perspectives">
       <perspective
             name="%perspectiveName"
-            icon="$nl$/icons/view/provision.png"
+            icon="$nl$/icons/view/provision.svg"
             class="org.eclipse.equinox.internal.p2.ui.admin.ProvisioningPerspective"
             id="org.eclipse.equinox.p2.ui.admin.ProvisioningPerspective">
       </perspective>

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Export-Package: org.eclipse.equinox.internal.p2.ui.discovery;x-internal:=true,
  org.eclipse.equinox.internal.p2.ui.discovery.wizards;x-internal:=true
 Import-Package: org.eclipse.equinox.p2.planner;version="2.0.0"
 Automatic-Module-Name: org.eclipse.equinox.p2.ui.discovery
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/icons/etool16/find.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/icons/etool16/find.svg
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="find.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4177">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4179" />
+      <stop
+         style="stop-color:#e2edf7;stop-opacity:1"
+         offset="1"
+         id="stop4181" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4167"
+       id="linearGradient4173"
+       x1="24.279608"
+       y1="1038.3673"
+       x2="22.69014"
+       y2="1045.7269"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7071067,0,0,0.7071067,-0.61192312,304.5052)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4167">
+      <stop
+         style="stop-color:#6f877d;stop-opacity:1"
+         offset="0"
+         id="stop4169" />
+      <stop
+         style="stop-color:#2b66b2;stop-opacity:1"
+         offset="1"
+         id="stop4171" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4177"
+       id="radialGradient4245"
+       cx="14.311938"
+       cy="1039.2069"
+       fx="14.311938"
+       fy="1039.2069"
+       r="5.4497476"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56661844,0,0,0.7071067,6.4781913,304.5052)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="40.932365"
+     inkscape:cx="7.9971098"
+     inkscape:cy="7.9902516"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4196"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     showguides="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4242">
+      <g
+         transform="translate(-9.5563496,1.6205583)"
+         id="g3353">
+        <g
+           id="g4196">
+          <image
+             y="1034.7417"
+             x="25.556349"
+             id="image4545"
+             xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0
+U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAEOSURBVHjaYvz//z8DJYCRagaA6CsPb/xf
+s/cOw8fXp8Fi/KKmDCHOKgw68hqMKJoYkbggjSB86f61//nttf8fvnr///XH72AMYoPEQHL//v1j
+gGGYHrDlMEbpjINgDe++/ULg77/AYnVzNuE0gAnmkm3nPjJwsXMw/P39j+H3Xwj+++sfWGztKdxh
+wIIu8P0PaqBysuAPRLh0sBkDw7efPxh+MbEyMPxjYGAGiv0FhdHf32A5XADuBVBoe9UcZvj+7S9Y
+M9g1P/4ylMU0M9w78Zi0aIT5GWQzSPPvR3cZWOWUGRbNymREj0YUA3CBuLTp/5ENIdkAdEMWz85i
+xAgDQgBkM0gz7fLCgBkAEGAAEK3gCltmSwUAAAAASUVORK5CYII=
+"
+             style="image-rendering:optimizeSpeed"
+             preserveAspectRatio="none"
+             height="16"
+             width="16" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4185"
+             d="m 22.198388,1047.091 0,-0.9107 -4.082341,-3.9411 -1.05718,1.0207 4.163663,4.0196 z"
+             style="fill:#574672;fill-opacity:1;fill-rule:evenodd;stroke:#5c6495;stroke-width:0.71592331;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <circle
+             r="3.4999998"
+             cy="1040.7417"
+             cx="15.55635"
+             id="path4157"
+             style="opacity:1;fill:url(#radialGradient4245);fill-opacity:1;stroke:url(#linearGradient4173);stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/icons/obj16/iu_disabled_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/icons/obj16/iu_disabled_obj.svg
@@ -1,0 +1,768 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="iu_disabled_obj.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#b6b6b6;stop-opacity:1" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#989898;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#b6b6b6;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-148.40713,-87.106181)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4284"
+       id="linearGradient10790-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33571488,0,0,0.59088033,378.76626,66.374404)"
+       x1="305"
+       y1="513.87781"
+       x2="305"
+       y2="545.35248" />
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         id="stop4286"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:0" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999967"
+         id="stop4288" />
+      <stop
+         id="stop4290"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10790-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,175.7687,-135.72514)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-9"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-0"
+       id="linearGradient10792-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,175.7687,-135.72514)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-0">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10786-1"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818"
+       gradientTransform="matrix(1.0391435,0,0,0.59796602,163.7026,66.310928)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-9"
+       id="linearGradient10782-3"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,178.81671,-139.61919)" />
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-3" />
+      <stop
+         id="stop10422-8"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-3"
+       id="linearGradient10784-2"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,178.81671,-139.61919)" />
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         id="stop10434-4"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-2" />
+      <stop
+         id="stop10438-9"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-90"
+       id="linearGradient10778-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="matrix(1.0765606,0,0,1.061954,151.89304,-176.68416)" />
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-0" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-96"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-8"
+       id="linearGradient10774-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.062525,0,0,1.0891236,163.76228,-191.1002)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         id="stop10750-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-8" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-8" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-7"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient10770-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0387443,0,0,1.1623096,171.67815,-229.42387)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-7" />
+      <stop
+         id="stop10456-4-1-5-3"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-4" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4485"
+       x="-0.100931"
+       y="-0.091065558"
+       width="1.201862"
+       height="1.1821311">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4487" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4489"
+       x="-0.045429614"
+       y="-0.062483285"
+       width="1.0908592"
+       height="1.1247113">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4491" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4493"
+       x="0"
+       y="-inf"
+       width="1"
+       height="inf">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4495" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4497"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4499" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4501"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4503" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4505"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4507" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4509"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4511" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4513"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4515" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4517"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4519" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4521"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4523" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4525"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4527" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4529"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4531" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4533"
+       x="-0.068962558"
+       y="-0.080227087"
+       width="1.1379251"
+       height="1.1604542">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4535" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4537"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4539" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4541"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4543" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4545"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4547" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4549"
+       x="-0.16745919"
+       y="-0.050075785"
+       width="1.3349184"
+       height="1.1001516">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4551" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4553"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4555" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4557"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4559" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4561"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4563" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16.249838"
+     inkscape:cx="-3.1077233"
+     inkscape:cy="5.6308254"
+     inkscape:document-units="px"
+     inkscape:current-layer="g13862"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <rect
+         ry="3.1069043"
+         rx="3.1069043"
+         y="347.32736"
+         x="473.10382"
+         height="19.677061"
+         width="17.753738"
+         id="rect13693-3"
+         style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4485)" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="rect13693"
+         d="m 472.68093,354.495 33.22969,0 c 1.72122,0 3.1069,1.38903 3.1069,3.11442 l 0,13.39945 c 0,1.72538 -1.44501,2.66525 -3.1069,3.11442 l -33.22969,8.9812 c -1.66188,0.44917 -3.1069,-1.38903 -3.1069,-3.11442 l 0,-22.38065 c 0,-1.72539 1.38568,-3.11442 3.1069,-3.11442 z"
+         style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4489)" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10770-6);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4497)"
+         id="rect10007-0-74-2-7-6"
+         width="21.018066"
+         height="10.826942"
+         x="500.47601"
+         y="374.24786"
+         rx="0"
+         ry="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4501)"
+         d="m 509.4754,374.25254 0,3.5838 12.01134,0 0,-3.5838 -12.01134,0 z"
+         id="path4313-8-8"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4505)"
+         d="m 510.67013,374.23175 0,10.8213 3.63939,0 0,-10.8213 z"
+         id="path4313-8-8-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4509)"
+         d="m 521.45874,381.40617 -12.03934,0.1111 0.0351,3.58381 12.03934,-0.1111 -0.0351,-3.58381 z"
+         id="path4313-5-1-8"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10774-5);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4513)"
+         id="rect10007-0-74-2-7"
+         width="11.41908"
+         height="17.791901"
+         x="499.25452"
+         y="370.73755"
+         rx="0"
+         ry="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4517)"
+         d="m 510.75632,385.0251 -12.03934,0.1111 0.035,3.5838 12.03935,-0.1111 -0.0351,-3.5838 z"
+         id="path4313-5-1"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4521)"
+         d="m 510.72133,370.66192 -12.03935,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+         id="path4313-8"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10778-6);fill-opacity:1;stroke:none;stroke-width:1.50161433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4525)"
+         id="rect10007-0-74-2"
+         width="11.811058"
+         height="24.955921"
+         x="491.81702"
+         y="367.15549"
+         rx="0"
+         ry="0" />
+      <rect
+         style="display:inline;fill:#5079bc;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4529)"
+         id="rect10007-0"
+         width="13.428176"
+         height="17.908186"
+         x="478.51385"
+         y="370.66931"
+         rx="0"
+         ry="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10782-3);fill-opacity:1;stroke:url(#linearGradient10784-2);stroke-width:1.48636866;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4533)"
+         id="rect10007-0-7"
+         width="10.776635"
+         height="9.2635088"
+         x="468.54718"
+         y="374.93893"
+         rx="0"
+         ry="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10786-1);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4537)"
+         id="rect10007-0-74"
+         width="13.378973"
+         height="10.763388"
+         x="478.56305"
+         y="374.18103"
+         rx="0"
+         ry="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4541)"
+         d="m 503.55372,367.07095 -12.03935,0.1111 0.035,3.5838 12.03935,-0.11109 -0.0351,-3.58381 z"
+         id="path4313"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4545)"
+         d="m 503.57471,388.57378 -12.03934,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+         id="path4313-5"
+         inkscape:connector-curvature="0" />
+      <rect
+         ry="5.3502665"
+         style="display:inline;fill:url(#linearGradient10790-8);fill-opacity:1;stroke:url(#linearGradient10792-6);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4549)"
+         id="rect10007-6"
+         width="10.700533"
+         height="35.783813"
+         x="483.90643"
+         y="361.72815" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10790-8-2);fill-opacity:1;stroke:none;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4553)"
+         id="rect10007-6-6"
+         width="3.5889285"
+         height="19.98802"
+         x="482.11456"
+         y="369.51785" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:0.64640886;fill-rule:evenodd;stroke:none;stroke-width:0.97351193px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4557)"
+         d="m 503.58072,374.25075 0,10.78725 3.5848,0 0,-10.78725 z"
+         id="path4313-8-8-7-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/icons/obj16/iu_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/icons/obj16/iu_obj.svg
@@ -1,0 +1,557 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#c48a4e;stop-opacity:1;" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#ad6c24;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-148.40713,-87.106181)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955"
+       id="linearGradient3945"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-147.48911,-87.252829)" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4284"
+       id="linearGradient10790-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33571488,0,0,0.59088033,417.52974,47.073021)"
+       x1="305"
+       y1="513.87781"
+       x2="305"
+       y2="545.35248" />
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         id="stop4286"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:0" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999967"
+         id="stop4288" />
+      <stop
+         id="stop4290"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10790-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,214.53218,-155.02652)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-9"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-0"
+       id="linearGradient10792-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,214.53218,-155.02652)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-0">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10786-1"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818"
+       gradientTransform="matrix(1.0391435,0,0,0.59796602,202.46608,47.009545)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-9"
+       id="linearGradient10782-3"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,217.58019,-158.92057)" />
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-3" />
+      <stop
+         id="stop10422-8"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-3"
+       id="linearGradient10784-2"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,217.58019,-158.92057)" />
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         id="stop10434-4"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-2" />
+      <stop
+         id="stop10438-9"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-90"
+       id="linearGradient10778-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="matrix(1.0765606,0,0,1.061954,190.65652,-195.98554)" />
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-0" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-96"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-8"
+       id="linearGradient10774-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.062525,0,0,1.0891236,202.52576,-210.40158)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         id="stop10750-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-8" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-8" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-7"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient10770-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0387443,0,0,1.1623096,210.44163,-248.72525)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-7" />
+      <stop
+         id="stop10456-4-1-5-3"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-4" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="54.508621"
+     inkscape:cx="15.113239"
+     inkscape:cy="6.9688496"
+     inkscape:document-units="px"
+     inkscape:current-layer="g13862"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <rect
+         ry="3.1069043"
+         rx="3.1069043"
+         y="347.32736"
+         x="473.10382"
+         height="19.677061"
+         width="17.753738"
+         id="rect13693-3"
+         style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="rect13693"
+         d="m 472.68093,354.495 33.22969,0 c 1.72122,0 3.1069,1.38903 3.1069,3.11442 l 0,13.39945 c 0,1.72538 -1.44501,2.66525 -3.1069,3.11442 l -33.22969,8.9812 c -1.66188,0.44917 -3.1069,-1.38903 -3.1069,-3.11442 l 0,-22.38065 c 0,-1.72539 1.38568,-3.11442 3.1069,-3.11442 z"
+         style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path13797"
+         d="m 471.31191,354.49499 23.78261,0"
+         style="fill:none;stroke:url(#linearGradient3945);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         id="g4301"
+         transform="translate(-38.76348,19.301383)">
+        <rect
+           ry="0"
+           rx="0"
+           y="354.94647"
+           x="539.2395"
+           height="10.826942"
+           width="21.018066"
+           id="rect10007-0-74-2-7-6"
+           style="display:inline;fill:url(#linearGradient10770-6);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8-8"
+           d="m 548.23888,354.95116 0,3.5838 12.01134,0 0,-3.5838 -12.01134,0 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7"
+           d="m 549.43361,354.93037 0,10.8213 3.63939,0 0,-10.8213 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1-8"
+           d="m 560.22222,362.10479 -12.03934,0.1111 0.0351,3.58381 12.03934,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="351.43616"
+           x="538.01801"
+           height="17.791901"
+           width="11.41908"
+           id="rect10007-0-74-2-7"
+           style="display:inline;fill:url(#linearGradient10774-5);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1"
+           d="m 549.5198,365.72372 -12.03934,0.1111 0.035,3.5838 12.03935,-0.1111 -0.0351,-3.5838 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8"
+           d="m 549.48481,351.36054 -12.03935,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="347.8541"
+           x="530.58051"
+           height="24.955921"
+           width="11.811058"
+           id="rect10007-0-74-2"
+           style="display:inline;fill:url(#linearGradient10778-6);fill-opacity:1;stroke:none;stroke-width:1.50161433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="351.36792"
+           x="517.27734"
+           height="17.908186"
+           width="13.428176"
+           id="rect10007-0"
+           style="display:inline;fill:#5079bc;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="355.63754"
+           x="507.31067"
+           height="9.2635088"
+           width="10.776635"
+           id="rect10007-0-7"
+           style="display:inline;fill:url(#linearGradient10782-3);fill-opacity:1;stroke:url(#linearGradient10784-2);stroke-width:1.48636866;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="354.87964"
+           x="517.32654"
+           height="10.763388"
+           width="13.378973"
+           id="rect10007-0-74"
+           style="display:inline;fill:url(#linearGradient10786-1);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313"
+           d="m 542.3172,347.76957 -12.03935,0.1111 0.035,3.5838 12.03935,-0.11109 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5"
+           d="m 542.33819,369.2724 -12.03934,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           y="342.42676"
+           x="522.66992"
+           height="35.783813"
+           width="10.700533"
+           id="rect10007-6"
+           style="display:inline;fill:url(#linearGradient10790-8);fill-opacity:1;stroke:url(#linearGradient10792-6);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           ry="5.3502665" />
+        <rect
+           y="350.21646"
+           x="520.87805"
+           height="19.98802"
+           width="3.5889285"
+           id="rect10007-6-6"
+           style="display:inline;fill:url(#linearGradient10790-8-2);fill-opacity:1;stroke:none;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7-8"
+           d="m 542.3442,354.94937 0,10.78725 3.5848,0 0,-10.78725 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:0.64640886;fill-rule:evenodd;stroke:none;stroke-width:0.97351193px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <image
+           y="326.2341"
+           x="560.24866"
+           id="image4280"
+           xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAeJJREFU
+OI2Nk09IFFEcxz9vWTfbtFQkWCg2IZcuG8RiDihdiqAIEeoYE3jx0KVAuglBhw5ueBCJLkEeRZDq
+EHboIBJLge2xf0JLRiEpO4szs81u8+vwZnbXJrUvPN7/z/u+33s/JSKEKuSNZgcwJgqK/SQiiAjP
+b2XkbwVj7FWUiFDIG5IzxwGoO1Wcio1bruBY22x9eB05tNVZPGy0dZwOajh4FEik9cT5UgRQyBsS
+QhoA6k5zRXs/5oMvAMzdPgbVT7uGIAZQ9wU8q1HM6XX6eoW+XsGcXtduEmnwKuBZen3rFWo1X28G
+6BoEyiTb4ygE8Fl+qK9zblw78Tx/JyB99hJ0ngHAnClrzqE2FApwGbq+CMDyo34AThiTOwF3V0dg
+Vcfgcu4IXzfKdHUkkAAg/i8U0J0e5VRumJX5CUrv7gkqAHTHA/sIqZ4UqZ5k4wS3ukHscFZ3kq9Q
+nRncAye5eOVG08HHH82gfN9yKL7/xmD2OErBtu3i/yzqSauEbL5BNj/z8skkEgJeTF1ofIzhm88k
+BmQzdRCwbQd+O4CwVlxirbjE6H2JfqRQK7MjamBsQSy7BiK4rsfT2TsAXJ2SSG5EAKEqdi14xn9v
+DKVas7FVA2MLAvD28bU9M3JXwP/qD5PM7CDw/+DMAAAAAElFTkSuQmCC
+"
+           style="image-rendering:optimizeSpeed"
+           preserveAspectRatio="none"
+           height="57.340881"
+           width="57.340881" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/icons/obj16/iu_update_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/icons/obj16/iu_update_obj.svg
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_update.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4274">
+      <stop
+         id="stop4276"
+         offset="0"
+         style="stop-color:#15629b;stop-opacity:1" />
+      <stop
+         id="stop4278"
+         offset="1"
+         style="stop-color:#6994ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4268">
+      <stop
+         id="stop4270"
+         offset="0"
+         style="stop-color:#c1ebca;stop-opacity:1" />
+      <stop
+         id="stop4272"
+         offset="1"
+         style="stop-color:#739ab3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a86e11;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#739ab3;stop-opacity:1"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#c1ebca;stop-opacity:1"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient4873"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99194778,0,0,0.90415386,28.747558,98.91832)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1"
+       id="linearGradient4875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99194778,0,0,0.90415386,28.747558,98.91832)"
+       x1="23.107393"
+       y1="1040.0905"
+       x2="23.107393"
+       y2="1044.9022" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4268"
+       id="linearGradient4262"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99194778,0,0,-0.90415386,-2.747602,1988.8045)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.373606"
+       y2="1039.7751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4274"
+       id="linearGradient4264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99194778,0,0,-0.90415386,-2.747602,1988.8045)"
+       x1="23.107393"
+       y1="1040.0905"
+       x2="23.107393"
+       y2="1044.9022" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="41.50087"
+     inkscape:cx="17.746156"
+     inkscape:cy="8.8506495"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4155" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="17"
+       id="image4216"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAYNJREFU
+OI2Nkk8og3EYxz8/HDTEHLyHndxdlCI3DhwkO0gur4Pbm5TiIhepnRTSyiguMmXt8irH1W6iuPqT
+snIxmuZts2Hv48BeNnvHt371fHue59vzfH+PEhHKEQtoAtC/cK9+JctQ45bom790hP4tEAto8rOp
+ezL0p4gqrhALaNI1No2nrbOkIJs853hvnYHFZMV16pzmER1Psw/yyZKC+toXcnnbdYI6gNTjG56G
+Vuy7OOauCQr803PYmQTmdoTR1ZSrmY4H9tMV5q7J6GpKvb0KdiZBNHRQtRkAEUFEiMx4pRiHp1ok
+PNXicCMYFSMYLeHF2BFwe0YwKvGHE0egnLveAcDESkT8wz5esjZWroDucMHKFb5NrIShpX3p7fBi
+PX8W+gd9IAorbXNxnSaVea8ukLTeec3bpJ8KKED49DJxZ3F09sjpsq7gxyFVQruxI+M9Gpq3kbWj
+G740uN2Y/P6Zv0xs0kMyu3UoTfqmVMpXnaAINbYhAHJg/LqJfwlUwwenxRkkxaNangAAAABJRU5E
+rkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <g
+       id="g4221">
+      <path
+         sodipodi:nodetypes="ccssscsccsszcc"
+         inkscape:connector-curvature="0"
+         id="path7582"
+         d="m 5.5000007,1038.7178 0,-1.4385 c 0,0 0.2030217,-0.8491 1.2113028,-0.1297 1.0082813,0.7193 2.1919159,1.8781 2.3672696,2.1977 0.1753525,0.3197 0.9206039,0.8791 -0.087678,1.7583 -1.0082811,0.879 -2.1042395,1.798 -2.1042395,1.798 0,0 -1.3866564,1.4086 -1.3866564,0.1695 l 0,-1.2109 c -1.649686,-0.033 -1.7527346,0.9812 -3.3800406,1.9981 -0.4029788,0.1131 -0.6199673,-1.9778 -0.6199673,-2.3734 0,-0.3955 0.1733855,-1.1246 0.7129624,-1.78 0.2911803,-0.3536 0.9984659,-0.8639 1.5189201,-0.9944 0.5204541,-0.1305 1.7681254,0.1497 1.7681254,0.1497 z"
+         style="fill:url(#linearGradient4873);fill-opacity:1;stroke:url(#linearGradient4875);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602"
+         d="m 6.0176775,1038.1899 0,-0.5395 c 0,0 -0.110485,-0.3397 0.220971,-0.2198 0.331456,0.1199 0.972272,0.5994 1.038563,0.6993 0.06629,0.1 0.751301,0.5394 0.596622,0.7392 -0.15468,0.1999 -1.458408,0.06 -1.458408,0.06 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="g4280"
+       transform="translate(-9.999967,1.1757519e-5)">
+      <path
+         sodipodi:nodetypes="ccssscsccsszcc"
+         inkscape:connector-curvature="0"
+         id="path7582-5"
+         d="m 20.499955,1049.005 0,1.4385 c 0,0 -0.203021,0.8491 -1.211302,0.1297 -1.008282,-0.7193 -2.191916,-1.8781 -2.36727,-2.1977 -0.175353,-0.3197 -0.920604,-0.8791 0.08768,-1.7583 1.008281,-0.879 2.104239,-1.798 2.104239,-1.798 0,0 1.386657,-1.4086 1.386657,-0.1695 l 0,1.2109 c 1.649686,0.033 1.752734,-0.9812 3.38004,-1.9981 0.402979,-0.1131 0.619968,1.9778 0.619968,2.3734 0,0.3955 -0.173386,1.1246 -0.712963,1.78 -0.29118,0.3536 -0.998466,0.8639 -1.51892,0.9944 -0.520454,0.1305 -1.768125,-0.1497 -1.768125,-0.1497 z"
+         style="fill:url(#linearGradient4262);fill-opacity:1;stroke:url(#linearGradient4264);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602-4"
+         d="m 19.958224,1045.7682 0,-0.5395 c 0,0 0.1105,-0.3397 -0.221,-0.2198 -0.3314,0.1199 -0.9722,0.5994 -1.0385,0.6993 -0.066,0.1 -0.7513,0.5394 -0.5966,0.7392 0.1546,0.1999 1.4584,0.06 1.4584,0.06 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/icons/obj16/message_info.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/icons/obj16/message_info.svg
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="message_info.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3857">
+      <stop
+         style="stop-color:#0e62a4;stop-opacity:1"
+         offset="0"
+         id="stop3859" />
+      <stop
+         style="stop-color:#02468c;stop-opacity:1"
+         offset="1"
+         id="stop3861" />
+    </linearGradient>
+    <linearGradient
+       y2="1060.6793"
+       x2="16.307018"
+       y1="1055.0179"
+       x1="16.307018"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898"
+       xlink:href="#linearGradient4890"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1056.5471"
+       x2="18.340696"
+       y1="1056.5471"
+       x1="14.256123"
+       id="linearGradient4896"
+       xlink:href="#linearGradient4890"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4996-4"
+       id="linearGradient5028"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(38.469436,55.035191)"
+       x1="13.903196"
+       y1="1062.1353"
+       x2="13.903196"
+       y2="1051.7347" />
+    <linearGradient
+       id="linearGradient4996-4"
+       inkscape:collect="always">
+      <stop
+         id="stop4998-5"
+         offset="0"
+         style="stop-color:#02468c;stop-opacity:1" />
+      <stop
+         id="stop5000-5"
+         offset="1"
+         style="stop-color:#0e62a4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4890">
+      <stop
+         id="stop4892"
+         offset="0"
+         style="stop-color:#2857bd;stop-opacity:1;" />
+      <stop
+         id="stop4894"
+         offset="1"
+         style="stop-color:#3d5384;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1056.5471"
+       x2="18.340696"
+       y1="1056.5471"
+       x1="14.256123"
+       id="linearGradient4896-1"
+       xlink:href="#linearGradient4890-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4890-6">
+      <stop
+         id="stop4892-2"
+         offset="0"
+         style="stop-color:#2857bd;stop-opacity:1;" />
+      <stop
+         id="stop4894-2"
+         offset="1"
+         style="stop-color:#3d5384;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1060.6793"
+       x2="16.307018"
+       y1="1055.0179"
+       x1="16.307018"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4898-7"
+       xlink:href="#linearGradient4890-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3052">
+      <stop
+         id="stop3054"
+         offset="0"
+         style="stop-color:#2857bd;stop-opacity:1;" />
+      <stop
+         id="stop3056"
+         offset="1"
+         style="stop-color:#3d5384;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="1060.6793"
+       x2="16.307018"
+       y1="1055.0179"
+       x1="16.307018"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3060"
+       xlink:href="#linearGradient3857"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="7.4539771"
+     inkscape:cy="21.313618"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8159"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="900"
+     inkscape:window-x="222"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8159"
+       transform="translate(-8.2201163,-12.904699)">
+      <path
+         sodipodi:type="arc"
+         style="fill:#f8fdff;fill-opacity:1;stroke:#02468c;stroke-width:1.52293062;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path4110"
+         sodipodi:cx="11.9375"
+         sodipodi:cy="11.6875"
+         sodipodi:rx="9.875"
+         sodipodi:ry="9.875"
+         d="m 21.8125,11.6875 a 9.875,9.875 0 1 1 -19.75,0 9.875,9.875 0 1 1 19.75,0 z"
+         transform="matrix(0.65662871,0,0,0.65662871,8.3816111,1049.5926)" />
+      <g
+         transform="translate(1.790992,32.464778)"
+         style="display:inline"
+         id="layer1-8"
+         inkscape:label="Layer 1">
+        <g
+           transform="translate(-8.2201163,-12.904699)"
+           id="g8159-9"
+           style="display:inline">
+          <text
+             sodipodi:linespacing="125%"
+             id="text4140-1-8-1"
+             y="1117.2119"
+             x="50.288464"
+             style="font-size:15.07241726px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient5028);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy"
+             xml:space="preserve"><tspan
+               style="fill:url(#linearGradient5028);fill-opacity:1"
+               y="1117.2119"
+               x="50.288464"
+               id="tspan4142-7-8-7"
+               sodipodi:role="line">Kozuka Mincho Pr6N H</tspan></text>
+        </g>
+      </g>
+      <g
+         transform="matrix(0.87196374,0,0,0.80250065,2.0740224,208.83353)"
+         id="text4140-1-8"
+         style="font-size:15.07241726px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4896-1);fill-opacity:1;stroke:none;display:inline;font-family:Kozuka Mincho Pr6N H;-inkscape-font-specification:Kozuka Mincho Pr6N H Heavy">
+        <path
+           inkscape:connector-curvature="0"
+           id="path5058"
+           style="fill:url(#linearGradient3060);fill-opacity:1"
+           d="m 16.245657,1050.9177 c -0.355456,0.01 -0.65062,0.1291 -0.885494,0.3674 -0.234876,0.2383 -0.35671,0.5529 -0.365501,0.9439 0.0088,0.3981 0.130625,0.7172 0.365502,0.9571 0.234873,0.2399 0.530037,0.363 0.885493,0.3692 0.362672,-0.01 0.662232,-0.1293 0.898681,-0.3692 0.236442,-0.2399 0.358903,-0.559 0.367386,-0.9571 -0.0057,-0.3778 -0.122466,-0.6886 -0.35043,-0.9326 -0.227971,-0.244 -0.533183,-0.3702 -0.915637,-0.3787 z m 0.94955,3.3912 c -1.039986,0.4346 -2.019679,0.6808 -2.939084,0.7386 l 0,0.6029 c 0.435838,-0.02 0.70965,0.039 0.821436,0.1771 0.111784,0.1381 0.159513,0.476 0.143187,1.0136 l 0,3.4515 c 0.01539,0.5401 -0.03423,0.888 -0.148838,1.0438 -0.114613,0.1557 -0.386541,0.2248 -0.815785,0.2072 l 0,0.633 4.084573,0 0,-0.633 c -0.386544,0.017 -0.634608,-0.051 -0.744192,-0.2054 -0.109591,-0.1541 -0.157947,-0.4977 -0.145069,-1.0305 l 0,-5.8631 z" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/icons/ovr32/message_warning.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/icons/ovr32/message_warning.svg
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="message_warning.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3922"
+       inkscape:collect="always">
+      <stop
+         id="stop3924"
+         offset="0"
+         style="stop-color:#c49a60;stop-opacity:1" />
+      <stop
+         id="stop3926"
+         offset="1"
+         style="stop-color:#d3a568;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3914">
+      <stop
+         style="stop-color:#7b5113;stop-opacity:1;"
+         offset="0"
+         id="stop3916" />
+      <stop
+         style="stop-color:#9a681f;stop-opacity:1"
+         offset="1"
+         id="stop3918" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3903">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3905" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3907" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3891">
+      <stop
+         style="stop-color:#ffe59e;stop-opacity:1;"
+         offset="0"
+         id="stop3893" />
+      <stop
+         style="stop-color:#fff5dc;stop-opacity:1"
+         offset="1"
+         id="stop3895" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         style="stop-color:#ffe69e;stop-opacity:1"
+         offset="0"
+         id="stop5083" />
+      <stop
+         id="stop5089"
+         offset="0.37960318"
+         style="stop-color:#ffc85a;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091"
+       id="linearGradient4200"
+       gradientUnits="userSpaceOnUse"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientTransform="matrix(1.0698871,0,0,1.0698871,4.6141416,1043.527)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081"
+       id="radialGradient4963"
+       cx="19.36529"
+       cy="1051.1095"
+       fx="19.36529"
+       fy="1051.1095"
+       r="3.7734281"
+       gradientTransform="matrix(2.8249601,0,0,1.7930635,-46.347422,-833.43041)"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       id="filter3805"
+       x="-0.15965195"
+       width="1.3193039"
+       y="-0.036941662"
+       height="1.0738833">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.077130848"
+         id="feGaussianBlur3807" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081-4"
+       id="radialGradient4963-8"
+       cx="19.36529"
+       cy="1051.1095"
+       fx="19.36529"
+       fy="1051.1095"
+       r="3.7734282"
+       gradientTransform="matrix(2.8249601,0,0,1.7930635,-46.347422,-833.43041)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5081-4">
+      <stop
+         style="stop-color:#ffe69e;stop-opacity:1"
+         offset="0"
+         id="stop5083-9" />
+      <stop
+         id="stop5089-7"
+         offset="0.37960318"
+         style="stop-color:#ffc85a;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091-2"
+       id="linearGradient4200-7"
+       gradientUnits="userSpaceOnUse"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientTransform="matrix(1.0698871,0,0,1.0698871,4.6141416,1043.527)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091-2">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093-4" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095-7" />
+    </linearGradient>
+    <linearGradient
+       y2="0.39338252"
+       x2="6.3885393"
+       y1="7.2369323"
+       x1="6.3885393"
+       gradientTransform="matrix(1.0698871,0,0,1.0698871,4.6141415,1043.527)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3831"
+       xlink:href="#linearGradient3922"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081-0"
+       id="radialGradient4963-2"
+       cx="19.36529"
+       cy="1051.1095"
+       fx="19.36529"
+       fy="1051.1095"
+       r="3.7734282"
+       gradientTransform="matrix(2.8249601,0,0,1.7930635,-46.347422,-833.43041)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5081-0">
+      <stop
+         style="stop-color:#ffe69e;stop-opacity:1"
+         offset="0"
+         id="stop5083-3" />
+      <stop
+         id="stop5089-75"
+         offset="0.37960318"
+         style="stop-color:#ffc85a;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091-7"
+       id="linearGradient4200-1"
+       gradientUnits="userSpaceOnUse"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientTransform="matrix(1.0698871,0,0,1.0698871,4.6141416,1043.527)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091-7">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093-6" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3891"
+       id="linearGradient3897"
+       x1="8.3908825"
+       y1="1051.37"
+       x2="8.3908825"
+       y2="1044.4331"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3903"
+       id="linearGradient3909"
+       x1="7.7905316"
+       y1="1048.343"
+       x2="8.9500166"
+       y2="1048.343"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3914"
+       id="linearGradient3920"
+       x1="-12.219131"
+       y1="5.3947439"
+       x2="-12.219131"
+       y2="12.915895"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="52.936769"
+     inkscape:cy="-43.411463"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8472"
+     showgrid="true"
+     inkscape:window-width="1280"
+     inkscape:window-height="900"
+     inkscape:window-x="150"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4202"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,5.428189,69.044514)">
+      <g
+         id="g4193"
+         transform="matrix(1.9494937,0,0,1.9494937,-13.566249,-998.69171)">
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4292"
+           d="m 7.6231986,1044.4966 -2.434777,4.3798 c -0.648383,1.0968 -0.206291,2.7732 1.003019,2.7928 l 1.632362,0 1.069887,0 1.6323624,0 c 1.209311,-0.019 1.651402,-1.6961 1.003019,-2.7928 l -2.4347774,-4.3798 c -0.314859,-0.5957 -1.196998,-0.4999 -1.471095,0 z"
+           style="fill:url(#radialGradient4963);fill-opacity:1;stroke:url(#linearGradient4200);stroke-width:0.5488025;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <g
+           id="g3797"
+           style="opacity:0.5;stroke:#fff5da;stroke-width:0.5488025;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;filter:url(#filter3805)">
+          <path
+             sodipodi:type="arc"
+             style="fill:#ffdb9f;fill-opacity:1;stroke:#fff5da;stroke-width:0.5916447;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+             id="path4253-1"
+             sodipodi:cx="3.484375"
+             sodipodi:cy="5.484375"
+             sodipodi:rx="0.625"
+             sodipodi:ry="0.625"
+             d="m 4.109375,5.484375 c 0,0.345178 -0.279822,0.625 -0.625,0.625 -0.345178,0 -0.625,-0.279822 -0.625,-0.625 0,-0.345178 0.279822,-0.625 0.625,-0.625 0.345178,0 0.625,0.279822 0.625,0.625 z"
+             transform="matrix(0.92758799,0,0,0.92758799,5.1382097,1045.1815)" />
+          <path
+             style="fill:#ffdb9f;fill-opacity:1;stroke:#fff5da;stroke-width:0.5488025;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+             d="m 8.3828217,1045.8375 c -0.311801,0 -0.577113,0.2776 -0.577113,0.6378 l 0.07528,2.1544 c 0,0.3202 0.22468,0.5796 0.501836,0.5796 0.277156,0 0.501835,-0.2594 0.501835,-0.5796 l 0.05018,-2.1544 c 0,-0.3602 -0.240219,-0.6378 -0.552018,-0.6378 z"
+             id="path4253-7-8"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="sccsccs" />
+        </g>
+        <g
+           id="g3899"
+           style="fill:url(#linearGradient3909);fill-opacity:1">
+          <path
+             style="fill:url(#linearGradient3920);fill-opacity:1;stroke:none"
+             d="m -11.96875,4.90625 c -0.568148,0 -1.0625,0.4999119 -1.0625,1.15625 l 0.125,3.9375 c 0,0.583452 0.43248,1.03125 0.9375,1.03125 0.50502,0 0.90625,-0.447798 0.90625,-1.03125 l 0.09375,-3.9375 c 0,-0.6563381 -0.431856,-1.15625 -1,-1.15625 z m -0.03125,7 c -0.583421,0 -1.0625,0.479079 -1.0625,1.0625 0,0.583421 0.479079,1.0625 1.0625,1.0625 0.583421,0 1.0625,-0.479079 1.0625,-1.0625 0,-0.583421 -0.479079,-1.0625 -1.0625,-1.0625 z"
+             transform="matrix(0.54880252,0,0,0.54880252,14.955904,1043.149)"
+             id="path4253"
+             inkscape:connector-curvature="0" />
+        </g>
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4292-34"
+           d="m 7.7042244,1044.9418 -2.1665688,3.8974 c -0.5769589,0.976 -0.1835666,2.4677 0.8925293,2.4852 l 1.4525456,0 0.9520312,0 1.4525473,0 c 1.076097,-0.017 1.469488,-1.5093 0.892529,-2.4852 l -2.1665702,-3.8974 c -0.2801751,-0.5299 -1.0651401,-0.4448 -1.3090434,0 z"
+           style="fill:none;stroke:url(#linearGradient3897);stroke-width:0.48834795;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4292-3"
+           d="m 7.6231985,1044.4966 -2.434777,4.3798 c -0.648383,1.0968 -0.206291,2.7732 1.003019,2.7928 l 1.632362,0 1.069887,0 1.6323635,0 c 1.209311,-0.019 1.651402,-1.6961 1.003019,-2.7928 l -2.4347785,-4.3798 c -0.314859,-0.5957 -1.196998,-0.4999 -1.471095,0 z"
+           style="fill:none;stroke:url(#linearGradient3831);stroke-width:0.5488025;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/icons/wizban/banner-discovery.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/icons/wizban/banner-discovery.svg
@@ -1,0 +1,1026 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="banner-discovery.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4432">
+      <stop
+         style="stop-color:#ced8e7;stop-opacity:1;"
+         offset="0"
+         id="stop4434" />
+      <stop
+         style="stop-color:#b7c5e0;stop-opacity:1"
+         offset="1"
+         id="stop4436" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4456"
+       id="linearGradient4462"
+       x1="63.734764"
+       y1="1039.3618"
+       x2="61.727211"
+       y2="1006.3618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,-0.72750163,1,733.40264,2.0004)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4456">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.659"
+         offset="0"
+         id="stop4458" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.369"
+         offset="1"
+         id="stop4460" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4606"
+       x="-0.062976152"
+       width="1.1259522"
+       y="-0.10879012"
+       height="1.2175802">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5412116"
+         id="feGaussianBlur4608" />
+    </filter>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2-8">
+      <stop
+         id="stop11150-4-72-3-9-7-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#ad6e48;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4368">
+      <stop
+         id="stop4370"
+         offset="0"
+         style="stop-color:#9c7561;stop-opacity:1" />
+      <stop
+         style="stop-color:#966d59;stop-opacity:1"
+         offset="0.18181793"
+         id="stop4372" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.36363617"
+         id="stop4374" />
+      <stop
+         style="stop-color:#794f40;stop-opacity:1"
+         offset="0.49999985"
+         id="stop4376" />
+      <stop
+         style="stop-color:#8c6250;stop-opacity:1"
+         offset="0.63636351"
+         id="stop4378" />
+      <stop
+         id="stop4380"
+         offset="0.81818175"
+         style="stop-color:#966d59;stop-opacity:1" />
+      <stop
+         id="stop4382"
+         offset="1"
+         style="stop-color:#99705c;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4432"
+       id="linearGradient4438"
+       x1="8"
+       y1="1019.3622"
+       x2="52"
+       y2="1039.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.84042551,0,0,0.80432696,11.287235,201.41841)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4506"
+       x="-0.092571429"
+       width="1.1851429"
+       y="-0.0324"
+       height="1.0648">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.27"
+         id="feGaussianBlur4508" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4524"
+       x="-0.029837838"
+       width="1.0596757"
+       y="-0.12266667"
+       height="1.2453333">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.46"
+         id="feGaussianBlur4526" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4566"
+       x="-0.08775"
+       width="1.1755"
+       y="-0.1404"
+       height="1.2808">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.2925"
+         id="feGaussianBlur4568" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4588"
+       x="-0.042439024"
+       width="1.084878"
+       y="-0.10235294"
+       height="1.2047059">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.725"
+         id="feGaussianBlur4590" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4661"
+       x="-0.14766911"
+       width="1.2953382"
+       y="-0.11646623"
+       height="1.2329325">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.36234727"
+         id="feGaussianBlur4663" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4527"
+       id="linearGradient4533"
+       x1="29.521629"
+       y1="29.827848"
+       x2="31.546745"
+       y2="39.175972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-0.41994314,1068.4388)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4527">
+      <stop
+         style="stop-color:#68b367;stop-opacity:1"
+         offset="0"
+         id="stop4529" />
+      <stop
+         style="stop-color:#5eaa6e;stop-opacity:1"
+         offset="1"
+         id="stop4531" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4578"
+       id="linearGradient4584"
+       x1="42.780308"
+       y1="1025.5621"
+       x2="40.143147"
+       y2="1039.7532"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-8.6400594,2067.7057)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4578">
+      <stop
+         style="stop-color:#c5f0b4;stop-opacity:1"
+         offset="0"
+         id="stop4580" />
+      <stop
+         style="stop-color:#80c171;stop-opacity:1"
+         offset="1"
+         id="stop4582" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#a5a5a5"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.426667"
+     inkscape:cx="75.000001"
+     inkscape:cy="33"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       y="0"
+       x="75"
+       id="image4388"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJ
+bWFnZVJlYWR5ccllPAAAEGVJREFUeNrsm3mQHFd9x3+vz7l2rl1pV7sraWUZ0GGwZR1olaoEuwow
+RwE2BpEKpOQ/lFT8F6JcQJJKGSdFSMp2JBJSgbKNbRmDZSNLdsoBBIWpwiCTEB9R2dIq2ljWtdfs
+7szO2dPdr/P7ve6e6RntodXuSuuVW37uObp73vu87+/3fr/33jLHceDd4+Lj/gMXZEQTQj4JPLfg
+R2H2LqwGQCpBQSRx5BLFczj4/TUPa9/BAVJQlKOKOHfCDnfotTbZtdcsrO8cHgxzDhFsv4ZwZATV
+gkUnHHwKJNcUrO/9+5CEIBCI0+IQIALDnQiWGL5meIZ3YeHx0AvDLdxxUEkgeVBITeibQKP3tgvu
+2ob1/Z8Mh7HxQknUVgKBfsn9jDvMU9e1DevxIyOaN6qp6JtcSI6AgeDI9Fw41zSsJ3+RQV8kzCvk
+A/JgMXyX9M3uisJijF3Sdb33rr4JT8mmj7NH73v7tfkHNUKxUQzbJHGnriY8K/h1As1O8eEsClgI
+h8DswvJpLB+a5hFZLL/C8hyCe2wukA68mFE9NWmOE4DgwiJQaccb7RYFLA/SXgKlaSq8d8310NO1
+CtqSbdDR3gYhJSKumyjlYGw8BxeGB+B/TrwBg5kh+vg0lj0I7fBs6/HMrzIURMbEKOd4jfUgOK6i
+EFTdkV91WJ6pvRjSQ8ktN2yC61b3QNUyoVI1IJvP1a5LxhKgayEE2AqtybQrr4kc/OzXP4e+/ztJ
+bwnWXQgtO9PvP/vrUQwBIIXN0xzPgQdh4UnBGqZ5s6KuJiwE9Rk8HYpFY3DD+g2AwMCyLTAtC2FV
+xDUhBMSYDJqqUyOwQgyh6dDd3gkrsdDR/3Y/HPrZIagYFfJlt0wH7PBLo+S8EzU1NcESimKoKI6g
+hINfBLAQVA++fLUt3Zq8Yf1GyJcKMDaRFbBshGVZNkSiUQRnA1FikgzRcAvEUWGyrIrPYpEofOD6
+dQhZhyE0yScP7RfAENamyX73ud+MxfG2qFPzS42wwAclFOV+tlhgPaooyq7tm7fBWD4Lg8NDkJ/I
+g1mtNlyrqhqEIhGIICQkJj5LtKRFoV9XZAW2rNsIUQRHwH50+DEwjMo+BLbHf8YLL4/RCJcSQ78b
+WF4Ei5y5xBianu+j5heWNMfRugdVBUOjw9DX1wdjmdEsgtpHZoRlDZYUvTbN6n35XPb00Pm3oZSf
+EJ0/msvCAIIh0RkWh98dPw4Fw4R0axf0br2Vnv1lT7nwH78bRxmyZWj42tSdh2KVWRpVxWCBjrkq
+65CmaZ+x0OQ45zM6Z7z+y3i6V1b1ZEu6Cx8ig66HoaOtSyiMTHIrDhDoauCxH9wP+fz4Y/d+4rW7
+8bskKcFPVy5SFpqc5Jqe0qigxaWs+6rV6mEERcP+7TONYvi9UJ1tGtn86HlUlQOlsiFUxh0JcsUy
+nBvJgIWvb9p0C4nkduyT5EyVUFBR2HnKQmcHCx7BTxPVvxqKtoIUXi4+61qxGhRFFX7r5vffDAUc
+LH64/29hZerGO+/a8fhvp1IWKipOs5sXKWcRKuuyDi/V2VcpjmLNTKwcQzglrDCDiWIJChUTtFAC
+4sl2GCud7Z3qObLEIpLUOPW7kMdVgeUd36b/VQrDYHMJ8miCdKaSQ2A2Vi0aS2Nv2/FJKy6BJkti
+IWGBLQ9Umm6mScIFt3MKWpe1dPzRrRs/fueBl7//yEX5oV1OkrLcIglHP1EoQTKJMVmsDYbO9932
+4M9vnfBvoO8lJkm6EiNFsYiWuvDHmx95fs4VpbjMBaMQIC9VYlfMZyEoSqgfnfHC+I0QCoWhfXmX
+qN6q7h64buUaeOU/n4djrx2Z8fb2lnUPfGnbD5+cjc+ycci1bUfFQYYAqfheCWQAkw8kCywsMZJt
+3nYbXN+zFtpbl2EH6lDhClQdGUc9GWQMH85ceAt+/19HhV1RmKSjjYWw/GHvHXBr72fxGlITfeO2
+QgDAf5lcBn586AGweOWSzJFmSxGKipA023bntaaDczXmsx6VZHWXnnwvqHoUR70V0NnZg0pKQVTR
+ICzLAkLf2X6Mq/JC9+1tHdC5vAPoG4IkefZAqmhPpnAgcGAkNwIHnvsnMEqlvjtu3Lt7ZWpbfjJl
+2WjfqB7dpoIKmmo0bMotr17o4ANTE+swWpcFgDAm3CtXdIMqk7oISuMz3YTbEQ2gYd3C1u143/uh
+B011IDsCTxy6H4xyse+zm/buXpVEUE1mZqJyXEBc96eVpwsdFg2sIDAtsQEbrwAmcRAJhWBVhwtM
+8oAFYXEvrkJFwPb33ADXt3fDBQT13YPfQkUV+z63ad/uVemteR8Gqci0nLDFnRB+JrmxGYd3HCwf
+mEzAYmvQJJN1YO0+MKgNQL6qJEyyN123EVa3tmOkPwrffuabUC4V+j6/ed/u1WR6jnDWctVyIqSk
+ZjOcT1hXNM761y++8WeqpB8o504CN0YREIYKtgWZsUExU6dJmCviZ1TI2Uc0Hf5g/WboSi9HH5WB
+f/nx30MFQX1hy77da1qF6amopAQWmo3Ql0y68+qpgoq2RTOX0j1Pf3BvxSzsTLe+BxLxDldh5MOW
+dWFU7vYfzX1tuO4DEI+0QGZ8EB45/CAUi/m+L2xF00ttq5ikJBzZeH31ZtJ05x1nhq/3FynISwdX
+Xb76jAusY/n7oDW5gpJhVFIIulo7MUfUYG3PRoiGYjCYOQMPHfwHsC2n70+2fefuzvjNaG0ieKw1
+8B0B6yv7Xkzi+SZ6ho2Bi4XFxu52X+PZrS3rbk+xz3906/HmRPhrB7cLYKs710N7GiHhM0Noets3
+3yZADWTOwsMIittw8k8/+NBXOlo2GP79J/rPtA9mxjtoKPAb6I6g3mKq9zqdTAyu6uwemg9Ycw1K
+b4qFJ17kTho0RYeqaUE4dAreOre8dgFV5Ozg2G/x5Z3NN3/rjpf3/OWz2+HtC8d3kp/qauuGSDiM
+oKIwMHIGHn72H9Gnsf/d1fvw1wQoaqF3vHb81EeHMmNfmqmCranUEwhr/3z4rDnBosrHIgA7PxyH
+RGwdmtIwGOYm/FylmUsB76mfHoNXTgxM+Yxv3n50z18f6oWTZ9/YqSsIrGMrjJCiEBRwqf+uHQ99
+tSO+oRDgVDs2ru2Ab/zFR6DuEerhx0TegHv/7QgUjPlbcZ8TLDKzitGKJrcCwpqJoNJgVLlYAqM6
+950ehrJhzphP/N2nj+75m+d64dhbx3ZGYwk4+MunQGOx33xxxz8/0BFfX+DT3E6/UyiZouMYcyN+
+EyPS02dyMN9bE+YUOpBvMqo0pWwhKA6WVUJ4E1AoVrABBr62RGMupcr3feroPYlwx/6Xj70EEbXt
+yNdv+8U3OpMbCjM7T4BSuQoThSoUqBSrkMezaXGY720cc1IWOfFCOYc9egYmihux0tiz0hC+p3WD
+sOhlP22ZPsEVu1pif/WxI99DdTzhj3CXPNiAlz+KZNv9R6p3f5ctEjNEZeWLDIbHV8LylAWliolm
+twwujOQwXirRTKbQFZ8aVm1DmVidkViYz1INI2MleLN/RAS469YuwxCD0/goOpIvJmVRmOBNfdRM
+gnkJ8ekLWShWqhgnFUSYcNHg4KnJ73qMs6Li9SwaOJiZgMef/2/hr+7e2UuTglCyTaBAzDXDxaSs
+mq04NXPwnWz/+XEYGi2cRXGdVWT5jUCGLNQEgR3BksRUvEfjs3AykbA+OFgovv7KiXOxqmmu/Xrs
+Q1BERy9iPu7BAmfxKUvMydZU5SqLKh3W1afv2fWRB+vRtLs9sbm7UVUts3XGn7xlxxF81pGXfv/6
+ja8fP/WAPzISKDJB2jKwqBx8LUh0XFUBc5eDyVWJpSrf/MT8tvhLBX2SNb+I8M9zbBjz3IEtpowR
+ls0XV+gQxdzEV5dQlD8iMX97ohi+aW67FSYBRU4dTXCelrKYmyfajli8taz5d/CXDevciKHGY3rE
+VxeDJjMk5yRLmEAjKBz1JpU1qoo1mKRD9itRYQ6XmWMrVCTwC28oMtiaItVXooUJNikL83NZk2yd
+ii43lpDM9ZBSL2Gv6DJXFcmR58UMB0arBDlF6wguLM9n+Q5ecs2wVDF27N1/RK8lt14hBTAmSZoq
+h/zkGinR/hqFNnJ50+7CvJ3GeCy4+CCOUqW6zL3UT4q5qyzb9VlhTY4lNKPdT5ADu5YDxVuJpmdw
+htEHsyqWVClU5aKJr+fqsxJkQo4T8EtNylrdmcS8UduCl2xxwKlX0CPgzwwEvXDzQO/A9OE//VY8
+pkJHW7Q2a+D6rHroENZYPKqYK8XPBGcmvN/2tlMKVsJ6bVYpW1KeYNkOs+ekrKFxswVrGQJPIZw2
+Rzl1X0WNbUvG4M/v3O76rqAiApX0s18/CXYHCM8vsMZeD97C/KsD9xF2m/vrgY4YpWlEpDtDqhRH
+E+xu/P16H4jtXYItKwFnharDCtmKMpqvKkWnKfaYFazhrEmxUazW87URr26GuqZAXFUgmy8FNnA4
+gU2xbjeiYxf3iPVAyVvyYqwWdtjes6nhdPbjNylwreQRIzBVVFIZc1Hfb/k+S1NZXGW82/OIQTPm
+7qIRKzsOy6GKSgjpzFBRGzCsuuldFqxMzqKIIOU0ROEcgg6e/iej57G8Bto+pCAwv+FSoOGBM3h5
+HUXh/pkaTdG5HADlvpbEcw3TFrCqeBb3kN/yEmldkuKy5HQFlEUVxm8x2HfYOPokUtGpwaL2Vs6Q
+i5xPbfizUVaqefTE0U74LYJEFaYZCGqID8b3H9wboXx1ERS5BsyD4BV6nJhl9YZ/UharAXKvde+V
+8DMufFPFtNzfF3WgfLXqmiFtWlBYCw6rqsfKwlJASMMWlwZKpnwyU9b6RkrqSNVm9kxx2SXBGpuw
+WrB+WvBZFD/FoyH6Sys0uQoUy4bY20niEI7Wj3e8Xha9bbu9LRotS+Ks0FlmtffCOWOjTdONwgUs
+/EfXKZIs5urds9tvZcOGkmGKJL6EZkjzZ1R8WJScYxeE8WcN1PR5k0unKpZ8ImuoJ4aL+pmSJRn8
+EgOyGWGN5y0V6xprGsPDSCaBMQ7FUfDkC6+Arsr1Nb/avHjw7NRGoXqYUV/4YF70L+7l/ny4Uxsh
+a9MvLHht3alzYX6NJl82qt7wwrLowE8atvxm3lTfHCnrp/KGUrT57EL8aWHlijapP9WkqBhtrea2
+La/tTGXPDaV+pIhEGDtcAg1vwICRETnZGyDFlgX8HP9jcnOcBM2hQlO44DS+gemiicmemYq3FIqW
+0l+y1FOoptPZqjZ2uWnjtKs7CCvpJb9u3mU7cXwd9ntdbLxw6lsLayMeh+bRj2mqJP4sxPa3AjVt
+UXR4cFlrsuUtN+DkTb91JZfCpkx3Jkp2CFURDvSa2Lt5OREs5g5hBmzBtlxfqWNSMyyUbfLTCaem
+PkhfbrRPLka5jBnQxXhIU6QRCfrOmSMoX1ULuZH/qsIqGTyKjELeFO+cQJGqMCwIwxI5GmBVqlx2
+0xlnzoqq+aoloqrJlEV7QOX5AEWQlCWkqgZYhsmpYbprenP/046lpqoaLNNyaA4gOR+KWqqqqiuL
+idmEVkrB5iUekZnOYGmpSsDC/IhGvhXzBUqYIK3YLMGDlLWGzeMfD2CSqGEOKC1FWP8vwABtfSgS
+5v/0BQAAAABJRU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:url(#linearGradient4462);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4606)"
+       d="m 47.000294,1007.3622 -12.319149,16.9335 -12.416197,17.0669 16.933329,0 17.066666,0 12.416197,-17.0669 0.09676,-0.133 12.2221,-16.8001 -17.066666,0 -16.933329,0 z"
+       id="rect10961-8-3-6-1"
+       inkscape:connector-curvature="0"
+       transform="matrix(1.2008267,0,0.09173299,0.36603268,-107.57532,658.98864)"
+       inkscape:transform-center-x="4.4580006"
+       inkscape:transform-center-y="0.53407962" />
+    <path
+       style="fill:url(#linearGradient4438);fill-opacity:1;fill-rule:evenodd;stroke:#3d5b8a;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 16.75,1020.1127 0,18.4995 39.5,0 0,-18.4995 -9.344086,-3e-4 0,6.5775 2.620682,4e-4 -2.72e-4,5.7552 -26.830222,2e-4 2.71e-4,-5.7553 2.548251,-8e-4 0,-6.5774 z"
+       id="path4430"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#edf2f8;stroke-width:1.09422028px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4506)"
+       d="m 24.648,1021.0102 -7,0 0,20"
+       id="path4480"
+       inkscape:connector-curvature="0"
+       transform="matrix(1,0,0,0.83519998,0,168.2625)" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4524)"
+       d="m 18.074162,1037.2582 36,0 0,-9"
+       id="path4510"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="opacity:0.98000004;fill:none;fill-rule:evenodd;stroke:#eef1f8;stroke-width:1.05717111px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4566)"
+       d="m 47.702,1026.0642 0,-5 8,0"
+       id="path4528"
+       inkscape:connector-curvature="0"
+       transform="matrix(0.94986293,0,0,0.94199461,2.3901865,59.170241)" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#5d7aad;stroke-width:1.09975278px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4588)"
+       d="m 13.260003,1037.1022 41,0 0,-17"
+       id="path4570"
+       inkscape:connector-curvature="0"
+       transform="matrix(0.87772752,0,0,0.94199841,7.8472592,61.066627)" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;opacity:0.9;fill:#ffffff;fill-opacity:0.81584156;stroke:none;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter4661)"
+       id="path4252-6-0-1"
+       sodipodi:sides="4"
+       sodipodi:cx="4.7729707"
+       sodipodi:cy="1041.2474"
+       sodipodi:r1="3.3255017"
+       sodipodi:r2="1.0287941"
+       sodipodi:arg1="2.432965"
+       sodipodi:arg2="3.1299058"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="-0.017554997"
+       d="m 2.2999628,1043.3702 1.5012045,-2.162 -1.1922203,-2.4846 2.095707,1.5226 2.5543357,-1.1444 -1.4929874,2.1437 1.1965937,2.5068 -2.164271,-1.4559 z"
+       transform="matrix(-0.3564605,0.66452158,-0.554066,-0.47418772,596.48075,1512.3241)"
+       inkscape:transform-center-x="0.084658908"
+       inkscape:transform-center-y="0.18052959" />
+    <g
+       style="display:inline"
+       id="g8662"
+       transform="matrix(0.96914262,0.93367652,0.97038433,-0.9348728,-1001.1352,1947.0731)">
+      <path
+         style="fill:url(#linearGradient4533);fill-opacity:1;fill-rule:evenodd;stroke:#398a43;stroke-width:0.74287361px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 40.244943,1041.4693 c -0.24182,0.7378 -4.276215,-4.6418 -4.276215,-4.6418 -11.44876,7.9356 -17.573348,-1.4122 -16.632852,-8.3285 0.287455,-2.114 2.873263,9.5491 13.24418,4.9398 0,0 -6.161054,-4.0913 -5.456972,-5.1523 0.390532,-0.5886 13.008987,-0.7195 13.731155,0.03 0.722169,0.75 -0.343071,12.3401 -0.609296,13.1524 z"
+         id="path4522"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scscszs" />
+      <path
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4584);stroke-width:0.74287361px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 40.029866,1028.5266 c 0.335464,3.4409 -0.540551,10.8513 -0.558812,11.097 -0.130143,-0.1351 -3.305251,-4.1177 -3.305251,-4.1177 -13.489832,9.4517 -15.979945,-3.8837 -15.944315,-4.5632 0,0 4.159907,8.1407 14.425918,2.5964 -3.722931,-2.2 -6.36447,-4.7334 -6.416153,-4.8694"
+         id="path4522-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccscc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/DiscoveryImages.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/DiscoveryImages.java
@@ -33,28 +33,22 @@ public class DiscoveryImages {
 
 	private static final String T_WIZBAN = "wizban"; //$NON-NLS-1$
 
-	private static final String T_TOOL = "etool16"; //$NON-NLS-1$
-
 	private static final URL baseURL = Platform.getBundle(DiscoveryUi.ID_PLUGIN).getEntry("/icons/"); //$NON-NLS-1$
 
 	/**
 	 * image descriptor for a warning overlay suitable for use with 32x32 images.
 	 */
-	public static final ImageDescriptor OVERLAY_WARNING_32 = create(T_OVR_32, "message_warning.png"); //$NON-NLS-1$
+	public static final ImageDescriptor OVERLAY_WARNING_32 = create(T_OVR_32, "message_warning.svg"); //$NON-NLS-1$
 
-	public static final ImageDescriptor BANNER_DISOVERY = create(T_WIZBAN, "banner-discovery.png"); //$NON-NLS-1$
+	public static final ImageDescriptor BANNER_DISOVERY = create(T_WIZBAN, "banner-discovery.svg"); //$NON-NLS-1$
 
-	public static final ImageDescriptor IU_AVAILABLE = create(T_OBJ_16, "iu_disabled_obj.png"); //$NON-NLS-1$
+	public static final ImageDescriptor IU_AVAILABLE = create(T_OBJ_16, "iu_disabled_obj.svg"); //$NON-NLS-1$
 
-	public static final ImageDescriptor IU_INSTALLED = create(T_OBJ_16, "iu_obj.png"); //$NON-NLS-1$
+	public static final ImageDescriptor IU_INSTALLED = create(T_OBJ_16, "iu_obj.svg"); //$NON-NLS-1$
 
-	public static final ImageDescriptor IU_UPDATABLE = create(T_OBJ_16, "iu_update_obj.png"); //$NON-NLS-1$
+	public static final ImageDescriptor IU_UPDATABLE = create(T_OBJ_16, "iu_update_obj.svg"); //$NON-NLS-1$
 
-	public static final ImageDescriptor MESSAGE_INFO = create(T_OBJ_16, "message_info.png"); //$NON-NLS-1$
-
-	public static final ImageDescriptor FIND_CLEAR = create(T_TOOL, "find-clear.gif"); //$NON-NLS-1$
-
-	public static final ImageDescriptor FIND_CLEAR_DISABLED = create(T_TOOL, "find-clear-disabled.gif"); //$NON-NLS-1$
+	public static final ImageDescriptor MESSAGE_INFO = create(T_OBJ_16, "message_info.svg"); //$NON-NLS-1$
 
 	private static ImageRegistry imageRegistry;
 

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/TextSearchControl.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/TextSearchControl.java
@@ -66,12 +66,12 @@ public class TextSearchControl extends Composite {
 	 */
 	static {
 		ImageDescriptor descriptor = AbstractUIPlugin.imageDescriptorFromPlugin(PlatformUI.PLUGIN_ID,
-				"$nl$/icons/full/etool16/clear_co.png"); //$NON-NLS-1$
+				"$nl$/icons/full/etool16/clear_co.svg"); //$NON-NLS-1$
 		if (descriptor != null) {
 			JFaceResources.getImageRegistry().put(CLEAR_ICON, descriptor);
 		}
 
-		descriptor = AbstractUIPlugin.imageDescriptorFromPlugin(DiscoveryUi.ID_PLUGIN, "$nl$/icons/etool16/find.png"); //$NON-NLS-1$
+		descriptor = AbstractUIPlugin.imageDescriptorFromPlugin(DiscoveryUi.ID_PLUGIN, "$nl$/icons/etool16/find.svg"); //$NON-NLS-1$
 		if (descriptor != null) {
 			JFaceResources.getImageRegistry().put(FIND_ICON, descriptor);
 		}

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/icons/wizban/install_wiz.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/icons/wizban/install_wiz.svg
@@ -1,0 +1,1325 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="install_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5134"
+       inkscape:collect="always">
+      <stop
+         id="stop5136"
+         offset="0"
+         style="stop-color:#446190;stop-opacity:1;" />
+      <stop
+         id="stop5138"
+         offset="1"
+         style="stop-color:#a4b4c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5034">
+      <stop
+         style="stop-color:#e2cefd;stop-opacity:1"
+         offset="0"
+         id="stop5036" />
+      <stop
+         id="stop5044"
+         offset="0.50000155"
+         style="stop-color:#d5b9fe;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2cefd;stop-opacity:1"
+         offset="1"
+         id="stop5038" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5024">
+      <stop
+         style="stop-color:#c9c7ff;stop-opacity:1"
+         offset="0"
+         id="stop5026" />
+      <stop
+         id="stop5032"
+         offset="0.41626066"
+         style="stop-color:#aca8fd;stop-opacity:1" />
+      <stop
+         style="stop-color:#bcb9fa;stop-opacity:1"
+         offset="1"
+         id="stop5028" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5016">
+      <stop
+         style="stop-color:#dee6ee;stop-opacity:1"
+         offset="0"
+         id="stop5018" />
+      <stop
+         style="stop-color:#c7d2e0;stop-opacity:1"
+         offset="1"
+         id="stop5020" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4928">
+      <stop
+         style="stop-color:#f1f2ec;stop-opacity:1"
+         offset="0"
+         id="stop4930" />
+      <stop
+         style="stop-color:#d2d5c4;stop-opacity:1"
+         offset="1"
+         id="stop4932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4536">
+      <stop
+         style="stop-color:#446190;stop-opacity:1;"
+         offset="0"
+         id="stop4538" />
+      <stop
+         style="stop-color:#b8c4d4;stop-opacity:1"
+         offset="1"
+         id="stop4540" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4524">
+      <stop
+         style="stop-color:#828da3;stop-opacity:1"
+         offset="0"
+         id="stop4526" />
+      <stop
+         style="stop-color:#8897ab;stop-opacity:1"
+         offset="1"
+         id="stop4528" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4514">
+      <stop
+         style="stop-color:#4b5875;stop-opacity:1"
+         offset="0"
+         id="stop4516" />
+      <stop
+         id="stop4522"
+         offset="0.3333365"
+         style="stop-color:#828da3;stop-opacity:1" />
+      <stop
+         style="stop-color:#49607e;stop-opacity:1"
+         offset="1"
+         id="stop4518" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4470">
+      <stop
+         style="stop-color:#f8f9fb;stop-opacity:1"
+         offset="0"
+         id="stop4472" />
+      <stop
+         style="stop-color:#9eb8d8;stop-opacity:1"
+         offset="1"
+         id="stop4474" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4462">
+      <stop
+         style="stop-color:#a0adc0;stop-opacity:1"
+         offset="0"
+         id="stop4464" />
+      <stop
+         style="stop-color:#a3afc2;stop-opacity:1"
+         offset="1"
+         id="stop4466" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient6406"
+       gradientUnits="userSpaceOnUse"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908" />
+    <linearGradient
+       id="linearGradient5517"
+       inkscape:collect="always">
+      <stop
+         id="stop5519"
+         offset="0"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+      <stop
+         id="stop5521"
+         offset="1"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5031"
+       x="-0.11202575"
+       width="1.2240515"
+       y="-1.0690457"
+       height="3.1380913">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.4343883"
+         id="feGaussianBlur5033" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient5041"
+       x1="98.407524"
+       y1="1065.2891"
+       x2="136.02242"
+       y2="1065.2891"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,-95.625351,-19.272328)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4462"
+       id="linearGradient4468"
+       x1="48"
+       y1="994.36218"
+       x2="88"
+       y2="1028.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-28.014084,-0.01639)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4470"
+       id="linearGradient4476"
+       x1="51"
+       y1="995.36218"
+       x2="84"
+       y2="1026.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-28.014084,-0.01639)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4514"
+       id="linearGradient4520"
+       x1="36"
+       y1="1037.3622"
+       x2="36"
+       y2="1029.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.1249998,0,-128.67002)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4524"
+       id="linearGradient4530"
+       x1="49"
+       y1="1039.3622"
+       x2="46"
+       y2="1034.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5134"
+       id="linearGradient4542"
+       x1="27"
+       y1="1042.3622"
+       x2="7"
+       y2="1020.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515675,8.628538e-5)" />
+    <linearGradient
+       gradientTransform="matrix(0.14667021,0,0,0.14667136,17.184701,879.66442)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4536"
+       id="linearGradient4542-7"
+       x1="27"
+       y1="1042.3622"
+       x2="7"
+       y2="1020.3622"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4792"
+       x="-0.16768435"
+       width="1.3353687"
+       y="-0.17985532"
+       height="1.3597106">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4794" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-4"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-0" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-0"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-5" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-5"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-9" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-49"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-01" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4928"
+       id="linearGradient4934"
+       x1="-11.097116"
+       y1="988.03119"
+       x2="1.5470241"
+       y2="994.73035"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4984"
+       x="-0.084"
+       width="1.168"
+       y="-0.084"
+       height="1.168">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.98"
+         id="feGaussianBlur4986" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5012"
+       x="-0.048"
+       width="1.096"
+       y="-0.048"
+       height="1.096">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.24000032"
+         id="feGaussianBlur5014" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5016"
+       id="linearGradient5022"
+       x1="-5.7292957"
+       y1="996.90344"
+       x2="4.3120389"
+       y2="1000.6044"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5024"
+       id="linearGradient5030"
+       x1="9.1587505"
+       y1="1035.391"
+       x2="12.099871"
+       y2="1039.3212"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515674,9.266038e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5034"
+       id="linearGradient5042"
+       x1="21.856897"
+       y1="1019.8043"
+       x2="27.984741"
+       y2="1023.2879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515674,9.266038e-5)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5062"
+       x="-0.050661981"
+       width="1.101324"
+       y="-0.14436312"
+       height="1.2887262">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.1205165"
+         id="feGaussianBlur5064" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5282"
+       x="-0.27631978"
+       width="1.5526396"
+       y="-0.34539973"
+       height="1.6907995">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.3026648"
+         id="feGaussianBlur5284" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#e7e7e7"
+     borderopacity="1"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.195458"
+     inkscape:cx="64.394526"
+     inkscape:cy="32.083835"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       transform="translate(0,-986.3622)"
+       y="986.36218"
+       x="76"
+       id="image4438"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAABHNCSVQICAgIfAhkiAAAEJhJREFU
+eJztnFuMXEdagL86dS7dPd09PTP2OPZknInjJHbsOE4cx0kEK0RYaQnkBQkQWhArIRBo30BCQivx
+tuIZXtA+EQmkSIs2CwmIRYCUBEKUy8Zhgh3Hji+JbzMTTzy37j63quLhnNPdp28z9vQkiPBL9kyf
+rlOn6qv//+uvv+qMMMYY/l96xBiIlSGMNUFoiJTB/qob9b9JtIZYKfwwARWpvB597WEZA1GsUNoQ
+xYIw1ijdv+zXFpZShlgpYi0ACEKIB1FK5WsFyxjQ2hDGCm0EIFAKgkizFcc9ElhLt5ZYWlodRVU7
+LtLx2D87A0AQGpTe+vw2Ms366bkbd1ReCIElEhOQ0rqje1VqLgaDMXAnE/pkrcrMvhnCeLjJ9ZMv
+3QwHQZKW2NL9SpvWfUpphADNnQG7G1CwA7Cu31jg1VdeH3W125Lnv/Us++dmt13PyGGdPXOJP/6j
+3+axRw8hhMay5NDyWiuMsVDaoA3oVEOUNmiVOGKlNbFOnLPWBoMhTmMgpQzKGIyGWOuWiUbK4IeK
+i58u8txjk1z4dGnbfdsxM/RciWe7iE2syxgHbTRZ/Ke1aU3hSiWglTbEOg8xUqYFMIo12hhEDLZl
+EUQxAAV3+EDdqewYLMsSjBUdOl1R98SjtUohWeiUVqwMjhQoA1om4KQUSNWeubS2kJYBNDHJAywh
+kEIQk/k03ROBb7tPI62tQ2QKSaSqlTh26PbjsuuzEGCJ4c2yuiqxdqwXXc/diUqVTjpsiWSWEl22
+mPV1M3/WDSVfx5e//t8RWNKi5auEEIhUU5LfRUvLcg3pVrEBYrUqbjddsLV7tytfigIboxHCakHr
+ln6meLeyiQVvS74kawdL3GUgeIfR/U7Kjkbw2oBFNuULkli7V4ZNWptlArrF9CkuGE0IsWMOPpMs
+XOhcjvRbmmjV+f3gurOgtS+VHZYvRcc7gRmTRepJnDX0viEZgSTFkta7hQRL94x8NzJSM+xuUCcM
+TRIqbAZoKzIM4k7KjvisZL2X+KLOma4TVD8/pXSSctF9TCxbO/Z/XmKeqsN+u6N3IYab9yBROll3
+GnbQwWuj0UokGjUghtJ9iGWgOrVHDZgBBmVaVJ9JIYnFhtAyEGuD1u1B64Y7YjPMf1baIC3RF0pn
+mZ5rgzTI9GY2t2OSsUrrVKY1KQ3TvpHACpph7rPSJjFB+sPolqyB3eY3KGzQ2qB0+zvd0cNYbz5L
+hnECqD3xbHoLsJNmqA1qC4FotxZ1a4pKsw39mHeb6lajiUFmvZmMFFY2QpnPuJM2ZR0fFoSqNPnX
+775N27al/ZvhsmOaFSuNvYUwTisLTZy71jnyrRyW6bzWBmowAzXFD7cfpnTKNmG1G1n0HAAKpQJa
+2GkHtmIXuqezbUD5NHOnZFnSVktM21/1S/qN4kTHHcLKnqiB/Kjtmy7QDGPum9nNRKWATMOFLLYy
+Jq9lQujctU5Ayc88JN31M2lNMtV3SnfYEN3h2nKYbBFWpiUK6Jz5fAC8sYDauEMNhwP315iZiilK
+n8AIwEvSxz2+JYl7BsGBXkCZ+bU3L9LWmV7N6zbBURwW2gIsRRuSnz44JIwaLC77BIHhyvUmABPV
+kH1TDgcPTKB0A6k9lDIElgBswljkfA/0dnIQIMibXnZdG0O2+d4vGAUwjMZ3DYGVaVMT8FuALlxp
+cvbCOje/SDRsV3mD2FQAePODdYJA8fqH53hkbpKnn6hSKZWR2qORPs6PIOoOvbOoPV0cdwOCPMTM
+/DLw2TYY9PdXo5IBsAwQ0damFc5caDJ/vokwEfv2aJ54OGJiPAQEjuOAnMaypllajrl4/hbvXbrE
+f5z+lGMHS/zScw9QsqdoAI6yiOgNLIHWdle3dnXDUcq0wxRtthSIjkL6wGqDMmaNMGrw2rsBjY0G
++/c47Ju2seU64JL3X4nUvDEO7x/n0NRBzty8yXsff8Sf/eBDvvPCQe6dnQSvitLQDEVubaf7+KpB
+kDQmp03Jd+2tr8xfhfGOhw6aDNT6RoO35gMAHry/hGP7RArsAYnHWLtov13lg7W97D+yj7evnuEv
+XnqXb79whMcOQ+SUCGI3uSduH/LI+p6LqbKdZ9OO0LshQa/5jRoU9MBSZD4qjNqgpibSTcu4gGP7
+vbUIB1sWaYSpRtQFYROCjcQHnZo9QqVq8eKP3+L3nId48L5ZQhuiWNJUnR1P70+1B+irQZl0Axp1
+ENotHbAMCazER334SUShWMRzJLECnwYFO4m0m2GJotvIVRSrAlZg0QjIgQLwyoZTuw+xvtbkr16e
+53u/X2Oj0eTGSpHl9YDV9Xxd3RJEgyEEzaDn2ihjq07pgJWZX8jntwV136NaLiQNCiJiVcKnAbS1
+qx6UGfM22jX4Nqaez9N4ZYNbBDFmeOEXjnN+9Rov/+Rj/uDbx5mddgmDCkHY2+GtyqBwoVOuLI7m
+oF0Kq61VQjS4dqNAtWxRcBwiDZ7XB5iU6GiZYGMFYbsIsUF02+CEky2t6gRV8MAtSH7zF3+WP/3L
+H/LclQUK3jgrqxG31wVBEDJs18t2Eh8XBCGel/zebDYpFout680goFz0AKinaaOxoosfxn1qvGtY
+0KlV62HI/qkJlNJYWhPjggcm1IQpsM8XbqDiJUpeHSF3Y6Jlmp9vEKwuMTdzmMpuk4NkF8Gy4aHa
+JE8enePf3lzgV741jmUVAT9dFg3esvrk7AU+OneFw4fmeP3N95ie2sXhQ3Ocnv+Yy1du8uxTx6lN
+lnj73XkATp08BsDb784zN7eHkyef3DasdCzbqrx0q0G1XMCzLBzHwXVsPE9QcBzsdNQuXPyC2xt5
+P6I2XILVRKNubpwFoDouKU1IijXwxgyOpxAy5Ikjs7xz9haeJ3CLUPCipBVaDfw3vW8PpYrk5Vde
+Y25uDxO1Gi+/8hqlSplvfOMEN5cWef+D88zN7eHUyWO8/8H51udRgIKWZrVNcG3dZnqPh+3aWMqg
+pIWwFIHUOEqzuLCItAT1sAzA4uoE674hiG9R1RUO7vMojRvW5HmmJw4iLY1SEYGvUiARjz1YJQxj
+Fm6sYBWnkhZoM9T/SMvi6VNPcerUSSCZMR87cai15nvkkYO58qM46dctdncSf3nV5+CBAq4twU6T
+97bENhq/mdh+pZCs9a4ulwBoNH3A53a0wT3uFGNjNvVolcUbNmPjYwCtk3omzUJM1caYv7DMZHWN
+85dX+eTSAmtBb5DbKRL4zm/8Mvv3Tff9Xuvhe4NqmwnAXJy1vJw0tlLyOhqQdE4Zi6DhU3RtcG3q
+YWI6hw7s5pvPHOHSjWX+5u/f4oOLqzztJI1eYIEZb2/fB1fLBb5YbTBZHaceaVYaTRr+5rNiteCw
+e7KW7L4AmPZwt3P5eShZMNsuN6K0chCEeI6dK5JV7nuKCS/RpkvhbQBOHXsAgAP7ppiolln4fBUo
+tO4WHWewTJ8N1mLRplK0qJWKOHL4mQS5Q/HTViUHK9SaUAlU1L6mFIBAxxAEkpX1pMF22rG35y/y
+zWeO8MHZa9xe26Ba9rDtZDq3bQ9LJOW0UTlwmRSkoexajBfHsJ3hGaM4Gk0IcLeSa93e3QVitc7S
+WkjZdZNFrIIwdSWiXqPRXGb1dkywVgK3wftnrvL+masEUUwQKI7d3w6W3GIBYUmMVi1omSyvNDh1
+ZE+rXG0ywm4M16zYV/zdP/0747XTSFti25Kjhx/i6MP35cpptbUjHBagzNZP2Nh0nZqzpWTl1gbW
++GTrmtpQbMQSkKhwjPW129Q3JNVyBa8SEMQeE5WA6XGL3bVklvQ8i92TUwjs3PEToxV1P2bpiw0m
+a7PYdgHwKbjupo3doNenXf7sGg/O7sXOre7z5j5IHy2rMOCb/pJqliTzM7sn4Mb1W4zL8aSBKaS1
+taSkY09T30g+VMbrzE3D+PgYcWxTr9dbFU/tnsGWyYtEAhuTNllYktNnblBwJVPVEtcW17h9K2Bh
+YWXTxtbjgPFyKXctCCPe+/Acjz98/6b3W9JGSAm2REqBMXd2BiKFlQy9MSUeuHeNV9+4wey+hwBa
+kNbXEke2cluy956HMdY5il77KbbtAQmsfffOUimNAQop09lUJY8yxLzx00scPzRBvV5nYXGdT69f
+4/r1ZP0WRe2shuO0R95JNacbFsDNW19w6J5JpJO/LmQJyzJYlkBIpwXKJhnATSKNQbAAXIRwOXBf
+ldrYOleuXGdycqYFyg8MfiMpXptQjFWmKY87YPuMFycAqIwXKHklpEw0SSm7BUtKhVKSC5cX+OjS
+Et//7gmuLa7RqEf4oUWx4OSgtBpoW1gyea5Wgx386U8XOXpP23U4noOkAVYRIR2k62HbEiEdyPzn
+HUYQKSxBZorGlDhxdJJXX/uQp+wk+OsEVSjFjFXWqFYbeGWbWmUX5VIVKR1W1yW+30AbhUT2BfbD
+f/6Yp4/tQkUNFhbXubnQoLG+0UoCdkICWqBcKUFKYl+xurJBueS18rTSdQjXG9wq2OyqVZG2hXTA
+8UpIt4jw3ESb7AJCiFHEWRaZdh19qMjpsyXmr87z0PSjOVAFT6SdgYKT76Bju2lWInHkWaiglERK
+xd/+ZJ7L15b58z95lkbgcPzgLh7Y0yQIHhzYQGn3n9ls2RtmVCpFHM/BLRWRjtvWJruAJcS2N/A7
+ntjWLqjxq89H/OCli5xfgv3lx1ugxiqruBUfaZu+cZOULkqFaAssDViJf3jjnc/40b+c4/vfPcFE
+bZJSIKm6Aj/YeqC5lXMN0nGxpI3juQjpYFmjO6HQVVOiXQCeM86vPT/Hiz++xpn6W5wonWSskjjh
+gtA4MsISHo6dlBdCYllOArArUH/pH9/hH16/yB/+1mGOHr6fWBVwvBJYCrcMWt15OnhYij2DlJ2J
+H9VZXdH7dx3yuztBtMqLP/qMT66u8/T9j3DgcJWyoxmrRkjpUiqW8NwCtl2g6dcJwjq+n5ji5Wur
+/PWr/82tlQbf+50TPH5shjAcJ9Y2SrfHSQ1Yy0F+ndc6qJz+Z9LCJp3Nu9eE3fV1rw37nc8a5s76
+wMret2kDE6LB6+/c5NXXFgE4cXgvD+93mZmZoeh5LVhx7HNtcYn5j5Z487+u8vGlBX7uyRl+99cf
+pVIutUABPbBkemywE1y3RnSD2+5CeiSwtAZjFMYolIpQagVpNwn8JqfPrfCv//kZVxeSuahaLjA5
+UWGj7nP52i0gyVr8zPFJfv6ZWXZNVvEjgdFFTAhh3PZzInXS0s57Aytdd7bPonbcIyQG2idEvwpY
+xiQvOUZxjB9qAj8kDnzQEa0DIG6M7SVPdhzF+U97NwJm7qnhpu+0xYFFENpEfvJWaZQmAC0pWwGk
+kCVsO0nuZZCyGbAfzKyMsQQWWaBr5SLxnYLVakV2SjeKDVGkUHGMijVBoFBRTMGVRL7EKdgtcLNT
+u3prjKAeJmUSSDEqgiiIciBURAtYMsvpHIxOiQds7GpiLGzSM9GDezkiyZlhdpw5Vio9kqjwQ528
+oxzG2DJAD9kpyfbrjIJIKVScX0/IjrcoLSl7NAj6axGAsByMjlpBKoBB5g5sf3lmmP7Xr3Bv5brn
+WvcLAcOOc3eLNjaWiDEiNasBU/1X7eA7h2lTsUTygOTdwfQaCTzZEfzZxoCdfye6810byJKK7Tog
+sUllzMjjo1GJBaM5b/l1kJF7xf/Lf7vsfwATg3L02Jgm8AAAAABJRU5ErkJggg==
+"
+       style="display:inline;image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5"
+       d="m 46.222683,1020.16 c 8.333975,-0.071 27.129514,0 35.462879,-0.1802 l -17.709438,18.6283 -35.372568,-1.6657 z"
+       style="display:inline;opacity:0.62999998;fill:url(#linearGradient6406);fill-opacity:1;stroke:none;filter:url(#filter5062)"
+       transform="matrix(0.70870669,0,0,0.20224267,4.9701057,830.67497)" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4476);fill-opacity:1;stroke:url(#linearGradient4468);stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4460"
+       width="39"
+       height="34.000019"
+       x="19.485916"
+       y="993.84576" />
+    <path
+       style="fill:url(#linearGradient4530);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1"
+       d="m 51.55265,1039.9958 -29.999998,0 3,-6 23.937878,-0.1336 z"
+       id="path4512"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4520);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4510"
+       width="16"
+       height="9.0000172"
+       x="28"
+       y="1029.3622" />
+    <g
+       transform="matrix(0.92787456,0,0,0.92766861,-334.80763,585.97703)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:0.30075619;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430-2"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(3.3253216,0,0,3.3245835,49.654056,-2426.2108)" />
+    <g
+       transform="matrix(3.1391206,0,0,3.5217855,49.654056,-2426.2108)"
+       style="font-style:normal;font-weight:normal;font-size:15.56941891px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="text3782-3" />
+    <g
+       id="g11331-3-1-1-00"
+       style="display:inline"
+       transform="matrix(0,-0.14879357,0.14879357,0,3.0151033,1093.2759)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-1" />
+    </g>
+    <g
+       id="g7590-7-0"
+       style="display:inline"
+       transform="matrix(1.122791,0,0,1.122791,51.605476,-118.01412)" />
+    <g
+       id="g7827-7-5"
+       style="display:inline"
+       transform="matrix(0.45489265,0,0,0.45489265,119.65899,561.31682)" />
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,71.714017,852.06346)"
+       style="display:inline"
+       id="g11331-3-1-1-0">
+      <g
+         id="g13408-8-4"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#384569;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 56.989486,995.8587 -35.499999,0 0,30.5"
+       id="path4478"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#819dc4;stroke-width:0.99999982px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 22,1024.8622 33.5,0 0,-28.5"
+       id="path4478-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#c5ccd6;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 20.985916,1025.8458 35.5,0 0,-30.5"
+       id="path4478-1-4"
+       inkscape:connector-curvature="0" />
+    <circle
+       style="display:inline;opacity:1;fill:#ffffeb;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4984)"
+       id="path4534-9"
+       cx="17.5"
+       cy="1030.8622"
+       r="14"
+       transform="matrix(1.1084537,0,0,1.1084624,0.35349044,-111.8097)" />
+    <ellipse
+       style="opacity:1;fill:url(#linearGradient5041);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5031)"
+       id="path5009"
+       cx="21.588707"
+       cy="1046.0166"
+       rx="15.364794"
+       ry="1.6100959" />
+    <ellipse
+       style="display:inline;opacity:1;fill:#eceee6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4534-4"
+       cx="19.751431"
+       cy="1030.8623"
+       rx="13.99989"
+       ry="14" />
+    <path
+       style="display:inline;fill:#faf8ff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0)"
+       d="m 19.57989,1030.4338 0,-13.577 c 6.933977,-2e-4 13.67501,6.9493 13.576826,10.0041 z"
+       id="path4620-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:#faf8ff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-4)"
+       d="m -13.666785,1005.1109 1.161185,-12.9517 c 4.0695527,0.23247 10.7443039,6.19437 11.87981528,9.2895 z"
+       id="path4620-5-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       transform="matrix(-0.99999218,0,0,-1,5.9137479,2036.4825)" />
+    <path
+       style="display:inline;fill:url(#linearGradient5022);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-0)"
+       d="m -4.8580548,1007.0312 -1.7458573,-12.74883 c 7.24929196,-0.95759 12.7683084,3.82096 13.5094793,7.37643 z"
+       id="path4620-5-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       transform="matrix(-0.14456141,-0.98949567,0.98948793,-0.14456254,-977.63999,1171.806)" />
+    <path
+       style="display:inline;fill:url(#linearGradient4934);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-49)"
+       d="m -9.0220443,997.69719 -2.1437267,-11.87986 c 7.4203185,-2.43164 15.217233,4.86601 14.9167613,8.93224 z"
+       id="path4620-5-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       transform="matrix(0,1,-0.99999218,0,1018.3411,1039.9465)" />
+    <path
+       style="fill:url(#linearGradient5042);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796)"
+       d="m 19.937173,1030.7464 4.376741,-12.7731 c 3.367335,0.5614 5.452204,3.0464 7.41366,5.7166 z"
+       id="path4620"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <ellipse
+       style="display:inline;opacity:0.46100003;fill:#828877;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5012)"
+       id="path4534-2-9"
+       cx="19.751431"
+       cy="1030.8623"
+       rx="5.9999614"
+       ry="6.0000081" />
+    <path
+       style="display:inline;fill:#eceab4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-5)"
+       d="m 19.66921,1030.0766 -8.038911,-9.7363 c 0.819785,-0.058 5.009981,-3.5206 7.770945,-2.769 z"
+       id="path4620-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <ellipse
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4542-7);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4534-2"
+       cx="19.751431"
+       cy="1030.8623"
+       rx="2.0533831"
+       ry="2.0533991" />
+    <path
+       style="fill:url(#linearGradient5030);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4792)"
+       d="m 19.401245,1031.7289 -11.433118,5.27 c 0.8910204,2.5032 2.747862,3.9513 4.823347,5.27 l 6.609771,-10.0041"
+       id="path4622"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <rect
+       style="opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect5068"
+       width="2"
+       height="2"
+       x="43"
+       y="1026.8622" />
+    <rect
+       style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect5068-8"
+       width="2"
+       height="2"
+       x="47"
+       y="1026.8622" />
+    <rect
+       style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect5068-85"
+       width="2"
+       height="2"
+       x="51"
+       y="1026.8622" />
+    <rect
+       style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect5068-85-3"
+       width="2"
+       height="2"
+       x="55"
+       y="1026.8622" />
+    <ellipse
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient4542);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4534"
+       cx="19.751431"
+       cy="1030.8623"
+       rx="13.99989"
+       ry="14" />
+    <rect
+       style="opacity:0.656;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5282)"
+       id="rect5140"
+       width="20"
+       height="16"
+       x="25"
+       y="1000.3622"
+       transform="matrix(1.2408001,0,0,1.1760011,-6.0200014,-176.06482)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ExportWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ExportWizard.java
@@ -49,7 +49,7 @@ public class ExportWizard extends AbstractWizard implements IExportWizard {
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
 		setWindowTitle(Messages.ExportWizard_WizardTitle);
 		setDefaultPageImageDescriptor(ImageDescriptor
-				.createFromURL(Platform.getBundle(Constants.Bundle_ID).getEntry("icons/wizban/install_wiz.png"))); //$NON-NLS-1$
+				.createFromURL(Platform.getBundle(Constants.Bundle_ID).getEntry("icons/wizban/install_wiz.svg"))); //$NON-NLS-1$
 		setNeedsProgressMonitor(true);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ImportFromInstallationWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ImportFromInstallationWizard.java
@@ -55,7 +55,7 @@ public class ImportFromInstallationWizard extends InstallWizard implements IImpo
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
 		setWindowTitle(Messages.ImportWizard_WINDOWTITLE);
 		setDefaultPageImageDescriptor(ImageDescriptor
-				.createFromURL(Platform.getBundle(Constants.Bundle_ID).getEntry("icons/wizban/install_wiz.png"))); //$NON-NLS-1$
+				.createFromURL(Platform.getBundle(Constants.Bundle_ID).getEntry("icons/wizban/install_wiz.svg"))); //$NON-NLS-1$
 		setNeedsProgressMonitor(true);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ImportWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/ImportWizard.java
@@ -65,7 +65,7 @@ public class ImportWizard extends InstallWizard implements IImportWizard {
 	public void init(IWorkbench workbench, IStructuredSelection selection) {
 		setWindowTitle(Messages.ImportWizard_WINDOWTITLE);
 		setDefaultPageImageDescriptor(ImageDescriptor
-				.createFromURL(Platform.getBundle(Constants.Bundle_ID).getEntry("icons/wizban/install_wiz.png"))); //$NON-NLS-1$
+				.createFromURL(Platform.getBundle(Constants.Bundle_ID).getEntry("icons/wizban/install_wiz.svg"))); //$NON-NLS-1$
 		setNeedsProgressMonitor(true);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/META-INF/MANIFEST.MF
@@ -39,3 +39,4 @@ Import-Package: org.eclipse.equinox.internal.p2.core.helpers,
  org.osgi.framework;version="1.6.0",
  org.osgi.service.packageadmin;version="1.2.0"
 Automatic-Module-Name: org.eclipse.equinox.p2.ui.sdk.scheduler
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/icons/tool/close.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/icons/tool/close.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="close.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="40.329829"
+     inkscape:cx="8.0087892"
+     inkscape:cy="7.5097478"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4794"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g4794"
+       transform="matrix(0.97551468,0,0,0.97551468,9.2809852,25.497327)">
+      <path
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:none"
+         d="m 4.0078125,4.96875 0.029297,1.0214844 0.9003906,0 2.2949219,2.296875 0,0.40625 -2.2949219,2.2968746 -0.9003906,0 -0.029297,1.021485 1.9511719,0 2.0488281,-2.0507815 2.0507815,2.0507815 1.951172,0 -0.03125,-1.021485 -0.898438,0 -2.3027342,-2.302734 -0.013672,0.00781 0,-0.4101563 0.013672,0.00781 2.3027342,-2.3027344 0.898438,0 0.03125,-1.0214844 -1.951172,0 L 8.0078125,7.0195312 5.9589844,4.96875 Z"
+         id="close_x"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccccccccccc"
+         transform="matrix(1.0250999,0,0,1.0250999,-9.513937,1036.2375)" />
+      <image
+         y="1036.2374"
+         x="6.8876615"
+         id="image4179"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAEtJREFU
+OI1j/P//PwMlgIki3cPUAIcEh/+MjIwYIYtLnOH///8Y2D7e/j9ECjsfGWM1AFkTPs14DSBkM21d
+QFEY4FKMS5xxNC8wAABoIAhpDX9ijgAAAABJRU5ErkJggg==
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="16.401598"
+         width="16.401598" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/icons/tool/close_hot.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/icons/tool/close_hot.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="close_hot.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.499919"
+     inkscape:cx="6.7468724"
+     inkscape:cy="7.5097478"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4794"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g4794"
+       transform="matrix(0.97551468,0,0,0.97551468,9.2809852,25.497327)">
+      <path
+         style="display:inline;fill:#ac0c00;fill-opacity:1;stroke:none"
+         d="m 4.0078125,4.96875 0.029297,1.0214844 0.9003906,0 2.2949219,2.296875 0,0.40625 -2.2949219,2.2968746 -0.9003906,0 -0.029297,1.021485 1.9511719,0 2.0488281,-2.0507815 2.0507815,2.0507815 1.951172,0 -0.03125,-1.021485 -0.898438,0 -2.3027342,-2.302734 -0.013672,0.00781 0,-0.4101563 0.013672,0.00781 2.3027342,-2.3027344 0.898438,0 0.03125,-1.0214844 -1.951172,0 L 8.0078125,7.0195312 5.9589844,4.96875 Z"
+         id="close_x"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccccccccccc"
+         transform="matrix(1.0250999,0,0,1.0250999,-9.513937,1036.2375)" />
+      <image
+         y="1036.2374"
+         x="6.8876619"
+         id="image4196"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAE1JREFU
+OI1j/P//PwMlgIki3cPUAIcEh/9/hBkxQhaXOMP///8xsH28/f/fQgz/cfGRMVYDkDXh04zXAEI2
+09YFFIUBLsW4xBlH8wIDAGU7FhJfeDFeAAAAAElFTkSuQmCC
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="16.401598"
+         width="16.401598" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/icons/tool/update.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/icons/tool/update.svg
@@ -1,0 +1,631 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="update.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4241">
+      <stop
+         style="stop-color:#e8e797;stop-opacity:1"
+         offset="0"
+         id="stop4243" />
+      <stop
+         id="stop4253"
+         offset="0.35728768"
+         style="stop-color:#d9d960;stop-opacity:1" />
+      <stop
+         id="stop4251"
+         offset="0.52198553"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4249"
+         offset="0.59030288"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#dbd859;stop-opacity:1"
+         offset="0.83932275"
+         id="stop4255" />
+      <stop
+         style="stop-color:#e8e797;stop-opacity:1"
+         offset="1"
+         id="stop4245" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4008">
+      <stop
+         style="stop-color:#3a4e81;stop-opacity:1;"
+         offset="0"
+         id="stop4010" />
+      <stop
+         style="stop-color:#7688b7;stop-opacity:1;"
+         offset="1"
+         id="stop4012" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3906">
+      <stop
+         style="stop-color:#546483;stop-opacity:1;"
+         offset="0"
+         id="stop3908" />
+      <stop
+         style="stop-color:#818b9f;stop-opacity:1;"
+         offset="1"
+         id="stop3910" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3892">
+      <stop
+         style="stop-color:#2b5c9c;stop-opacity:1;"
+         offset="0"
+         id="stop3894" />
+      <stop
+         style="stop-color:#3673c4;stop-opacity:1;"
+         offset="1"
+         id="stop3896" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3884">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3886" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3888" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082">
+      <stop
+         id="stop4084"
+         offset="0"
+         style="stop-color:#4476aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#5a9ccc;stop-opacity:1"
+         offset="0.5"
+         id="stop4864" />
+      <stop
+         id="stop4086"
+         offset="1"
+         style="stop-color:#4476aa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.7236701"
+       id="linearGradient5838"
+       xlink:href="#linearGradient5832"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832">
+      <stop
+         id="stop5834"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840" />
+      <stop
+         id="stop5836"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846" />
+      <stop
+         id="stop5848"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask10494">
+      <path
+         inkscape:connector-curvature="0"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 21,1037.3622 0,0.5 0,2 0,0.5 0,8.5313 0,0.5 0.5,0 13.03125,0 0.5,0 0,-0.5 0,-11.0313 0,-0.5 -0.5,0 -13.03125,0 -0.5,0 z"
+         id="path10496" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11296"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.72367"
+       id="linearGradient5838-7"
+       xlink:href="#linearGradient5832-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832-2">
+      <stop
+         id="stop5834-8"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840-7" />
+      <stop
+         id="stop5836-9"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844-9">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846-2" />
+      <stop
+         id="stop5848-9"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290-2">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292-4" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294-75" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.72367"
+       id="linearGradient5838-0"
+       xlink:href="#linearGradient5832-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832-7">
+      <stop
+         id="stop5834-1"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840-6" />
+      <stop
+         id="stop5836-93"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844-7">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846-3" />
+      <stop
+         id="stop5848-0"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11407"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11409"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11413"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11415"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11417"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11623"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11625"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11629"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11631"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3892"
+       id="linearGradient3898"
+       x1="22.420315"
+       y1="1044.6581"
+       x2="22.420315"
+       y2="1037.9327"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99970452,0,0,1.0056059,-0.12636013,-5.9273647)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3906"
+       id="linearGradient3912"
+       x1="22.994839"
+       y1="1040.1731"
+       x2="22.994839"
+       y2="1048.3184"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99970452,0,0,1.0056059,-0.12636013,-5.9273647)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4008-8"
+       id="linearGradient4014-5"
+       x1="25.096403"
+       y1="1041.8778"
+       x2="19.998154"
+       y2="1041.8778"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4008-8">
+      <stop
+         style="stop-color:#3a4e81;stop-opacity:1;"
+         offset="0"
+         id="stop4010-9" />
+      <stop
+         style="stop-color:#7688b7;stop-opacity:1;"
+         offset="1"
+         id="stop4012-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-9-3-2">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop7586-6-3-6" />
+      <stop
+         id="stop4256"
+         offset="0.50837314"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="1"
+         id="stop7588-9-9-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4241"
+       id="linearGradient4247"
+       x1="10.349669"
+       y1="1050.4397"
+       x2="4.3227959"
+       y2="1043.6338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4.5991674,0.020415)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-9-3-2"
+       id="linearGradient7608-9-7-1"
+       gradientUnits="userSpaceOnUse"
+       x1="22.930616"
+       y1="1038.3976"
+       x2="22.932821"
+       y2="1042.8771"
+       gradientTransform="matrix(-0.99207725,0,0,1.0009034,28.75113,-0.45703587)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7134"
+       id="linearGradient7140"
+       x1="25.363291"
+       y1="1044.7311"
+       x2="25.363291"
+       y2="1037.7311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99207725,0,0,1.0009034,28.75113,-0.45703587)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7134">
+      <stop
+         style="stop-color:#a06d12;stop-opacity:1"
+         offset="0"
+         id="stop7136" />
+      <stop
+         style="stop-color:#be9c28;stop-opacity:1"
+         offset="1"
+         id="stop7138" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Fade to Black or White"
+       id="filter4362">
+      <feColorMatrix
+         values="0.635638 0 0 0 0.364362 0 0.635638 0 0 0.364362 0 0 0.635638 0 0.364362 0 0 0 1 0"
+         id="feColorMatrix4364" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Fade to Black or White"
+       id="filter4366">
+      <feColorMatrix
+         values="0.635638 0 0 0 0.364362 0 0.635638 0 0 0.364362 0 0 0.635638 0 0.364362 0 0 0 1 0"
+         id="feColorMatrix4368" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="38.21178"
+     inkscape:cx="7.4585081"
+     inkscape:cy="8.4643893"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4067"
+       transform="matrix(1,0,0,1.0060285,-9.9116543,-2.1489855)"
+       style="filter:url(#filter4366)">
+      <rect
+         ry="0.79516107"
+         rx="0.79526007"
+         y="1037.7573"
+         x="16.441561"
+         height="7.9330373"
+         width="8.9687681"
+         id="rect3101"
+         style="fill:url(#linearGradient3912);fill-opacity:1;stroke:url(#linearGradient3898);stroke-width:0.99964225;stroke-opacity:1" />
+      <rect
+         ry="0"
+         rx="0"
+         y="1039.2144"
+         x="17.924761"
+         height="4.9849854"
+         width="5.9879208"
+         id="rect3902"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      <g
+         id="g4243"
+         transform="translate(0,3.546875)">
+        <g
+           id="g3920"
+           transform="translate(-1.078125,-5.7036176)">
+          <rect
+             ry="0"
+             rx="0"
+             y="1048.2737"
+             x="20.970135"
+             height="1.1322982"
+             width="2.0329325"
+             id="rect3914"
+             style="fill:#2a5893;fill-opacity:1;stroke:none" />
+          <rect
+             y="1049.3667"
+             x="18.961622"
+             height="0.984375"
+             width="6.0546155"
+             id="rect3918"
+             style="fill:#2a5893;fill-opacity:1;stroke:none" />
+        </g>
+      </g>
+      <g
+         transform="translate(-0.05579793,-0.15736043)"
+         id="g3994">
+        <rect
+           style="fill:#cfedfb;fill-opacity:1;stroke:none"
+           id="rect3963"
+           width="5.9801044"
+           height="0.99152541"
+           x="17.987028"
+           y="3.0069129"
+           transform="translate(0,1036.3622)" />
+        <rect
+           style="display:inline;fill:#cfedfb;fill-opacity:1;stroke:none"
+           id="rect3963-2"
+           width="4.993042"
+           height="1.0093231"
+           x="1039.3691"
+           y="-18.981396"
+           transform="matrix(0,1,-1,0,0,0)" />
+      </g>
+    </g>
+    <g
+       id="g4237"
+       transform="translate(-6.065264,1.0079852)"
+       style="filter:url(#filter4362)">
+      <circle
+         r="4.0216699"
+         cy="1046.8804"
+         cx="11.515555"
+         id="path4239"
+         style="opacity:1;fill:url(#linearGradient4247);fill-opacity:1;stroke:#3d5f9f;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <circle
+         r="1"
+         cy="1046.8676"
+         cx="11.503272"
+         id="path4259"
+         style="opacity:1;fill:#fffffe;fill-opacity:1;stroke:#899bc0;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none"
+       d="m 4.9715613,1040.3749 0,0.4067 c 0,0 -0.09657,0.2562 0.1931408,0.1658 0.2897108,-0.09 0.8498193,-0.4519 0.9077613,-0.5273 0.057941,-0.075 0.6566784,-0.4067 0.5214805,-0.5573 -0.1351989,-0.1507 -1.274729,-0.045 -1.274729,-0.045 z"
+       id="path7602-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssscc" />
+    <image
+       width="16"
+       height="16"
+       preserveAspectRatio="none"
+       style="image-rendering:optimizeSpeed"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAilJREFU
+OI2lk09I02EYxz/v7/0tx7RtTrdqA7ND7SQ5Iymigi5lIAR2qq5dOvUPpE51CAk8dA/CTiJRSMOW
+VMtBl+yPkNDBg7gwdeWcLnT+tne/t8NPZ6sdhF54Ds/L9/t5nvfheYXWmv85Rq3LRF9YJ/rC2yLX
+BACc6f3KdiBVgL8rbwciNmeQ6AvrY+ev4AnFqgT2+gxvHt2j69acqAUwAYbv7tanei7h8UXA+lGt
+WJ3DsmyGRlJ6fMFfG7CSLeGpD2DPphgciANw8doN7NwUgwNx3KefMZvOECZTZZ7bsd8BABVxKZbA
+NdFVyQ/ecUzRo9WV3z4ZBl3eGuLgQJzAuTE6DgcreajnKe9fjhKtF/+ENAywbacDX5MLefwV7dEg
+hlEgfDuJy1hGyiXc5jLJj585EetA4wxcANKUYG10sNjynEioAcMoMJVe43F8mS/TzdQ1tBMO+Zmf
+X8dSNkWlKSqNpTSmlGArB5BVBZr9GinyjE8u0nv5JOOTixRXP9Do9ZLNlSmWNKWSprgR0jRAK+cJ
+TaablXyOPcFfdLYFuf8wRWdbM6qsyGR9NHgKjL4eA7Z2SkoTYZcdQGSfi+8/87TsynEktpeOAxmU
+UqhygPSCprXVTfLTGmLTL9iAlbc2cWgkpUP+aSKhRvxeL5klL+l5g/yq5kL3IXHzwQsN0H/1bNVG
+ij+/82jqnf6WkSytWAR8dUSCO0lOzIDQaAQVp9b0X+8WAL8BB5j04ADwiw4AAAAASUVORK5CYII=
+"
+       id="image4332"
+       x="16"
+       y="1036.3622" />
+    <path
+       style="opacity:1;fill:url(#linearGradient7608-9-7-1);fill-opacity:1;stroke:url(#linearGradient7140);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 5.442848,1038.3693 c 0,0 0.260734,-0.9953 1.269147,-0.1994 1.008413,0.7964 2.192202,2.079 2.367579,2.433 0.175374,0.354 0.920724,0.9731 -0.08769,1.9464 -1.008414,0.9731 -2.104515,1.9904 -2.104515,1.9904 0,0 -0.401069,0.3816 -0.793125,0.5713 -0.374826,0.1813 -0.651398,0.1872 -0.651398,-0.4831 l 0,-1.6106 c -1.387652,0 -1.84523,-0.3051 -2.113703,0.4861 -0.185059,0.5453 -0.254284,2.2297 -0.657316,2.3548 C 2.268796,1045.9829 1.5,1043.4093 1.5,1042.9714 c 0,-0.4377 0.093,-1.3136 0.713056,-1.9703 0.620048,-0.6571 0.998596,-0.9565 1.519119,-1.101 0.520523,-0.1439 1.710672,-0.094 1.710672,-0.094 z"
+       id="path7582-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssccccsssszcc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/icons/tool/update_problems.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/icons/tool/update_problems.svg
@@ -1,0 +1,718 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="update_problems.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4241">
+      <stop
+         style="stop-color:#e8e797;stop-opacity:1"
+         offset="0"
+         id="stop4243" />
+      <stop
+         id="stop4253"
+         offset="0.35728768"
+         style="stop-color:#d9d960;stop-opacity:1" />
+      <stop
+         id="stop4251"
+         offset="0.52198553"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4249"
+         offset="0.59030288"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#dbd859;stop-opacity:1"
+         offset="0.83932275"
+         id="stop4255" />
+      <stop
+         style="stop-color:#e8e797;stop-opacity:1"
+         offset="1"
+         id="stop4245" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4008">
+      <stop
+         style="stop-color:#3a4e81;stop-opacity:1;"
+         offset="0"
+         id="stop4010" />
+      <stop
+         style="stop-color:#7688b7;stop-opacity:1;"
+         offset="1"
+         id="stop4012" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3906">
+      <stop
+         style="stop-color:#546483;stop-opacity:1;"
+         offset="0"
+         id="stop3908" />
+      <stop
+         style="stop-color:#818b9f;stop-opacity:1;"
+         offset="1"
+         id="stop3910" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3892">
+      <stop
+         style="stop-color:#2b5c9c;stop-opacity:1;"
+         offset="0"
+         id="stop3894" />
+      <stop
+         style="stop-color:#3673c4;stop-opacity:1;"
+         offset="1"
+         id="stop3896" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3884">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3886" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3888" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4082">
+      <stop
+         id="stop4084"
+         offset="0"
+         style="stop-color:#4476aa;stop-opacity:1" />
+      <stop
+         style="stop-color:#5a9ccc;stop-opacity:1"
+         offset="0.5"
+         id="stop4864" />
+      <stop
+         id="stop4086"
+         offset="1"
+         style="stop-color:#4476aa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.7236701"
+       id="linearGradient5838"
+       xlink:href="#linearGradient5832"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832">
+      <stop
+         id="stop5834"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840" />
+      <stop
+         id="stop5836"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846" />
+      <stop
+         id="stop5848"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask10494">
+      <path
+         inkscape:connector-curvature="0"
+         style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+         d="m 21,1037.3622 0,0.5 0,2 0,0.5 0,8.5313 0,0.5 0.5,0 13.03125,0 0.5,0 0,-0.5 0,-11.0313 0,-0.5 -0.5,0 -13.03125,0 -0.5,0 z"
+         id="path10496" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11296"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.72367"
+       id="linearGradient5838-7"
+       xlink:href="#linearGradient5832-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832-2">
+      <stop
+         id="stop5834-8"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840-7" />
+      <stop
+         id="stop5836-9"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844-9">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846-2" />
+      <stop
+         id="stop5848-9"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11290-2">
+      <stop
+         style="stop-color:#567ead;stop-opacity:1"
+         offset="0"
+         id="stop11292-4" />
+      <stop
+         style="stop-color:#35679d;stop-opacity:1"
+         offset="1"
+         id="stop11294-75" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1067.9872"
+       x2="14.526336"
+       y1="1067.9872"
+       x1="4.72367"
+       id="linearGradient5838-0"
+       xlink:href="#linearGradient5832-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5832-7">
+      <stop
+         id="stop5834-1"
+         offset="0"
+         style="stop-color:#7d6fba;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4b3e81;stop-opacity:1;"
+         offset="0.5"
+         id="stop5840-6" />
+      <stop
+         id="stop5836-93"
+         offset="1"
+         style="stop-color:#9d93cb;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5844-7">
+      <stop
+         style="stop-color:#739cc6;stop-opacity:1"
+         offset="0"
+         id="stop5846-3" />
+      <stop
+         id="stop5848-0"
+         offset="0.47270355"
+         style="stop-color:#4b82b6;stop-opacity:1" />
+      <stop
+         style="stop-color:#aac2dc;stop-opacity:1"
+         offset="1"
+         id="stop5850-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11407"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11409"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11413"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11415"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.4806"
+       x2="12.51806"
+       y1="1037.6146"
+       x1="12.51806"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient11417"
+       xlink:href="#linearGradient11290-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11623"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11625"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11629"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11290"
+       id="linearGradient11631"
+       gradientUnits="userSpaceOnUse"
+       x1="12.51806"
+       y1="1037.6146"
+       x2="12.51806"
+       y2="1044.4806" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3892"
+       id="linearGradient3898"
+       x1="22.420315"
+       y1="1044.6581"
+       x2="22.420315"
+       y2="1037.9327"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99970452,0,0,1.0056059,-0.12636013,-5.9273647)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3906"
+       id="linearGradient3912"
+       x1="22.994839"
+       y1="1040.1731"
+       x2="22.994839"
+       y2="1048.3184"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99970452,0,0,1.0056059,-0.12636013,-5.9273647)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4008-8"
+       id="linearGradient4014-5"
+       x1="25.096403"
+       y1="1041.8778"
+       x2="19.998154"
+       y2="1041.8778"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4008-8">
+      <stop
+         style="stop-color:#3a4e81;stop-opacity:1;"
+         offset="0"
+         id="stop4010-9" />
+      <stop
+         style="stop-color:#7688b7;stop-opacity:1;"
+         offset="1"
+         id="stop4012-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-9-3-2">
+      <stop
+         style="stop-color:#fefdef;stop-opacity:1"
+         offset="0"
+         id="stop7586-6-3-6" />
+      <stop
+         id="stop4256"
+         offset="0.50837314"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1"
+         offset="1"
+         id="stop7588-9-9-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4241"
+       id="linearGradient4247"
+       x1="10.349669"
+       y1="1050.4397"
+       x2="4.3227959"
+       y2="1043.6338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4.5991674,0.020415)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-9-3-2"
+       id="linearGradient7608-9-7-1"
+       gradientUnits="userSpaceOnUse"
+       x1="22.930616"
+       y1="1038.3976"
+       x2="22.932821"
+       y2="1042.8771"
+       gradientTransform="matrix(-0.99207725,0,0,1.0009034,28.75113,-0.45703587)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7134"
+       id="linearGradient7140"
+       x1="25.363291"
+       y1="1044.7311"
+       x2="25.363291"
+       y2="1037.7311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99207725,0,0,1.0009034,28.75113,-0.45703587)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7134">
+      <stop
+         style="stop-color:#a06d12;stop-opacity:1"
+         offset="0"
+         id="stop7136" />
+      <stop
+         style="stop-color:#be9c28;stop-opacity:1"
+         offset="1"
+         id="stop7138" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Fade to Black or White"
+       id="filter4362">
+      <feColorMatrix
+         values="0.635638 0 0 0 0.364362 0 0.635638 0 0 0.364362 0 0 0.635638 0 0.364362 0 0 0 1 0"
+         id="feColorMatrix4364" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Fade to Black or White"
+       id="filter4366">
+      <feColorMatrix
+         values="0.635638 0 0 0 0.364362 0 0.635638 0 0 0.364362 0 0 0.635638 0 0.364362 0 0 0 1 0"
+         id="feColorMatrix4368" />
+    </filter>
+    <linearGradient
+       gradientTransform="matrix(0.28180129,0,0,0.32885889,-104.28234,887.41181)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient10798-1-9-3-7-1-15-1-7-6-1"
+       id="linearGradient8163-2"
+       gradientUnits="userSpaceOnUse"
+       x1="388.63736"
+       y1="477.77817"
+       x2="388.63736"
+       y2="458.68076" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-1-15-1-7-6-1">
+      <stop
+         style="stop-color:#eb6d71;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-2-8-1-7-3-7" />
+      <stop
+         id="stop10806-6-8-5-3-2-95-0-5-4-8"
+         offset="0.5"
+         style="stop-color:#f13f53;stop-opacity:1" />
+      <stop
+         style="stop-color:#f7a29a;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-2-0-9-8-4-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28180129,0,0,0.32885889,-104.28234,887.41181)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4880"
+       id="linearGradient4886"
+       x1="393.43765"
+       y1="458.68076"
+       x2="393.43765"
+       y2="477.77817"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4880">
+      <stop
+         style="stop-color:#c93e35;stop-opacity:1;"
+         offset="0"
+         id="stop4882" />
+      <stop
+         style="stop-color:#c8192a;stop-opacity:1"
+         offset="1"
+         id="stop4884" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4880"
+       id="linearGradient4334"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28180129,0,0,0.32885889,-104.28234,887.41181)"
+       x1="393.43765"
+       y1="458.68076"
+       x2="393.43765"
+       y2="477.77817" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.094889"
+     inkscape:cx="16.312144"
+     inkscape:cy="7.4739194"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4067"
+       transform="matrix(1,0,0,1.0060285,-9.9116543,-2.1489855)"
+       style="filter:url(#filter4366)">
+      <rect
+         ry="0.79516107"
+         rx="0.79526007"
+         y="1037.7573"
+         x="16.441561"
+         height="7.9330373"
+         width="8.9687681"
+         id="rect3101"
+         style="fill:url(#linearGradient3912);fill-opacity:1;stroke:url(#linearGradient3898);stroke-width:0.99964225;stroke-opacity:1" />
+      <rect
+         ry="0"
+         rx="0"
+         y="1039.2144"
+         x="17.924761"
+         height="4.9849854"
+         width="5.9879208"
+         id="rect3902"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      <g
+         id="g4243"
+         transform="translate(0,3.546875)">
+        <g
+           id="g3920"
+           transform="translate(-1.078125,-5.7036176)">
+          <rect
+             ry="0"
+             rx="0"
+             y="1048.2737"
+             x="20.970135"
+             height="1.1322982"
+             width="2.0329325"
+             id="rect3914"
+             style="fill:#2a5893;fill-opacity:1;stroke:none" />
+          <rect
+             y="1049.3667"
+             x="18.961622"
+             height="0.984375"
+             width="6.0546155"
+             id="rect3918"
+             style="fill:#2a5893;fill-opacity:1;stroke:none" />
+        </g>
+      </g>
+      <g
+         transform="translate(-0.05579793,-0.15736043)"
+         id="g3994">
+        <rect
+           style="fill:#cfedfb;fill-opacity:1;stroke:none"
+           id="rect3963"
+           width="5.9801044"
+           height="0.99152541"
+           x="17.987028"
+           y="3.0069129"
+           transform="translate(0,1036.3622)" />
+        <rect
+           style="display:inline;fill:#cfedfb;fill-opacity:1;stroke:none"
+           id="rect3963-2"
+           width="4.993042"
+           height="1.0093231"
+           x="1039.3691"
+           y="-18.981396"
+           transform="matrix(0,1,-1,0,0,0)" />
+      </g>
+    </g>
+    <g
+       id="g4237"
+       transform="translate(-6.065264,1.0079852)"
+       style="filter:url(#filter4362)">
+      <circle
+         r="4.0216699"
+         cy="1046.8804"
+         cx="11.515555"
+         id="path4239"
+         style="opacity:1;fill:url(#linearGradient4247);fill-opacity:1;stroke:#3d5f9f;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <circle
+         r="1"
+         cy="1046.8676"
+         cx="11.503272"
+         id="path4259"
+         style="opacity:1;fill:#fffffe;fill-opacity:1;stroke:#899bc0;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none"
+       d="m 4.9715613,1040.3749 0,0.4067 c 0,0 -0.09657,0.2562 0.1931408,0.1658 0.2897108,-0.09 0.8498193,-0.4519 0.9077613,-0.5273 0.057941,-0.075 0.6566784,-0.4067 0.5214805,-0.5573 -0.1351989,-0.1507 -1.274729,-0.045 -1.274729,-0.045 z"
+       id="path7602-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssscc" />
+    <path
+       style="opacity:1;fill:url(#linearGradient7608-9-7-1);fill-opacity:1;stroke:url(#linearGradient7140);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 5.442848,1038.3693 c 0,0 0.260734,-0.9953 1.269147,-0.1994 1.008413,0.7964 2.192202,2.079 2.367579,2.433 0.175374,0.354 0.920724,0.9731 -0.08769,1.9464 -1.008414,0.9731 -2.104515,1.9904 -2.104515,1.9904 0,0 -0.401069,0.3816 -0.793125,0.5713 -0.374826,0.1813 -0.651398,0.1872 -0.651398,-0.4831 l 0,-1.6106 c -1.387652,0 -1.84523,-0.3051 -2.113703,0.4861 -0.185059,0.5453 -0.254284,2.2297 -0.657316,2.3548 C 2.268796,1045.9829 1.5,1043.4093 1.5,1042.9714 c 0,-0.4377 0.093,-1.3136 0.713056,-1.9703 0.620048,-0.6571 0.998596,-0.9565 1.519119,-1.101 0.520523,-0.1439 1.710672,-0.094 1.710672,-0.094 z"
+       id="path7582-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssccccsssszcc" />
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4297"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAkxJREFU
+OI2lk0FI03EUxz///3+mxJpz/jfTgdmhvCSpgdShIiMagXjoMgInBN0jgg6duhSBB49BF7egTZSQ
+YoYY2qKTEUJepIO0KOfov+lW29z2316H/ZeZ6KUfPB68H9/ve3zf+yoiwv88m5UlFYxghCJ/PvSA
+n9ZRP4ByEIEKUAfrAT8N7W3oAT9GKEIqGDkIa7UWYXVwWIyJsIiIGBNhyW+bYkyEZXVwWGYftouI
+sF+odaLM/CKpYATXiI98ZIrM/CIAl2/e5/Wjjn2Fsv1b+LVtB6CcSNYKuXWKxSqT0ZgsbTj3J2i+
+cgnXiI/0s2lcIz4AjFCE8PgTmq6+4Fs8SQfJXeD1QydqBHXR6qB61gN+Tg9NA9B9bnfnxakZkEqN
+wFrXHnDrqJ/p51EC1317Rn+nqlCtoogIMw+OinZ+nt5uN6paQFOyNKhbaFqa5dUt8pziQl8/Qk1L
+BQhNRlkrempbMDpf4vXYUdUCn+N5gq+2+LSm02jvpcPjJJHYpmhWKZlCyRSKpmDTNKia1iGZBXSn
+oClZllYM7t26yNKKQSn3gRaHg9RmhVJZKJeFkhWaTQUxLQ1sTWSym7S7fzLQ4+bx0xgDPTpmxSSZ
+asZ+uMDcm7fAzjlomg2laonoPd7A9x9ZOts2Odt3jP6TSUzTxKy4iG8IXV1NLHzMo9TxChZZpSYi
+wGQ0Jh7nGl5PC06Hg2TaQTyhks0JN4bOKHfHZwVg7Pa1XeZS/rbzXOy9fE1qpDNFXM2NeN1HWFj+
+AoogKDu2FGHszpAC8Bt9fCOE3ANWlgAAAABJRU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <g
+       id="g4336"
+       transform="matrix(1.1702809,0,0,1,-0.91824849,-0.08103561)">
+      <ellipse
+         ry="3.4941258"
+         rx="2.9941387"
+         id="path10796-2-6-0"
+         style="display:inline;fill:url(#linearGradient8163-2);fill-opacity:1;stroke:url(#linearGradient4334);stroke-width:0.91702515;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         cx="5.0917864"
+         cy="1041.3959" />
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path4911-7"
+         d="m 6.5889,1038.3622 -3.587781,5.0156 0,0.4578 0.448473,0 3.550408,-4.95 0,-0.5234 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4911-7-4"
+         d="m 3.579579,1038.9391 0.03737,0.6979 c 0.133663,-0.012 0.204053,0.021 0.280296,0.088 0.07624,0.065 0.151635,0.1823 0.224236,0.349 0.1452,0.3333 0.257112,0.8512 0.392414,1.3956 0.135301,0.5444 0.302028,1.1268 0.616649,1.5919 0.314622,0.465 0.816386,0.8013 1.476223,0.785 l -0.01869,-0.6979 c -0.501075,0.013 -0.767177,-0.1933 -0.990377,-0.5233 -0.223201,-0.33 -0.374632,-0.8293 -0.504532,-1.3519 -0.1299,-0.5228 -0.231935,-1.0505 -0.429787,-1.5047 -0.09892,-0.2271 -0.23064,-0.4556 -0.4111,-0.6106 -0.180459,-0.155 -0.420685,-0.2325 -0.672709,-0.2181 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate" />
+      <ellipse
+         ry="3.4941258"
+         rx="2.9941387"
+         id="path10796-2-6-0-1"
+         style="display:inline;fill:none;fill-opacity:1;stroke:url(#linearGradient4886);stroke-width:0.91702515;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         cx="5.0917864"
+         cy="1041.3959" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatePlugin.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdatePlugin.java
@@ -45,10 +45,10 @@ public class AutomaticUpdatePlugin extends AbstractUIPlugin {
 	public final static String ICON_PATH = "$nl$/icons/"; //$NON-NLS-1$
 
 	// tool icons
-	public final static String IMG_TOOL_UPDATE = "tool/update.png"; //$NON-NLS-1$
-	public final static String IMG_TOOL_UPDATE_PROBLEMS = "tool/update_problems.png"; //$NON-NLS-1$
-	public final static String IMG_TOOL_CLOSE = "tool/close.png"; //$NON-NLS-1$
-	public final static String IMG_TOOL_CLOSE_HOT = "tool/close_hot.png"; //$NON-NLS-1$
+	public final static String IMG_TOOL_UPDATE = "tool/update.svg"; //$NON-NLS-1$
+	public final static String IMG_TOOL_UPDATE_PROBLEMS = "tool/update_problems.svg"; //$NON-NLS-1$
+	public final static String IMG_TOOL_CLOSE = "tool/close.svg"; //$NON-NLS-1$
+	public final static String IMG_TOOL_CLOSE_HOT = "tool/close_hot.svg"; //$NON-NLS-1$
 
 	private static AutomaticUpdatePlugin plugin;
 	private static BundleContext context;

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/migration/MigrationWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/migration/MigrationWizard.java
@@ -77,7 +77,7 @@ public class MigrationWizard extends InstallWizard implements IImportWizard {
 		setWindowTitle(firstTime ? ProvUIMessages.MigrationWizard_WINDOWTITLE_FIRSTRUN
 				: ProvUIMessages.MigrationWizard_WINDOWTITLE);
 		setDefaultPageImageDescriptor(ImageDescriptor
-				.createFromURL(Platform.getBundle(ProvUIActivator.PLUGIN_ID).getEntry("icons/install_wiz.png"))); //$NON-NLS-1$
+				.createFromURL(Platform.getBundle(ProvUIActivator.PLUGIN_ID).getEntry("icons/wizban/install_wiz.svg"))); //$NON-NLS-1$
 		setNeedsProgressMonitor(true);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.ui.sdk/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk/META-INF/MANIFEST.MF
@@ -35,3 +35,4 @@ Service-Component: OSGI-INF/policy_component.xml, OSGI-INF/licenseManager_compon
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.equinox.p2.ui.sdk
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.equinox.p2.ui.sdk/icons/obj/iu_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk/icons/obj/iu_obj.svg
@@ -1,0 +1,557 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#c48a4e;stop-opacity:1;" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#ad6c24;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-148.40713,-87.106181)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955"
+       id="linearGradient3945"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-147.48911,-87.252829)" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4284"
+       id="linearGradient10790-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33571488,0,0,0.59088033,417.52974,47.073021)"
+       x1="305"
+       y1="513.87781"
+       x2="305"
+       y2="545.35248" />
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         id="stop4286"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:0" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999967"
+         id="stop4288" />
+      <stop
+         id="stop4290"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10790-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,214.53218,-155.02652)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-9"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-0"
+       id="linearGradient10792-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,214.53218,-155.02652)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-0">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10786-1"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818"
+       gradientTransform="matrix(1.0391435,0,0,0.59796602,202.46608,47.009545)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-9"
+       id="linearGradient10782-3"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,217.58019,-158.92057)" />
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-3" />
+      <stop
+         id="stop10422-8"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-3"
+       id="linearGradient10784-2"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,217.58019,-158.92057)" />
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         id="stop10434-4"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-2" />
+      <stop
+         id="stop10438-9"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-90"
+       id="linearGradient10778-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="matrix(1.0765606,0,0,1.061954,190.65652,-195.98554)" />
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-0" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-96"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-8"
+       id="linearGradient10774-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.062525,0,0,1.0891236,202.52576,-210.40158)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         id="stop10750-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-8" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-8" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-7"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient10770-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0387443,0,0,1.1623096,210.44163,-248.72525)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-7" />
+      <stop
+         id="stop10456-4-1-5-3"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-4" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="54.508621"
+     inkscape:cx="15.113239"
+     inkscape:cy="6.9688496"
+     inkscape:document-units="px"
+     inkscape:current-layer="g13862"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <rect
+         ry="3.1069043"
+         rx="3.1069043"
+         y="347.32736"
+         x="473.10382"
+         height="19.677061"
+         width="17.753738"
+         id="rect13693-3"
+         style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="rect13693"
+         d="m 472.68093,354.495 33.22969,0 c 1.72122,0 3.1069,1.38903 3.1069,3.11442 l 0,13.39945 c 0,1.72538 -1.44501,2.66525 -3.1069,3.11442 l -33.22969,8.9812 c -1.66188,0.44917 -3.1069,-1.38903 -3.1069,-3.11442 l 0,-22.38065 c 0,-1.72539 1.38568,-3.11442 3.1069,-3.11442 z"
+         style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path13797"
+         d="m 471.31191,354.49499 23.78261,0"
+         style="fill:none;stroke:url(#linearGradient3945);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         id="g4301"
+         transform="translate(-38.76348,19.301383)">
+        <rect
+           ry="0"
+           rx="0"
+           y="354.94647"
+           x="539.2395"
+           height="10.826942"
+           width="21.018066"
+           id="rect10007-0-74-2-7-6"
+           style="display:inline;fill:url(#linearGradient10770-6);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8-8"
+           d="m 548.23888,354.95116 0,3.5838 12.01134,0 0,-3.5838 -12.01134,0 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7"
+           d="m 549.43361,354.93037 0,10.8213 3.63939,0 0,-10.8213 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1-8"
+           d="m 560.22222,362.10479 -12.03934,0.1111 0.0351,3.58381 12.03934,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="351.43616"
+           x="538.01801"
+           height="17.791901"
+           width="11.41908"
+           id="rect10007-0-74-2-7"
+           style="display:inline;fill:url(#linearGradient10774-5);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1"
+           d="m 549.5198,365.72372 -12.03934,0.1111 0.035,3.5838 12.03935,-0.1111 -0.0351,-3.5838 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8"
+           d="m 549.48481,351.36054 -12.03935,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="347.8541"
+           x="530.58051"
+           height="24.955921"
+           width="11.811058"
+           id="rect10007-0-74-2"
+           style="display:inline;fill:url(#linearGradient10778-6);fill-opacity:1;stroke:none;stroke-width:1.50161433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="351.36792"
+           x="517.27734"
+           height="17.908186"
+           width="13.428176"
+           id="rect10007-0"
+           style="display:inline;fill:#5079bc;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="355.63754"
+           x="507.31067"
+           height="9.2635088"
+           width="10.776635"
+           id="rect10007-0-7"
+           style="display:inline;fill:url(#linearGradient10782-3);fill-opacity:1;stroke:url(#linearGradient10784-2);stroke-width:1.48636866;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="354.87964"
+           x="517.32654"
+           height="10.763388"
+           width="13.378973"
+           id="rect10007-0-74"
+           style="display:inline;fill:url(#linearGradient10786-1);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313"
+           d="m 542.3172,347.76957 -12.03935,0.1111 0.035,3.5838 12.03935,-0.11109 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5"
+           d="m 542.33819,369.2724 -12.03934,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           y="342.42676"
+           x="522.66992"
+           height="35.783813"
+           width="10.700533"
+           id="rect10007-6"
+           style="display:inline;fill:url(#linearGradient10790-8);fill-opacity:1;stroke:url(#linearGradient10792-6);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           ry="5.3502665" />
+        <rect
+           y="350.21646"
+           x="520.87805"
+           height="19.98802"
+           width="3.5889285"
+           id="rect10007-6-6"
+           style="display:inline;fill:url(#linearGradient10790-8-2);fill-opacity:1;stroke:none;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7-8"
+           d="m 542.3442,354.94937 0,10.78725 3.5848,0 0,-10.78725 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:0.64640886;fill-rule:evenodd;stroke:none;stroke-width:0.97351193px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <image
+           y="326.2341"
+           x="560.24866"
+           id="image4280"
+           xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAeJJREFU
+OI2Nk09IFFEcxz9vWTfbtFQkWCg2IZcuG8RiDihdiqAIEeoYE3jx0KVAuglBhw5ueBCJLkEeRZDq
+EHboIBJLge2xf0JLRiEpO4szs81u8+vwZnbXJrUvPN7/z/u+33s/JSKEKuSNZgcwJgqK/SQiiAjP
+b2XkbwVj7FWUiFDIG5IzxwGoO1Wcio1bruBY22x9eB05tNVZPGy0dZwOajh4FEik9cT5UgRQyBsS
+QhoA6k5zRXs/5oMvAMzdPgbVT7uGIAZQ9wU8q1HM6XX6eoW+XsGcXtduEmnwKuBZen3rFWo1X28G
+6BoEyiTb4ygE8Fl+qK9zblw78Tx/JyB99hJ0ngHAnClrzqE2FApwGbq+CMDyo34AThiTOwF3V0dg
+Vcfgcu4IXzfKdHUkkAAg/i8U0J0e5VRumJX5CUrv7gkqAHTHA/sIqZ4UqZ5k4wS3ukHscFZ3kq9Q
+nRncAye5eOVG08HHH82gfN9yKL7/xmD2OErBtu3i/yzqSauEbL5BNj/z8skkEgJeTF1ofIzhm88k
+BmQzdRCwbQd+O4CwVlxirbjE6H2JfqRQK7MjamBsQSy7BiK4rsfT2TsAXJ2SSG5EAKEqdi14xn9v
+DKVas7FVA2MLAvD28bU9M3JXwP/qD5PM7CDw/+DMAAAAAElFTkSuQmCC
+"
+           style="image-rendering:optimizeSpeed"
+           preserveAspectRatio="none"
+           height="57.340881"
+           width="57.340881" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.sdk/icons/obj/iu_update_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk/icons/obj/iu_update_obj.svg
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_update.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4274">
+      <stop
+         id="stop4276"
+         offset="0"
+         style="stop-color:#15629b;stop-opacity:1" />
+      <stop
+         id="stop4278"
+         offset="1"
+         style="stop-color:#6994ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4268">
+      <stop
+         id="stop4270"
+         offset="0"
+         style="stop-color:#c1ebca;stop-opacity:1" />
+      <stop
+         id="stop4272"
+         offset="1"
+         style="stop-color:#739ab3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a86e11;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#739ab3;stop-opacity:1"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#c1ebca;stop-opacity:1"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient4873"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99194778,0,0,0.90415386,28.747558,98.91832)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1"
+       id="linearGradient4875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99194778,0,0,0.90415386,28.747558,98.91832)"
+       x1="23.107393"
+       y1="1040.0905"
+       x2="23.107393"
+       y2="1044.9022" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4268"
+       id="linearGradient4262"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99194778,0,0,-0.90415386,-2.747602,1988.8045)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.373606"
+       y2="1039.7751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4274"
+       id="linearGradient4264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99194778,0,0,-0.90415386,-2.747602,1988.8045)"
+       x1="23.107393"
+       y1="1040.0905"
+       x2="23.107393"
+       y2="1044.9022" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="41.50087"
+     inkscape:cx="17.746156"
+     inkscape:cy="8.8506495"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4155" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="17"
+       id="image4216"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAYNJREFU
+OI2Nkk8og3EYxz8/HDTEHLyHndxdlCI3DhwkO0gur4Pbm5TiIhepnRTSyiguMmXt8irH1W6iuPqT
+snIxmuZts2Hv48BeNnvHt371fHue59vzfH+PEhHKEQtoAtC/cK9+JctQ45bom790hP4tEAto8rOp
+ezL0p4gqrhALaNI1No2nrbOkIJs853hvnYHFZMV16pzmER1Psw/yyZKC+toXcnnbdYI6gNTjG56G
+Vuy7OOauCQr803PYmQTmdoTR1ZSrmY4H9tMV5q7J6GpKvb0KdiZBNHRQtRkAEUFEiMx4pRiHp1ok
+PNXicCMYFSMYLeHF2BFwe0YwKvGHE0egnLveAcDESkT8wz5esjZWroDucMHKFb5NrIShpX3p7fBi
+PX8W+gd9IAorbXNxnSaVea8ukLTeec3bpJ8KKED49DJxZ3F09sjpsq7gxyFVQruxI+M9Gpq3kbWj
+G740uN2Y/P6Zv0xs0kMyu3UoTfqmVMpXnaAINbYhAHJg/LqJfwlUwwenxRkkxaNangAAAABJRU5E
+rkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <g
+       id="g4221">
+      <path
+         sodipodi:nodetypes="ccssscsccsszcc"
+         inkscape:connector-curvature="0"
+         id="path7582"
+         d="m 5.5000007,1038.7178 0,-1.4385 c 0,0 0.2030217,-0.8491 1.2113028,-0.1297 1.0082813,0.7193 2.1919159,1.8781 2.3672696,2.1977 0.1753525,0.3197 0.9206039,0.8791 -0.087678,1.7583 -1.0082811,0.879 -2.1042395,1.798 -2.1042395,1.798 0,0 -1.3866564,1.4086 -1.3866564,0.1695 l 0,-1.2109 c -1.649686,-0.033 -1.7527346,0.9812 -3.3800406,1.9981 -0.4029788,0.1131 -0.6199673,-1.9778 -0.6199673,-2.3734 0,-0.3955 0.1733855,-1.1246 0.7129624,-1.78 0.2911803,-0.3536 0.9984659,-0.8639 1.5189201,-0.9944 0.5204541,-0.1305 1.7681254,0.1497 1.7681254,0.1497 z"
+         style="fill:url(#linearGradient4873);fill-opacity:1;stroke:url(#linearGradient4875);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602"
+         d="m 6.0176775,1038.1899 0,-0.5395 c 0,0 -0.110485,-0.3397 0.220971,-0.2198 0.331456,0.1199 0.972272,0.5994 1.038563,0.6993 0.06629,0.1 0.751301,0.5394 0.596622,0.7392 -0.15468,0.1999 -1.458408,0.06 -1.458408,0.06 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="g4280"
+       transform="translate(-9.999967,1.1757519e-5)">
+      <path
+         sodipodi:nodetypes="ccssscsccsszcc"
+         inkscape:connector-curvature="0"
+         id="path7582-5"
+         d="m 20.499955,1049.005 0,1.4385 c 0,0 -0.203021,0.8491 -1.211302,0.1297 -1.008282,-0.7193 -2.191916,-1.8781 -2.36727,-2.1977 -0.175353,-0.3197 -0.920604,-0.8791 0.08768,-1.7583 1.008281,-0.879 2.104239,-1.798 2.104239,-1.798 0,0 1.386657,-1.4086 1.386657,-0.1695 l 0,1.2109 c 1.649686,0.033 1.752734,-0.9812 3.38004,-1.9981 0.402979,-0.1131 0.619968,1.9778 0.619968,2.3734 0,0.3955 -0.173386,1.1246 -0.712963,1.78 -0.29118,0.3536 -0.998466,0.8639 -1.51892,0.9944 -0.520454,0.1305 -1.768125,-0.1497 -1.768125,-0.1497 z"
+         style="fill:url(#linearGradient4262);fill-opacity:1;stroke:url(#linearGradient4264);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602-4"
+         d="m 19.958224,1045.7682 0,-0.5395 c 0,0 0.1105,-0.3397 -0.221,-0.2198 -0.3314,0.1199 -0.9722,0.5994 -1.0385,0.6993 -0.066,0.1 -0.7513,0.5394 -0.5966,0.7392 0.1546,0.1999 1.4584,0.06 1.4584,0.06 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.sdk/icons/obj/profile_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk/icons/obj/profile_obj.svg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="profile_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17410">
+      <stop
+         style="stop-color:#e0ebf6;stop-opacity:1;"
+         offset="0"
+         id="stop17412" />
+      <stop
+         style="stop-color:#f3f5f6;stop-opacity:1"
+         offset="1"
+         id="stop17414" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17159">
+      <stop
+         style="stop-color:#ffeece;stop-opacity:1"
+         offset="0"
+         id="stop17161" />
+      <stop
+         style="stop-color:#e1eaba;stop-opacity:1"
+         offset="1"
+         id="stop17163" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17410"
+       id="linearGradient17441"
+       gradientUnits="userSpaceOnUse"
+       x1="-9.733428"
+       y1="12.635066"
+       x2="-3.9386158"
+       y2="6.8402538" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17159"
+       id="linearGradient17443"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.59076155,0.59076155,-0.59076155,0.59076155,17.040411,1049.6082)"
+       x1="-20.742412"
+       y1="7.9916593"
+       x2="-10.422931"
+       y2="7.9916593" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.063994"
+     inkscape:cx="8.506094"
+     inkscape:cy="7.4696588"
+     inkscape:document-units="px"
+     inkscape:current-layer="g17418"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5126" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline;fill:none"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="matrix(0.8261236,0,0,0.8261236,1.7832208,183.40446)">
+      <g
+         transform="matrix(1.2065384,0,0,1.2065384,-22.98457,-221.37405)"
+         id="g17594"
+         style="fill:none">
+        <g
+           id="g17418"
+           transform="matrix(0.96836657,0,0,0.96836657,20.738144,33.659982)">
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:url(#linearGradient17441);fill-opacity:1;stroke:#3f7fbf;stroke-width:0.5091278;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-5"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(1.0450409,-1.0450409,1.0450409,1.0450409,2.1256839,1029.9689)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14"
+             d="m 11.53513,1045.8134 c 0.07294,0.9455 0.07325,1.9032 9.05e-4,2.8489 l -2.3011454,-1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2"
+             d="m -1.0914354,1048.6741 c -0.07294,-0.9455 -0.07325,-1.9032 -9.07e-4,-2.849 l 2.301146,1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3"
+             d="m 6.6521976,1053.557 c -0.9455,0.073 -1.9032,0.073 -2.8489,9e-4 l 1.4186,-2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2"
+             d="m 3.7914976,1040.9305 c 0.9455,-0.073 1.9032,-0.073 2.849,-9e-4 l -1.4186,2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-2"
+             d="m 10.697423,1050.6965 c -0.616993,0.7202 -1.2939698,1.3976 -2.013837,2.0151 l -0.6240538,-2.6302 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-1"
+             d="m -0.2537278,1043.791 c 0.61699309,-0.7202 1.2939701,-1.3976 2.0139059,-2.0152 l 0.6240542,2.6303 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3-6"
+             d="m 1.7691159,1052.7193 c -0.7201883,-0.6169 -1.39738442,-1.2941 -2.0151129,-2.0138 l 2.6302251,-0.6241 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2-8"
+             d="m 8.6745793,1041.7682 c 0.7201883,0.6169 1.3973847,1.2941 2.0151837,2.0139 l -2.6302252,0.624 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:#1d4984;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-76"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(0.31739531,-0.31739531,0.31739531,0.31739531,4.2814936,1041.9971)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4"
+             d="m 11.535129,1046.4091 c 0.07294,0.5517 0.07325,1.1106 9.06e-4,1.6624 l -2.3011454,-0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5"
+             d="m -1.0914359,1048.0784 c -0.072942,-0.5517 -0.073247,-1.1106 -9.07e-4,-1.6625 l 2.3011463,0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51"
+             d="m 6.0564977,1053.557 c -0.5517,0.073 -1.1106,0.073 -1.6624,9e-4 l 0.8278,-2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7"
+             d="m 4.3871977,1040.9305 c 0.5517,-0.073 1.1106,-0.073 1.6624,-9e-4 l -0.8277,2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-1"
+             d="m 10.276129,1051.1178 c -0.3385343,0.4417 -0.7335171,0.8371 -1.1748536,1.1761 l -1.0418139,-2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-1"
+             d="m 0.16742503,1043.3698 c 0.33853445,-0.4416 0.73351722,-0.8371 1.17492367,-1.1762 l 1.0418137,2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51-5"
+             d="m 1.3478924,1052.2981 c -0.44172887,-0.3385 -0.83693085,-0.7337 -1.17612997,-1.1749 l 2.21246567,-1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7-2"
+             d="m 9.0958029,1042.1894 c 0.4417296,0.3385 0.8369322,0.7337 1.1761311,1.1749 l -2.2123961,1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:none;stroke:#3f7fbf;stroke-width:0.7180745;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(1.0202099,-1.0202099,1.0202099,1.0202099,2.1992508,1030.3794)" />
+          <path
+             sodipodi:nodetypes="cccccssc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-7"
+             d="m 6.0190516,1046.4513 -4.6356786,-3.9985 -1.80221867,-0.8517 0.85667548,1.7973 4.00338379,4.6307 c 0.2002055,0.2002 0.4771321,0.3237 0.7840021,0.3237 0.61367,0 1.1076548,-0.494 1.1076828,-1.1077 -5.64e-5,-0.3068 -0.1127546,-0.5927 -0.3138469,-0.7938 z"
+             style="color:#000000;fill:url(#linearGradient17443);fill-opacity:1;stroke:#4d607b;stroke-width:0.80260861;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <image
+             y="1038.406"
+             x="14.021823"
+             id="image4444"
+             xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAjhJREFU
+OI2lk09Ik3EYxz+LaFArCGHgQHxFUXBDAqGIDluxi4Qh1WHRYa8QhB0shru4gwtch5TBIOgSbBKh
+F20EHqrBu6A/iAkxVNiYNDVUxnRQ4weCvk+H5WzUpXwuv9/l+/D9PM/3sYgIR6ljR1IDxw8+Ho8u
+94fv4uywU9oThp9/o1FlUA4XJzcWsXZ2MXy5ifbmVsvvDSwHCC/ffJL45CwAAX8baBoNykZoLEkk
+2MdCsUIiDZoGCd1Ta1JDcHbYAXgVvUF0Ik85Z6VFcwLQojm5ef4CYR123qXQE2n5o0FpTwj427gW
+mGY62kd8cpa3778Q8LdhCohA9GGK634vhQLkVlekDsETTktYh3LOSnxylhfjV7k9VEUaD/djb3DU
+uJOf50gXqig1B40qQ4Oy4b54jv5bVfGzcS8A3oEpitsbmAKmQLfdxu5yph5BOVyExpLogxHOnsgC
+cGcoxZPHbi65TuMdmMIU0AcjhMaSKIerKhQRRARfMCaZpXnZLCvZ2lGSLeSlqWdUfMGYNPWMyszr
+j7K5o2SrrCSzNC++YExE5NCBtbOLhWKFfRP2BU6dcZB66uPD4g9iD67g7LBjCuybsFCsYO3sqneQ
+LeTFPWKI8dWQXj0kayUlayUl67/etZKSXj0kccMQ94gh2UK+3kF7c6tF0w5XdTCwe0OR6hpNCIx4
+mZlIoWnUElmLMlTXooMk0gBzdNttAHwvLh0m0e2tS6Llb9eYW12RR8Y6u8v/cAv/Wz8BBiUqWhPx
+5/kAAAAASUVORK5CYII=
+"
+             style="image-rendering:optimizeSpeed"
+             preserveAspectRatio="none"
+             height="16.576546"
+             width="16.576546" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui.sdk/plugin.xml
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk/plugin.xml
@@ -79,7 +79,7 @@
                   commandId="org.eclipse.equinox.p2.ui.sdk.update"
             	  mnemonic="%Update.command.mnemonic"
                   id="org.eclipse.equinox.p2.ui.sdk.update"
-                  icon="icons/obj/iu_update_obj.png">
+                  icon="icons/obj/iu_update_obj.svg">
             </command>
 
       </menuContribution>
@@ -89,7 +89,7 @@
                   commandId="org.eclipse.equinox.p2.ui.sdk.install"
             	  mnemonic="%Install.command.mnemonic"
                   id="org.eclipse.equinox.p2.ui.sdk.install"
-                  icon="icons/obj/iu_obj.png">
+                  icon="icons/obj/iu_obj.svg">
             </command>
 
       </menuContribution>

--- a/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
@@ -80,3 +80,4 @@ Service-Component: OSGI-INF/repositoryTracker_component.xml, OSGI-INF/serviceui.
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.equinox.p2.ui
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/artifact_repo_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/artifact_repo_obj.svg
@@ -1,0 +1,444 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="artifact_repo_obj.svg"
+   inkscape:export-filename="/Users/d026503/Documents/Icons/sapgui_obj/sapgui_obj.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4457">
+      <stop
+         style="stop-color:#efbf59;stop-opacity:1"
+         offset="0"
+         id="stop4459" />
+      <stop
+         id="stop4461"
+         offset="0.17353664"
+         style="stop-color:#f0c83b;stop-opacity:1" />
+      <stop
+         id="stop4463"
+         offset="0.34707329"
+         style="stop-color:#fdfabf;stop-opacity:1" />
+      <stop
+         id="stop4465"
+         offset="0.5"
+         style="stop-color:#fbf0a1;stop-opacity:1" />
+      <stop
+         style="stop-color:#f6e057;stop-opacity:1"
+         offset="0.63836575"
+         id="stop4467" />
+      <stop
+         id="stop4469"
+         offset="0.81918287"
+         style="stop-color:#f2b11f;stop-opacity:1" />
+      <stop
+         style="stop-color:#f6a81d;stop-opacity:1"
+         offset="1"
+         id="stop4471" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4371">
+      <stop
+         style="stop-color:#a6661f;stop-opacity:1"
+         offset="0"
+         id="stop4373" />
+      <stop
+         style="stop-color:#d2a40f;stop-opacity:1"
+         offset="1"
+         id="stop4375" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4355">
+      <stop
+         id="stop4357"
+         offset="0"
+         style="stop-color:#fadd5a;stop-opacity:1" />
+      <stop
+         style="stop-color:#efbf59;stop-opacity:1"
+         offset="0.17353664"
+         id="stop4359" />
+      <stop
+         style="stop-color:#f9e1b6;stop-opacity:1"
+         offset="0.34707329"
+         id="stop4361" />
+      <stop
+         style="stop-color:#faeed1;stop-opacity:1"
+         offset="0.5"
+         id="stop4363" />
+      <stop
+         id="stop4365"
+         offset="0.63836575"
+         style="stop-color:#ffff7a;stop-opacity:1" />
+      <stop
+         style="stop-color:#fee134;stop-opacity:1"
+         offset="0.81918287"
+         id="stop4367" />
+      <stop
+         id="stop4369"
+         offset="1"
+         style="stop-color:#fb9a09;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4347">
+      <stop
+         style="stop-color:#e6970d;stop-opacity:1"
+         offset="0"
+         id="stop4349" />
+      <stop
+         style="stop-color:#c4870c;stop-opacity:1"
+         offset="1"
+         id="stop4351" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4294">
+      <stop
+         id="stop4296"
+         offset="0"
+         style="stop-color:#eacc8c;stop-opacity:1" />
+      <stop
+         style="stop-color:#efe1c9;stop-opacity:1"
+         offset="0.17353664"
+         id="stop4298" />
+      <stop
+         style="stop-color:#f3f3f5;stop-opacity:1"
+         offset="0.34707329"
+         id="stop4300" />
+      <stop
+         style="stop-color:#f3f3f5;stop-opacity:1"
+         offset="0.5"
+         id="stop4302" />
+      <stop
+         id="stop4304"
+         offset="0.63836575"
+         style="stop-color:#e9e9cb;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7e1b4;stop-opacity:1"
+         offset="0.81918287"
+         id="stop4306" />
+      <stop
+         id="stop4308"
+         offset="1"
+         style="stop-color:#e7cf9a;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509" />
+      <stop
+         id="stop10511"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-4-4-4-6-2">
+      <stop
+         id="stop11150-4-72-3-9-7"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-9-0-7-3-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-3-2-6-1-7">
+      <stop
+         id="stop11150-7-5-9-3-8-2"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-4-35-5-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-7-5-30-1-1-4">
+      <stop
+         id="stop11150-9-6-9-5-6-9"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-6-7-6-3-3-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient11146-8-7-5-7-5-6-8">
+      <stop
+         id="stop11150-7-8-3-8-7-0-6"
+         offset="0"
+         style="stop-color:#faefba;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e6542;stop-opacity:1"
+         offset="1"
+         id="stop11152-8-8-6-3-2-5-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10507-2">
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="0"
+         id="stop10509-4" />
+      <stop
+         id="stop10511-2"
+         offset="0.18181793"
+         style="stop-color:#9e7058;stop-opacity:1" />
+      <stop
+         id="stop10513-9"
+         offset="0.36363617"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10515-0"
+         offset="0.49999985"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         id="stop10517-9"
+         offset="0.63636351"
+         style="stop-color:#794f40;stop-opacity:1" />
+      <stop
+         style="stop-color:#9e7058;stop-opacity:1"
+         offset="0.81818175"
+         id="stop10519-2" />
+      <stop
+         style="stop-color:#5f392d;stop-opacity:1"
+         offset="1"
+         id="stop10522-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4794-9">
+      <stop
+         style="stop-color:#3a9ed6;stop-opacity:1"
+         offset="0"
+         id="stop4796-8" />
+      <stop
+         id="stop4802-2"
+         offset="0.38869566"
+         style="stop-color:#2692d1;stop-opacity:1" />
+      <stop
+         style="stop-color:#3a9ed6;stop-opacity:1"
+         offset="1"
+         id="stop4798-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4695-9">
+      <stop
+         style="stop-color:#ffc42e;stop-opacity:1"
+         offset="0"
+         id="stop4697-8" />
+      <stop
+         id="stop4719-3"
+         offset="0.17353664"
+         style="stop-color:#ffcd49;stop-opacity:1" />
+      <stop
+         id="stop4713-8"
+         offset="0.34707329"
+         style="stop-color:#ffe66d;stop-opacity:1" />
+      <stop
+         id="stop4711-6"
+         offset="0.5"
+         style="stop-color:#fff1ae;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffe56c;stop-opacity:1"
+         offset="0.63836575"
+         id="stop4715-9" />
+      <stop
+         id="stop4717-8"
+         offset="0.81918287"
+         style="stop-color:#fdd771;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffc42e;stop-opacity:1"
+         offset="1"
+         id="stop4699-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4347"
+       id="linearGradient4353-6-8"
+       x1="-8.1449289"
+       y1="1055.5972"
+       x2="-8.0524807"
+       y2="1052.5642"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1578466,0,0,1.2556724,17.730739,-284.16504)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4371"
+       id="linearGradient4377-6-9"
+       x1="3.5805521"
+       y1="1063.3384"
+       x2="3.4927168"
+       y2="1052.5967"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1431743,0,0,1.3001921,3.9273029,-331.06196)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4457"
+       id="linearGradient4331-6-9-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31514318,0,0,0.28028373,-207.40147,915.23296)"
+       x1="673.60974"
+       y1="460.61569"
+       x2="696.68384"
+       y2="460.61569" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="38.23371"
+     inkscape:cx="8.0000003"
+     inkscape:cy="8.4997792"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="false"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:snap-bbox-edge-midpoints="false"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-others="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4304"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAU1JREFU
+OI2lk09LAlEUxX9vngxDplYE7foDLSIKKggKovoE0aK2fcE20SeQahFEbWZTS7WssHI0ZUyd91o4
+mfPHCenChffOPZxz7+NdobXmP5GKA6/PD3XnsQQpiepqvFaHTqNLbm2RrYMzMcgV4Q7yp7t6Z66K
+yi0g54/QboVO7Y52tYhRLHH7Ncv+8UVfxAi7mw0FhgDPjW25dvmaPEKtbPCsykxuW5itKzznBbd8
+T7NQRdp1srnVZAHtQXZlCXN6E2mtY0xUQGSQY0WMdAlugvzICCKCaD/9ugi+WVTgh6ABBIigQDhi
+BMKIGk3AEIOw9s+yX5fyjxFA8Pu2nk9JBcvJAqCV8N2V7y7jaMCQr+zYNqlMHdOq4zkfuE8PNAtv
+SPuT2ruV3MHU8sxQNwB3Ix24R3YBesukHQchQGuFanu9HLfYO8knL9Oo8Q0Ap4CWom9IWwAAAABJ
+RU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <g
+       style="display:inline;fill:#ffffff;stroke:#ffffff"
+       transform="matrix(0.33025864,0,0,0.33025864,-148.65244,917.1459)"
+       id="g14104" />
+    <g
+       mask="none"
+       id="g6258"
+       style="display:inline"
+       transform="matrix(0.33025864,0,0,0.33025864,-148.65244,917.1459)" />
+    <path
+       sodipodi:nodetypes="sccsccs"
+       inkscape:connector-curvature="0"
+       id="path3868-1-3-3-4-1"
+       d="M 8.4823509,1037.8068 C 5.9921973,1037.8068 4,1038.477 4,1039.3136 l 0,10.0447 c 0,0.8367 1.9921973,1.507 4.4823509,1.507 2.4901581,0 4.5176491,-0.6703 4.5176491,-1.507 l 0,-10.0447 c 0,-0.8366 -2.027491,-1.5068 -4.5176491,-1.5068 z"
+       style="display:inline;fill:url(#linearGradient4331-6-9-0);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="sccsccs"
+       inkscape:connector-curvature="0"
+       id="path3868-1-4-6-9-1"
+       d="m 8.4843081,1037.8612 c -2.2140523,0 -3.985361,0.6672 -3.985361,1.4999 l 0,10.0016 c 0,0.8331 1.7713087,1.5006 3.985361,1.5006 2.2140559,0 4.0167459,-0.6675 4.0167459,-1.5006 l 0,-10.0016 c 0,-0.8327 -1.80269,-1.4999 -4.0167459,-1.4999 z"
+       style="display:inline;fill:none;stroke:url(#linearGradient4377-6-9);stroke-width:0.99789387;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <ellipse
+       ry="1.4424163"
+       rx="3.9424307"
+       cy="1039.3622"
+       cx="8.5"
+       id="path3868-67-2-9"
+       style="display:inline;fill:none;stroke:url(#linearGradient4353-6-8);stroke-width:1.11513841;stroke-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2" />
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/category_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/category_obj.svg
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="category_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4177">
+      <stop
+         style="stop-color:#5d7bae;stop-opacity:1"
+         offset="0"
+         id="stop4179" />
+      <stop
+         style="stop-color:#7593c1;stop-opacity:1"
+         offset="1"
+         id="stop4181" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4169">
+      <stop
+         style="stop-color:#a77e1c;stop-opacity:1"
+         offset="0"
+         id="stop4171" />
+      <stop
+         style="stop-color:#bb9826;stop-opacity:1"
+         offset="1"
+         id="stop4173" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4161">
+      <stop
+         style="stop-color:#679989;stop-opacity:1"
+         offset="0"
+         id="stop4163" />
+      <stop
+         style="stop-color:#7eb89d;stop-opacity:1"
+         offset="1"
+         id="stop4165" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4154">
+      <stop
+         style="stop-color:#b7d1da;stop-opacity:1"
+         offset="0"
+         id="stop4156" />
+      <stop
+         style="stop-color:#e3ebf2;stop-opacity:1"
+         offset="1"
+         id="stop4158" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4146">
+      <stop
+         style="stop-color:#fef5da;stop-opacity:1;"
+         offset="0"
+         id="stop4148" />
+      <stop
+         style="stop-color:#f2c17b;stop-opacity:1"
+         offset="1"
+         id="stop4150" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4138">
+      <stop
+         style="stop-color:#e6e9a0;stop-opacity:1;"
+         offset="0"
+         id="stop4140" />
+      <stop
+         style="stop-color:#b0c994;stop-opacity:1"
+         offset="1"
+         id="stop4142" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4138"
+       id="linearGradient4144"
+       x1="-2.8482134"
+       y1="1039.3826"
+       x2="-6.4833174"
+       y2="1039.3895"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9900552,0,0,1.0181818,-1040.9674,-1066.6974)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4146"
+       id="linearGradient4152"
+       x1="-3.1607134"
+       y1="1044.2325"
+       x2="-6.5167546"
+       y2="1044.3405"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98925048,0,0,1.0159748,-1040.9697,-1064.438)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4154"
+       id="linearGradient4160"
+       x1="-6.2849989"
+       y1="1049.3586"
+       x2="-3.0267849"
+       y2="1049.2792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98898333,0,0,1.0152424,-1040.9704,-1063.7492)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4161"
+       id="linearGradient4167"
+       x1="-7.3195014"
+       y1="1038.4507"
+       x2="1.5850949"
+       y2="1038.4636"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9900552,0,0,1.0181818,-1040.9674,-1066.6974)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4169"
+       id="linearGradient4175"
+       x1="-7.3483715"
+       y1="1043.2987"
+       x2="0.64690268"
+       y2="1043.3798"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98925048,0,0,1.0159748,-1040.9697,-1064.438)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4177"
+       id="linearGradient4183"
+       x1="-7.3477387"
+       y1="1048.321"
+       x2="1.0305251"
+       y2="1048.4708"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98898333,0,0,1.0152424,-1040.9704,-1063.7492)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="69.591725"
+     inkscape:cx="16.468793"
+     inkscape:cy="7.9941582"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4218"
+     showgrid="true"
+     units="px"
+     inkscape:snap-others="false"
+     inkscape:snap-grids="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3336" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4218"
+       transform="translate(11.428571,-2.1875007e-7)">
+      <image
+         y="1036.368"
+         x="4.5090156"
+         id="image4255"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAVNJREFU OI3V07FKA0EQgOF/Y17AIrVIEBUVSRAFLRQjWIsiFqZPlRewtvUlBIugjdgEtLCxPJDTzvRKClHR xOzMjsXdaWIbG7fZYYb5ZndhnZkxzMoN1f0XQB6gEV3bfbsFwEyhyG551d1eHli7dQpAobjD/Mah u7qJrRk9A7BZHqWyPOdyAPHjA7XSCLXSCPHTAwDt1imV6gWV6gUZ1Iyeqe+VqO+VyKA8gKriNYcZ qAgAIRiELlgapzmvATBCCH2AKF2fJ4mTQhDD/BvOOYImgIjwmQ4Q6QPEKx2fJNRrsmvA5HUAFQ10 vMfhkBTKZ00fPU0KGSAG8vITA+KFrs9O0A+I0vEG2Pc0lQD+BesHROl4wWGI6O83SBs1u4KBvg+g IkJPBLDBN1gYm+E8ugNgcXwWgImlfc6Oj8AckytVALbWpjhpxABsr08D4P7/Xxga+AKmQd3c/21Y UAAAAABJRU5ErkJggg== "
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="16"
+         width="16" />
+      <rect
+         ry="0.37885901"
+         rx="0.37885901"
+         y="-9.9285707"
+         x="-1047.8622"
+         height="3"
+         width="8"
+         id="rect4186"
+         style="opacity:1;fill:url(#linearGradient4144);fill-opacity:1;stroke:url(#linearGradient4167);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         transform="matrix(0,-1,1,0,0,0)" />
+      <rect
+         ry="0.38411137"
+         rx="0.37855414"
+         y="-4.9253197"
+         x="-1047.859"
+         height="2.9934971"
+         width="7.9934974"
+         id="rect4186-4"
+         style="opacity:1;fill:url(#linearGradient4152);fill-opacity:1;stroke:url(#linearGradient4175);stroke-width:1.00650275;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         transform="matrix(0,-1,1,0,0,0)" />
+      <rect
+         ry="0.38586339"
+         rx="0.37845296"
+         y="0.075759336"
+         x="-1047.8579"
+         height="2.9913392"
+         width="7.9913392"
+         id="rect4186-4-0"
+         style="opacity:1;fill:url(#linearGradient4160);fill-opacity:1;stroke:url(#linearGradient4183);stroke-width:1.00866067;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         transform="matrix(0,-1,1,0,0,0)" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/copy_edit.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/copy_edit.svg
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="copy_edit.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="fold-bg-7">
+      <stop
+         style="stop-color:#d8bc68;stop-opacity:1;"
+         offset="0"
+         id="fold-bg-stop0" />
+      <stop
+         style="stop-color:#fff0c2;stop-opacity:1;"
+         offset="1"
+         id="fold-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="frontpaper-bg-2">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="frontpaper-bg-stop0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="frontpaper-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="frontpaper-stroke-1">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="frontpaper-stroke-stop0" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="frontpaper-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="back-bg-0">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="back-bg-stop0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="back-bg-stop1" />
+    </linearGradient>
+    <linearGradient
+       id="back-stroke-9">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="back-stroke-stop0" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="back-stroke-stop1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#back-bg-0"
+       id="linearGradient5568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7089396,0,0,1.6630222,-8.0201048,-693.2724)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#back-stroke-9"
+       id="linearGradient5570"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7089396,0,0,1.6630222,-8.0201048,-698.4173)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#frontpaper-bg-2"
+       id="linearGradient4279"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-4.9210482,-731.7352)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#frontpaper-stroke-1"
+       id="linearGradient4281"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-4.9210482,-736.99747)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254833"
+     inkscape:cx="4.3183483"
+     inkscape:cy="7.4077604"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1409"
+     inkscape:window-height="977"
+     inkscape:window-x="622"
+     inkscape:window-y="413"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4250" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       id="backpaper"
+       d="m 1.4964779,1037.8555 0,12.013 8.9390701,0 0,-8.5938 -1.8866429,-0.031 c -0.045,0 -0.03125,-3.388 -0.03125,-3.388 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient5568);fill-opacity:1;stroke:url(#linearGradient5570);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate">
+      <title
+         id="title3444">backpaper</title>
+    </path>
+    <path
+       id="page-lines-back"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7795b6;fill-opacity:1;stroke:none;stroke-width:0.99252546;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 2.9988794,1049.3833 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9991 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9969 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9991 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-2.0054 3.6479367,0 0,-1.0155 -3.6479367,0 z"
+       inkscape:connector-curvature="0">
+      <title
+         id="title3384-9">page-lines-back</title>
+    </path>
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4279);fill-opacity:1;stroke:url(#linearGradient4281);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 4.5239373,1038.8424 0,13.0137 9.9557807,0 0.01563,-9.9733 -2.950551,-0.023 0.02422,-3.0176 z"
+       id="frontpaper"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc">
+      <title
+         id="title3291">frontpaper</title>
+    </path>
+    <path
+       id="page-lines"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7795b6;fill-opacity:1;stroke:none;stroke-width:0.99252546;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 6.006692,1050.3755 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9991 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9969 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-1.9991 5.990228,0 0,-1.0156 -5.990228,0 z m 0,-2.0054 3.6479367,0 0,-1.0155 -3.6479367,0 z"
+       inkscape:connector-curvature="0">
+      <title
+         id="title3384">page-lines</title>
+    </path>
+    <path
+       style="fill:#d8bc68;fill-opacity:1;stroke:none"
+       d="m 12.033136,1038.3884 2.941491,3.0035 -2.965778,0 z"
+       id="fold"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc">
+      <title
+         id="title3222">fold</title>
+    </path>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_add.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_add.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_add.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5591-4">
+      <stop
+         style="stop-color:#e0e566;stop-opacity:1;"
+         offset="0"
+         id="stop5593-0" />
+      <stop
+         style="stop-color:#82c448;stop-opacity:1;"
+         offset="1"
+         id="stop5595-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5583-2">
+      <stop
+         style="stop-color:#426e4a;stop-opacity:1;"
+         offset="0"
+         id="stop5585-3" />
+      <stop
+         style="stop-color:#669f71;stop-opacity:1;"
+         offset="1"
+         id="stop5587-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.9388757,0,0,2.0202578,3.680533,1029.0766)"
+       y2="10.041095"
+       x2="2.2278204"
+       y1="7.5661631"
+       x1="2.2278204"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5618"
+       xlink:href="#linearGradient5591-4"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="matrix(1.9388757,0,0,2.0202578,3.680533,1029.0766)"
+       y2="6.5761905"
+       x2="2.2278204"
+       y1="10.041095"
+       x1="2.2278204"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5620"
+       xlink:href="#linearGradient5583-2"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="51.574603"
+     inkscape:cx="6.9415782"
+     inkscape:cy="7.1700733"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3971" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="display:inline;fill:url(#linearGradient5618);fill-opacity:1;stroke:url(#linearGradient5620);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.5,1038.8622 3,0 0,4 3.999999,0 0,3 -3.999999,0 0,4 -3,0 6e-7,-3.9997 -4.0000001,0 0,-3 4.0000001,0 z"
+       id="path5581"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4202"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAQ1JREFU
+OI2lk7FKA1EQRc+IRRDJ12QbsfEL7NII6jcEbCRNIFhYWFsqIoip/AJBglU+REghiprsztsdi7fZ
+uJIRdae6w8xc7ps7T8yMJrHWaBpY9wqHd/2atIvdofxZwSCZMkim/1OQh4IsGAgUoXAJXAVBQ4X1
+C/4esnChe9UzM0MQDOhvvdYah4/tWj7aP5PaE3SuHG2/xcSE9yzKxyJlL3lmsdXT8WZFVBFkaeDp
+RUsCwwTEAImKhKUpmuoKgnnG+bhVTsFe5yMKKOvXk42YiADLnYh3iTsnB9btzADhdtLi/vhy5R24
+NoY0MFMDCjT1XfBtDHmFc829tp8OKefmAaIVPoG7g99G49/4CQdgcbIHUwIgAAAAAElFTkSuQmCC
+
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_disabled_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_disabled_obj.svg
@@ -1,0 +1,768 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="iu_disabled_obj.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#b6b6b6;stop-opacity:1" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#989898;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#b6b6b6;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-148.40713,-87.106181)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4284"
+       id="linearGradient10790-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33571488,0,0,0.59088033,378.76626,66.374404)"
+       x1="305"
+       y1="513.87781"
+       x2="305"
+       y2="545.35248" />
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         id="stop4286"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:0" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999967"
+         id="stop4288" />
+      <stop
+         id="stop4290"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10790-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,175.7687,-135.72514)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-9"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-0"
+       id="linearGradient10792-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,175.7687,-135.72514)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-0">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10786-1"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818"
+       gradientTransform="matrix(1.0391435,0,0,0.59796602,163.7026,66.310928)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-9"
+       id="linearGradient10782-3"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,178.81671,-139.61919)" />
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-3" />
+      <stop
+         id="stop10422-8"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-3"
+       id="linearGradient10784-2"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,178.81671,-139.61919)" />
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         id="stop10434-4"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-2" />
+      <stop
+         id="stop10438-9"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-90"
+       id="linearGradient10778-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="matrix(1.0765606,0,0,1.061954,151.89304,-176.68416)" />
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-0" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-96"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-8"
+       id="linearGradient10774-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.062525,0,0,1.0891236,163.76228,-191.1002)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         id="stop10750-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-8" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-8" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-7"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient10770-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0387443,0,0,1.1623096,171.67815,-229.42387)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-7" />
+      <stop
+         id="stop10456-4-1-5-3"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-4" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4485"
+       x="-0.100931"
+       y="-0.091065558"
+       width="1.201862"
+       height="1.1821311">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4487" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4489"
+       x="-0.045429614"
+       y="-0.062483285"
+       width="1.0908592"
+       height="1.1247113">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4491" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4493"
+       x="0"
+       y="-inf"
+       width="1"
+       height="inf">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4495" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4497"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4499" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4501"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4503" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4505"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4507" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4509"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4511" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4513"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4515" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4517"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4519" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4521"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4523" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4525"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4527" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4529"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4531" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4533"
+       x="-0.068962558"
+       y="-0.080227087"
+       width="1.1379251"
+       height="1.1604542">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4535" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4537"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4539" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4541"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4543" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4545"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4547" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4549"
+       x="-0.16745919"
+       y="-0.050075785"
+       width="1.3349184"
+       height="1.1001516">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4551" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4553"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4555" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4557"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4559" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4561"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4563" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.499676"
+     inkscape:cx="18.877111"
+     inkscape:cy="7.2154565"
+     inkscape:document-units="px"
+     inkscape:current-layer="g13862"
+     showgrid="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <rect
+         ry="3.1069043"
+         rx="3.1069043"
+         y="347.32736"
+         x="473.10382"
+         height="19.677061"
+         width="17.753738"
+         id="rect13693-3"
+         style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4485)" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="rect13693"
+         d="m 472.68093,354.495 33.22969,0 c 1.72122,0 3.1069,1.38903 3.1069,3.11442 l 0,13.39945 c 0,1.72538 -1.44501,2.66525 -3.1069,3.11442 l -33.22969,8.9812 c -1.66188,0.44917 -3.1069,-1.38903 -3.1069,-3.11442 l 0,-22.38065 c 0,-1.72539 1.38568,-3.11442 3.1069,-3.11442 z"
+         style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4489)" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10770-6);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4497)"
+         id="rect10007-0-74-2-7-6"
+         width="21.018066"
+         height="10.826942"
+         x="500.47601"
+         y="374.24786"
+         rx="0"
+         ry="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4501)"
+         d="m 509.4754,374.25254 0,3.5838 12.01134,0 0,-3.5838 -12.01134,0 z"
+         id="path4313-8-8"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4505)"
+         d="m 510.67013,374.23175 0,10.8213 3.63939,0 0,-10.8213 z"
+         id="path4313-8-8-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4509)"
+         d="m 521.45874,381.40617 -12.03934,0.1111 0.0351,3.58381 12.03934,-0.1111 -0.0351,-3.58381 z"
+         id="path4313-5-1-8"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10774-5);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4513)"
+         id="rect10007-0-74-2-7"
+         width="11.41908"
+         height="17.791901"
+         x="499.25452"
+         y="370.73755"
+         rx="0"
+         ry="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4517)"
+         d="m 510.75632,385.0251 -12.03934,0.1111 0.035,3.5838 12.03935,-0.1111 -0.0351,-3.5838 z"
+         id="path4313-5-1"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4521)"
+         d="m 510.72133,370.66192 -12.03935,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+         id="path4313-8"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10778-6);fill-opacity:1;stroke:none;stroke-width:1.50161433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4525)"
+         id="rect10007-0-74-2"
+         width="11.811058"
+         height="24.955921"
+         x="491.81702"
+         y="367.15549"
+         rx="0"
+         ry="0" />
+      <rect
+         style="display:inline;fill:#5079bc;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4529)"
+         id="rect10007-0"
+         width="13.428176"
+         height="17.908186"
+         x="478.51385"
+         y="370.66931"
+         rx="0"
+         ry="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10782-3);fill-opacity:1;stroke:url(#linearGradient10784-2);stroke-width:1.48636866;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4533)"
+         id="rect10007-0-7"
+         width="10.776635"
+         height="9.2635088"
+         x="468.54718"
+         y="374.93893"
+         rx="0"
+         ry="0" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10786-1);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4537)"
+         id="rect10007-0-74"
+         width="13.378973"
+         height="10.763388"
+         x="478.56305"
+         y="374.18103"
+         rx="0"
+         ry="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4541)"
+         d="m 503.55372,367.07095 -12.03935,0.1111 0.035,3.5838 12.03935,-0.11109 -0.0351,-3.58381 z"
+         id="path4313"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4545)"
+         d="m 503.57471,388.57378 -12.03934,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+         id="path4313-5"
+         inkscape:connector-curvature="0" />
+      <rect
+         ry="5.3502665"
+         style="display:inline;fill:url(#linearGradient10790-8);fill-opacity:1;stroke:url(#linearGradient10792-6);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4549)"
+         id="rect10007-6"
+         width="10.700533"
+         height="35.783813"
+         x="483.90643"
+         y="361.72815" />
+      <rect
+         style="display:inline;fill:url(#linearGradient10790-8-2);fill-opacity:1;stroke:none;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4553)"
+         id="rect10007-6-6"
+         width="3.5889285"
+         height="19.98802"
+         x="482.11456"
+         y="369.51785" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:0.64640886;fill-rule:evenodd;stroke:none;stroke-width:0.97351193px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter4557)"
+         d="m 503.58072,374.25075 0,10.78725 3.5848,0 0,-10.78725 z"
+         id="path4313-8-8-7-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_disabled_patch_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_disabled_patch_obj.svg
@@ -1,0 +1,661 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_disabled_patch_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4351">
+      <stop
+         style="stop-color:#d22939;stop-opacity:1"
+         offset="0"
+         id="stop4353" />
+      <stop
+         style="stop-color:#f13f53;stop-opacity:1"
+         offset="1"
+         id="stop4355" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4325">
+      <stop
+         style="stop-color:#d84e4e;stop-opacity:1"
+         offset="0"
+         id="stop4327" />
+      <stop
+         style="stop-color:#e6878f;stop-opacity:1"
+         offset="1"
+         id="stop4329" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#c48a4e;stop-opacity:1;" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#ad6c24;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-148.40713,-87.106181)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955"
+       id="linearGradient3945"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-147.48911,-87.252829)" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4284"
+       id="linearGradient10790-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33571488,0,0,0.59088033,378.76626,66.374404)"
+       x1="305"
+       y1="513.87781"
+       x2="305"
+       y2="545.35248" />
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         id="stop4286"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:0" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999967"
+         id="stop4288" />
+      <stop
+         id="stop4290"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10790-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,175.7687,-135.72514)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-9"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-0"
+       id="linearGradient10792-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,175.7687,-135.72514)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-0">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10786-1"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818"
+       gradientTransform="matrix(1.0391435,0,0,0.59796602,163.7026,66.310928)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-9"
+       id="linearGradient10782-3"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,178.81671,-139.61919)" />
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-3" />
+      <stop
+         id="stop10422-8"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-3"
+       id="linearGradient10784-2"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,178.81671,-139.61919)" />
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         id="stop10434-4"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-2" />
+      <stop
+         id="stop10438-9"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-90"
+       id="linearGradient10778-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="matrix(1.0765606,0,0,1.061954,151.89304,-176.68416)" />
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-0" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-96"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-8"
+       id="linearGradient10774-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.062525,0,0,1.0891236,163.76228,-191.1002)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         id="stop10750-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-8" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-8" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-7"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient10770-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0387443,0,0,1.1623096,171.67815,-229.42387)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-7" />
+      <stop
+         id="stop10456-4-1-5-3"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4325"
+       id="linearGradient4331"
+       x1="514.31757"
+       y1="374.2059"
+       x2="514.31757"
+       y2="345.53546"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4351"
+       id="linearGradient4357"
+       x1="507.14996"
+       y1="370.6221"
+       x2="507.14996"
+       y2="349.11929"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4484">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4486" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4488">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4490" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4492">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4494" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4496">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4498" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter4500">
+      <feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix4502" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="50.690716"
+     inkscape:cx="13.271267"
+     inkscape:cy="8.0000036"
+     inkscape:document-units="px"
+     inkscape:current-layer="g13862"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <g
+         id="g4256"
+         style="filter:url(#filter4500)">
+        <rect
+           style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect13693-3"
+           width="17.753738"
+           height="19.677061"
+           x="473.10382"
+           y="347.32736"
+           rx="3.1069043"
+           ry="3.1069043" />
+        <path
+           style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 472.68093,354.495 33.22969,0 c 1.72122,0 3.1069,1.38903 3.1069,3.11442 l 0,13.39945 c 0,1.72538 -1.44501,2.66525 -3.1069,3.11442 l -33.22969,8.9812 c -1.66188,0.44917 -3.1069,-1.38903 -3.1069,-3.11442 l 0,-22.38065 c 0,-1.72539 1.38568,-3.11442 3.1069,-3.11442 z"
+           id="rect13693"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3945);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 471.31191,354.49499 23.78261,0"
+           id="path13797"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g4238"
+         style="filter:url(#filter4496)">
+        <rect
+           ry="0"
+           rx="0"
+           y="374.24786"
+           x="500.47601"
+           height="10.826942"
+           width="21.018066"
+           id="rect10007-0-74-2-7-6"
+           style="display:inline;fill:url(#linearGradient10770-6);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8-8"
+           d="m 509.4754,374.25254 0,3.5838 12.01134,0 0,-3.5838 -12.01134,0 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7"
+           d="m 510.67013,374.23175 0,10.8213 3.63939,0 0,-10.8213 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1-8"
+           d="m 521.45874,381.40617 -12.03934,0.1111 0.0351,3.58381 12.03934,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="370.73755"
+           x="499.25452"
+           height="17.791901"
+           width="11.41908"
+           id="rect10007-0-74-2-7"
+           style="display:inline;fill:url(#linearGradient10774-5);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1"
+           d="m 510.75632,385.0251 -12.03934,0.1111 0.035,3.5838 12.03935,-0.1111 -0.0351,-3.5838 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8"
+           d="m 510.72133,370.66192 -12.03935,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="367.15549"
+           x="491.81702"
+           height="24.955921"
+           width="11.811058"
+           id="rect10007-0-74-2"
+           style="display:inline;fill:url(#linearGradient10778-6);fill-opacity:1;stroke:none;stroke-width:1.50161433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="370.66931"
+           x="478.51385"
+           height="17.908186"
+           width="13.428176"
+           id="rect10007-0"
+           style="display:inline;fill:#5079bc;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="374.93893"
+           x="468.54718"
+           height="9.2635088"
+           width="10.776635"
+           id="rect10007-0-7"
+           style="display:inline;fill:url(#linearGradient10782-3);fill-opacity:1;stroke:url(#linearGradient10784-2);stroke-width:1.48636866;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="374.18103"
+           x="478.56305"
+           height="10.763388"
+           width="13.378973"
+           id="rect10007-0-74"
+           style="display:inline;fill:url(#linearGradient10786-1);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313"
+           d="m 503.55372,367.07095 -12.03935,0.1111 0.035,3.5838 12.03935,-0.11109 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5"
+           d="m 503.57471,388.57378 -12.03934,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           y="361.72815"
+           x="483.90643"
+           height="35.783813"
+           width="10.700533"
+           id="rect10007-6"
+           style="display:inline;fill:url(#linearGradient10790-8);fill-opacity:1;stroke:url(#linearGradient10792-6);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           ry="5.3502665" />
+        <rect
+           y="369.51785"
+           x="482.11456"
+           height="19.98802"
+           width="3.5889285"
+           id="rect10007-6-6"
+           style="display:inline;fill:url(#linearGradient10790-8-2);fill-opacity:1;stroke:none;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7-8"
+           d="m 503.58072,374.25075 0,10.78725 3.5848,0 0,-10.78725 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:0.64640886;fill-rule:evenodd;stroke:none;stroke-width:0.97351193px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      </g>
+      <rect
+         style="display:inline;opacity:0.756;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4492)"
+         id="rect4323-4"
+         width="28.67045"
+         height="28.670467"
+         x="491.0228"
+         y="347.32739" />
+      <rect
+         style="opacity:1;fill:#fffbf0;fill-opacity:1;stroke:url(#linearGradient4331);stroke-width:3.58380532;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4488)"
+         id="rect4323"
+         width="25.086651"
+         height="25.086649"
+         x="494.60663"
+         y="347.32736" />
+      <path
+         id="path4333-6"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4357);stroke-width:7.16761017;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter4484)"
+         d="m 507.14996,349.11928 0,21.50283 m -10.75142,-10.75142 21.50283,0" />
+      <image
+         y="345.53546"
+         x="525.06897"
+         id="image4473"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAbpJREFU
+OI2lk71uE0EUhT8jZyObwtOwFk9ASGN5q/AGLl144REciV85CoUfwFs6sCFuLPwKoXMVKreJ0iQp
+SbVmJaLZNVomXpulWGXYJY5A4khXmjNzz517z2gKZNDtdpMs7/V6Bdd1c3t3omXbyXK5zMXFxXmy
+1+9rvtPpJDudjuZ7/X5SBHj54nnS3t5mMpkQhiFXV98IgpBms8k8ju+8dB7HFAEMY51KRVCpiFyC
+EAKlFG9ev8rt3/AHZpV7qyoLIRgMBlxefkEpxSJe5OIGSqm0gz/FjuMghMAw1vm5XLB/cABAu90G
+0Pzt7m5aYM1YwzCMXKFSqQRAnLnxWl3f6rYAMJvN9FM5jgPAxsYjtrae4L5/t2pKjWJWBFC3LKae
+R6l8HwD76TPq9ToAURRRLpeRUur8WyZWTZNarUbVNJlOp3w6PNRnn4+OkFIyGo0IAkkQyLQD3/d1
+0lff5/zsDMuyAAjCEM/zAPgeRalQSkYfR79HGA6HhYxRCcDjzU1t3Hyemnd6cszpyTHu/gedrxdZ
+tGw7aTQaAIzHYx5WTYCcMGfiKvyIIr1eJfwrWradtGz7337i/+AX1AzauJ9AeZYAAAAASUVORK5C
+YII=
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="57.340881"
+         width="57.340881" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_downgraded.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_downgraded.svg
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_downgraded.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#f8e1a7;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#eccb7b;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.88889034,0.90909099,0,-940.92063,1037.5289)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="9.8777304"
+       y1="1047.141"
+       x2="10.352257"
+       y2="1043.776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.88889034,0.90909099,0,-940.92063,1037.5289)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.84375"
+     inkscape:cx="16.999998"
+     inkscape:cy="8.0000174"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4217"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAARklEQVR42mNgGLTgcKvZf3RMsgFv Tlf///FwORiPGkAvA9CjDd0AoqIUphGGYQaQ7BJshpAUDuiGkByIyIaQpRnZEJpmOgAr/NDIKDNq VgAAAABJRU5ErkJggg== "
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 3.5,1045.8622 3,0 0.00986,-5.9708 c 9.804e-4,-0.5937 0.3829541,-1.0292 0.990136,-1.0292 l 2,0 c 0.607091,0 1.009694,0.4063 1,1 l 4e-6,6 3,0 -5.000004,5 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsssscccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_info.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_info.svg
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="7"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_info.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5091">
+      <stop
+         style="stop-color:#c6852e;stop-opacity:1"
+         offset="0"
+         id="stop5093" />
+      <stop
+         style="stop-color:#e1a555;stop-opacity:1"
+         offset="1"
+         id="stop5095" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5081">
+      <stop
+         style="stop-color:#ffe296;stop-opacity:1"
+         offset="0"
+         id="stop5083" />
+      <stop
+         id="stop5089"
+         offset="0.5"
+         style="stop-color:#f8d880;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffcd3;stop-opacity:1"
+         offset="1"
+         id="stop5085" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5081"
+       id="linearGradient5087"
+       x1="3.3833356"
+       y1="7.0159616"
+       x2="3.3833356"
+       y2="0.98171616"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5091"
+       id="linearGradient5097"
+       x1="6.3885393"
+       y1="7.2369323"
+       x2="6.3885393"
+       y2="0.39338252"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#bbbbbb"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="59.3125"
+     inkscape:cx="6.7067301"
+     inkscape:cy="2.0545684"
+     inkscape:document-units="px"
+     inkscape:current-layer="g8472"
+     showgrid="true"
+     inkscape:window-width="1638"
+     inkscape:window-height="1174"
+     inkscape:window-x="398"
+     inkscape:window-y="172"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4146" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)">
+    <g
+       style="display:inline"
+       id="g8472"
+       transform="matrix(0.9346781,0,0,0.9346781,-14.571811,69.044514)">
+      <path
+         style="fill:url(#linearGradient5087);stroke:url(#linearGradient5097);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+         d="M 2.8125,0.90625 0.78125,5 C 0.17522066,6.0251238 0.58843406,7.4816983 1.71875,7.5 L 3,7.5 l 1,0 1.28125,0 C 6.4115665,7.4817738 6.8247794,6.0250615 6.21875,5 L 4.1875,0.90625 c -0.2942923,-0.55673837 -1.1188077,-0.46727236 -1.375,0 z"
+         id="path4292"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         transform="matrix(1.0698871,0,0,1.0698871,15.590192,1043.4798)" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#502800;fill-opacity:1;stroke:none"
+         id="path4253"
+         sodipodi:cx="3.484375"
+         sodipodi:cy="5.484375"
+         sodipodi:rx="0.625"
+         sodipodi:ry="0.625"
+         d="m 4.109375,5.484375 a 0.625,0.625 0 0 1 -0.625,0.625 0.625,0.625 0 0 1 -0.625,-0.625 0.625,0.625 0 0 1 0.625,-0.625 0.625,0.625 0 0 1 0.625,0.625 z"
+         transform="matrix(1.125929,0,0,1.125929,15.411638,1043.3738)" />
+      <path
+         style="fill:#502800;fill-opacity:1;stroke:none;display:inline"
+         d="m 19.350026,1045.5028 c -0.378471,0 -0.700512,0.3368 -0.700512,0.774 l 0.09137,1.4889 c 0,0.3887 0.272722,0.7037 0.609141,0.7037 0.336419,0 0.609139,-0.315 0.609139,-0.7037 l 0.06091,-1.4889 c 0,-0.4372 -0.291583,-0.774 -0.670056,-0.774 z"
+         id="path4253-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sccsccs" />
+      <image
+         y="1043.4797"
+         x="24.149288"
+         id="image4225"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAICAYAAAA1BOUGAAAABHNCSVQICAgIfAhkiAAAALhJREFU
+CJldyT0OwWAcgPGnb8PUoYlGFyqsPhZO4AYkLiCxmRxA7MIVWFxDwkJnFoOkHd6lTOIjRPwNKhG/
+5RkeRAQRkcifSDhrSeRPJAbfGc5aIs/Np/FUgBwWI9xqkUapjFstcliMAUQB3LTPr5teA2C2a/eB
+5TxIWjaV7IuUl8cwrhy3PorTHtsrcInO9IdLLtEZ2ysgpz1KBzuMhIOZztDpNjHTGVTCQQc7DL2a
+Sjgf8y9X7/EGjtBemt9BzeMAAAAASUVORK5CYII=
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="8.5590963"
+         width="7.4892092" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_notadd.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_notadd.svg
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_notadd.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4282">
+      <stop
+         style="stop-color:#b6bbaf;stop-opacity:1"
+         offset="0"
+         id="stop4284" />
+      <stop
+         style="stop-color:#cfd0c1;stop-opacity:1"
+         offset="1"
+         id="stop4286" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5591-4">
+      <stop
+         style="stop-color:#e0e566;stop-opacity:1;"
+         offset="0"
+         id="stop5593-0" />
+      <stop
+         style="stop-color:#c2c1c1;stop-opacity:1"
+         offset="1"
+         id="stop5595-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5583-2">
+      <stop
+         style="stop-color:#c2c1c1;stop-opacity:1"
+         offset="0"
+         id="stop5585-3" />
+      <stop
+         style="stop-color:#c2c1c1;stop-opacity:1"
+         offset="1"
+         id="stop5587-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.9388757,0,0,2.0202578,3.680533,1029.0766)"
+       y2="6.5761905"
+       x2="2.7435832"
+       y1="10.055841"
+       x1="2.742559"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5620"
+       xlink:href="#linearGradient5583-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4282"
+       id="linearGradient4288"
+       x1="6.9900699"
+       y1="1045.2262"
+       x2="7.058589"
+       y2="1042.828"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="67.133335"
+     inkscape:cx="17"
+     inkscape:cy="8.0000174"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3971" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="display:inline;fill:url(#linearGradient4288);fill-opacity:1;stroke:url(#linearGradient5620);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.5,1038.8622 3,0 0,4 3.999999,0 0,3 -3.999999,0 0,4 -3,0 6e-7,-3.9997 -4.0000001,0 0,-3 4.0000001,0 z"
+       id="path5581"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4279"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAKBJREFU
+OI21kmsKwjAQhL+EWgj1hfexh08vJIJEa5v4o7S6YmIkuBBYMsnM7LAqhEBJ6aLfQBUDOmuFtWPb
+qp8dbHbTSVWSICef4gzUrPI+s2kG8dBdZFxzJuK2NvelH71UesV6t1p6QXC99Vm2NREC7ZunSjhL
+B2r7kUzFku6sDW44AWCqfXQPoosEMHqfgoF/rjLAuj58JYhmkFvFIzwAPiMxcWeXh/gAAAAASUVO
+RK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_obj.svg
@@ -1,0 +1,557 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#c48a4e;stop-opacity:1;" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#ad6c24;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-148.40713,-87.106181)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955"
+       id="linearGradient3945"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-147.48911,-87.252829)" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4284"
+       id="linearGradient10790-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33571488,0,0,0.59088033,417.52974,47.073021)"
+       x1="305"
+       y1="513.87781"
+       x2="305"
+       y2="545.35248" />
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         id="stop4286"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:0" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999967"
+         id="stop4288" />
+      <stop
+         id="stop4290"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10790-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,214.53218,-155.02652)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-9"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-0"
+       id="linearGradient10792-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,214.53218,-155.02652)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-0">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10786-1"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818"
+       gradientTransform="matrix(1.0391435,0,0,0.59796602,202.46608,47.009545)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-9"
+       id="linearGradient10782-3"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,217.58019,-158.92057)" />
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-3" />
+      <stop
+         id="stop10422-8"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-3"
+       id="linearGradient10784-2"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,217.58019,-158.92057)" />
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         id="stop10434-4"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-2" />
+      <stop
+         id="stop10438-9"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-90"
+       id="linearGradient10778-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="matrix(1.0765606,0,0,1.061954,190.65652,-195.98554)" />
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-0" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-96"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-8"
+       id="linearGradient10774-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.062525,0,0,1.0891236,202.52576,-210.40158)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         id="stop10750-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-8" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-8" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-7"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient10770-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0387443,0,0,1.1623096,210.44163,-248.72525)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-7" />
+      <stop
+         id="stop10456-4-1-5-3"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-4" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="54.508621"
+     inkscape:cx="15.113239"
+     inkscape:cy="6.9688496"
+     inkscape:document-units="px"
+     inkscape:current-layer="g13862"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <rect
+         ry="3.1069043"
+         rx="3.1069043"
+         y="347.32736"
+         x="473.10382"
+         height="19.677061"
+         width="17.753738"
+         id="rect13693-3"
+         style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="rect13693"
+         d="m 472.68093,354.495 33.22969,0 c 1.72122,0 3.1069,1.38903 3.1069,3.11442 l 0,13.39945 c 0,1.72538 -1.44501,2.66525 -3.1069,3.11442 l -33.22969,8.9812 c -1.66188,0.44917 -3.1069,-1.38903 -3.1069,-3.11442 l 0,-22.38065 c 0,-1.72539 1.38568,-3.11442 3.1069,-3.11442 z"
+         style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path13797"
+         d="m 471.31191,354.49499 23.78261,0"
+         style="fill:none;stroke:url(#linearGradient3945);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         id="g4301"
+         transform="translate(-38.76348,19.301383)">
+        <rect
+           ry="0"
+           rx="0"
+           y="354.94647"
+           x="539.2395"
+           height="10.826942"
+           width="21.018066"
+           id="rect10007-0-74-2-7-6"
+           style="display:inline;fill:url(#linearGradient10770-6);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8-8"
+           d="m 548.23888,354.95116 0,3.5838 12.01134,0 0,-3.5838 -12.01134,0 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7"
+           d="m 549.43361,354.93037 0,10.8213 3.63939,0 0,-10.8213 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1-8"
+           d="m 560.22222,362.10479 -12.03934,0.1111 0.0351,3.58381 12.03934,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="351.43616"
+           x="538.01801"
+           height="17.791901"
+           width="11.41908"
+           id="rect10007-0-74-2-7"
+           style="display:inline;fill:url(#linearGradient10774-5);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1"
+           d="m 549.5198,365.72372 -12.03934,0.1111 0.035,3.5838 12.03935,-0.1111 -0.0351,-3.5838 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8"
+           d="m 549.48481,351.36054 -12.03935,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="347.8541"
+           x="530.58051"
+           height="24.955921"
+           width="11.811058"
+           id="rect10007-0-74-2"
+           style="display:inline;fill:url(#linearGradient10778-6);fill-opacity:1;stroke:none;stroke-width:1.50161433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="351.36792"
+           x="517.27734"
+           height="17.908186"
+           width="13.428176"
+           id="rect10007-0"
+           style="display:inline;fill:#5079bc;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="355.63754"
+           x="507.31067"
+           height="9.2635088"
+           width="10.776635"
+           id="rect10007-0-7"
+           style="display:inline;fill:url(#linearGradient10782-3);fill-opacity:1;stroke:url(#linearGradient10784-2);stroke-width:1.48636866;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="354.87964"
+           x="517.32654"
+           height="10.763388"
+           width="13.378973"
+           id="rect10007-0-74"
+           style="display:inline;fill:url(#linearGradient10786-1);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313"
+           d="m 542.3172,347.76957 -12.03935,0.1111 0.035,3.5838 12.03935,-0.11109 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5"
+           d="m 542.33819,369.2724 -12.03934,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           y="342.42676"
+           x="522.66992"
+           height="35.783813"
+           width="10.700533"
+           id="rect10007-6"
+           style="display:inline;fill:url(#linearGradient10790-8);fill-opacity:1;stroke:url(#linearGradient10792-6);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           ry="5.3502665" />
+        <rect
+           y="350.21646"
+           x="520.87805"
+           height="19.98802"
+           width="3.5889285"
+           id="rect10007-6-6"
+           style="display:inline;fill:url(#linearGradient10790-8-2);fill-opacity:1;stroke:none;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7-8"
+           d="m 542.3442,354.94937 0,10.78725 3.5848,0 0,-10.78725 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:0.64640886;fill-rule:evenodd;stroke:none;stroke-width:0.97351193px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <image
+           y="326.2341"
+           x="560.24866"
+           id="image4280"
+           xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAeJJREFU
+OI2Nk09IFFEcxz9vWTfbtFQkWCg2IZcuG8RiDihdiqAIEeoYE3jx0KVAuglBhw5ueBCJLkEeRZDq
+EHboIBJLge2xf0JLRiEpO4szs81u8+vwZnbXJrUvPN7/z/u+33s/JSKEKuSNZgcwJgqK/SQiiAjP
+b2XkbwVj7FWUiFDIG5IzxwGoO1Wcio1bruBY22x9eB05tNVZPGy0dZwOajh4FEik9cT5UgRQyBsS
+QhoA6k5zRXs/5oMvAMzdPgbVT7uGIAZQ9wU8q1HM6XX6eoW+XsGcXtduEmnwKuBZen3rFWo1X28G
+6BoEyiTb4ygE8Fl+qK9zblw78Tx/JyB99hJ0ngHAnClrzqE2FApwGbq+CMDyo34AThiTOwF3V0dg
+Vcfgcu4IXzfKdHUkkAAg/i8U0J0e5VRumJX5CUrv7gkqAHTHA/sIqZ4UqZ5k4wS3ukHscFZ3kq9Q
+nRncAye5eOVG08HHH82gfN9yKL7/xmD2OErBtu3i/yzqSauEbL5BNj/z8skkEgJeTF1ofIzhm88k
+BmQzdRCwbQd+O4CwVlxirbjE6H2JfqRQK7MjamBsQSy7BiK4rsfT2TsAXJ2SSG5EAKEqdi14xn9v
+DKVas7FVA2MLAvD28bU9M3JXwP/qD5PM7CDw/+DMAAAAAElFTkSuQmCC
+"
+           style="image-rendering:optimizeSpeed"
+           preserveAspectRatio="none"
+           height="57.340881"
+           width="57.340881" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_patch_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_patch_obj.svg
@@ -1,0 +1,621 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_patch_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4351">
+      <stop
+         style="stop-color:#d22939;stop-opacity:1"
+         offset="0"
+         id="stop4353" />
+      <stop
+         style="stop-color:#f13f53;stop-opacity:1"
+         offset="1"
+         id="stop4355" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4325">
+      <stop
+         style="stop-color:#d84e4e;stop-opacity:1"
+         offset="0"
+         id="stop4327" />
+      <stop
+         style="stop-color:#e6878f;stop-opacity:1"
+         offset="1"
+         id="stop4329" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3973"
+       inkscape:collect="always">
+      <stop
+         id="stop3975"
+         offset="0"
+         style="stop-color:#f8d078;stop-opacity:1" />
+      <stop
+         id="stop3977"
+         offset="1"
+         style="stop-color:#f8f0c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3967"
+       inkscape:collect="always">
+      <stop
+         id="stop3969"
+         offset="0"
+         style="stop-color:#c48a4e;stop-opacity:1;" />
+      <stop
+         id="stop3971"
+         offset="1"
+         style="stop-color:#ad6c24;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3955">
+      <stop
+         id="stop3957"
+         offset="0"
+         style="stop-color:#c38536;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2dc91;stop-opacity:1"
+         offset="0.15381166"
+         id="stop3959" />
+      <stop
+         style="stop-color:#fbdc8b;stop-opacity:1"
+         offset="0.5"
+         id="stop3961" />
+      <stop
+         id="stop3963"
+         offset="0.75"
+         style="stop-color:#e6bd7a;stop-opacity:1" />
+      <stop
+         id="stop3965"
+         offset="1"
+         style="stop-color:#ba772f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3949">
+      <stop
+         style="stop-color:#9e6627;stop-opacity:1"
+         offset="0"
+         id="stop3951" />
+      <stop
+         style="stop-color:#c38536;stop-opacity:1"
+         offset="1"
+         id="stop3953" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3967"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-148.40713,-87.106181)"
+       x1="531.09253"
+       y1="366.78851"
+       x2="531.09253"
+       y2="371.17883" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3955"
+       id="linearGradient3945"
+       gradientUnits="userSpaceOnUse"
+       x1="523.00781"
+       y1="373.2294"
+       x2="543.91406"
+       y2="373.2294"
+       gradientTransform="matrix(1.1835826,0,0,1.1835826,-147.48911,-87.252829)" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask4917">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m 462.77563,373.22885 29.11636,0 c 1.45425,0 2.625,1.17075 2.625,2.625 l 0,18.76896 c 0,1.45425 -1.17412,2.52598 -2.625,2.625 l -29.11636,1.98708 c -1.45088,0.099 -2.625,-1.17075 -2.625,-2.625 l 0,-20.75604 c 0,-1.45425 1.17075,-2.625 2.625,-2.625 z"
+         id="path4919"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3973"
+       id="linearGradient4933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="538.00562"
+       y1="396.2229"
+       x2="538.00562"
+       y2="374.21222" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3949"
+       id="linearGradient4935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1835826,0,0,1.1864473,-147.28832,-90.005325)"
+       x1="548.45923"
+       y1="398.98798"
+       x2="548.45923"
+       y2="373.77069" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4284"
+       id="linearGradient10790-8-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33571488,0,0,0.59088033,378.76626,66.374404)"
+       x1="305"
+       y1="513.87781"
+       x2="305"
+       y2="545.35248" />
+    <linearGradient
+       id="linearGradient4284">
+      <stop
+         id="stop4286"
+         offset="0"
+         style="stop-color:#6588c1;stop-opacity:0" />
+      <stop
+         style="stop-color:#becce3;stop-opacity:1"
+         offset="0.49999967"
+         id="stop4288" />
+      <stop
+         id="stop4290"
+         offset="1"
+         style="stop-color:#809dcb;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10790-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,175.7687,-135.72514)"
+       x1="305"
+       y1="504.36218"
+       x2="305"
+       y2="542.73901" />
+    <linearGradient
+       id="linearGradient10157-2-5">
+      <stop
+         style="stop-color:#6588c1;stop-opacity:1"
+         offset="0"
+         id="stop10159-8-3" />
+      <stop
+         id="stop10165-3-9"
+         offset="0.5"
+         style="stop-color:#becce3;stop-opacity:1" />
+      <stop
+         style="stop-color:#809dcb;stop-opacity:1"
+         offset="1"
+         id="stop10161-5-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10149-39-0"
+       id="linearGradient10792-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0009494,0,0,0.98394455,175.7687,-135.72514)"
+       x1="322.875"
+       y1="536.61243"
+       x2="322.875"
+       y2="504.44818" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient10149-39-0">
+      <stop
+         style="stop-color:#1d4d9d;stop-opacity:1"
+         offset="0"
+         id="stop10151-3-0" />
+      <stop
+         style="stop-color:#638ac8;stop-opacity:1"
+         offset="1"
+         id="stop10153-72-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10157-2-5"
+       id="linearGradient10786-1"
+       gradientUnits="userSpaceOnUse"
+       x1="306.05069"
+       y1="532.08228"
+       x2="306.05069"
+       y2="514.75818"
+       gradientTransform="matrix(1.0391435,0,0,0.59796602,163.7026,66.310928)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10414-9"
+       id="linearGradient10782-3"
+       gradientUnits="userSpaceOnUse"
+       x1="298.34253"
+       y1="528.1048"
+       x2="298.34253"
+       y2="519.08923"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,178.81671,-139.61919)" />
+    <linearGradient
+       id="linearGradient10414-9">
+      <stop
+         style="stop-color:#5078b9;stop-opacity:1;"
+         offset="0"
+         id="stop10416-3" />
+      <stop
+         id="stop10422-8"
+         offset="0.5"
+         style="stop-color:#6d8cbd;stop-opacity:1" />
+      <stop
+         style="stop-color:#5f88c9;stop-opacity:1"
+         offset="1"
+         id="stop10418-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10432-3"
+       id="linearGradient10784-2"
+       gradientUnits="userSpaceOnUse"
+       x1="289.8125"
+       y1="528.73804"
+       x2="289.8125"
+       y2="519.36218"
+       gradientTransform="matrix(0.99095518,0,0,0.99086966,178.81671,-139.61919)" />
+    <linearGradient
+       id="linearGradient10432-3">
+      <stop
+         id="stop10434-4"
+         offset="0"
+         style="stop-color:#1f4d9a;stop-opacity:1" />
+      <stop
+         style="stop-color:#4e6da1;stop-opacity:1"
+         offset="0.5"
+         id="stop10436-2" />
+      <stop
+         id="stop10438-9"
+         offset="1"
+         style="stop-color:#567ebc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-90"
+       id="linearGradient10778-6"
+       gradientUnits="userSpaceOnUse"
+       x1="324.1601"
+       y1="535.52948"
+       x2="324.1601"
+       y2="511.66458"
+       gradientTransform="matrix(1.0765606,0,0,1.061954,151.89304,-176.68416)" />
+    <linearGradient
+       id="linearGradient10448-90">
+      <stop
+         style="stop-color:#ecac18;stop-opacity:1"
+         offset="0"
+         id="stop10450-0" />
+      <stop
+         id="stop10458-2"
+         offset="0.25"
+         style="stop-color:#ffe38d;stop-opacity:1" />
+      <stop
+         id="stop10456-96"
+         offset="0.5"
+         style="stop-color:#fdf5d2;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffeba7;stop-opacity:1"
+         offset="0.75"
+         id="stop10460-3" />
+      <stop
+         style="stop-color:#e5b630;stop-opacity:1"
+         offset="1"
+         id="stop10452-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10748-8"
+       id="linearGradient10774-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.062525,0,0,1.0891236,163.76228,-191.1002)"
+       x1="324.1601"
+       y1="532.15552"
+       x2="324.1601"
+       y2="515.53949" />
+    <linearGradient
+       id="linearGradient10748-8">
+      <stop
+         id="stop10750-5"
+         offset="0"
+         style="stop-color:#ecac18;stop-opacity:1" />
+      <stop
+         style="stop-color:#f1ce66;stop-opacity:1"
+         offset="0.25"
+         id="stop10752-8" />
+      <stop
+         style="stop-color:#f6e5a6;stop-opacity:1"
+         offset="0.5"
+         id="stop10754-8" />
+      <stop
+         id="stop10756-4"
+         offset="0.75"
+         style="stop-color:#f1cf6c;stop-opacity:1" />
+      <stop
+         id="stop10758-7"
+         offset="1"
+         style="stop-color:#e5b630;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10448-9-7-0-5"
+       id="linearGradient10770-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0387443,0,0,1.1623096,171.67815,-229.42387)"
+       x1="324.1601"
+       y1="529.30121"
+       x2="323.98331"
+       y2="518.28192" />
+    <linearGradient
+       id="linearGradient10448-9-7-0-5">
+      <stop
+         style="stop-color:#cf9307;stop-opacity:1"
+         offset="0"
+         id="stop10450-3-5-6-7" />
+      <stop
+         id="stop10456-4-1-5-3"
+         offset="0.5"
+         style="stop-color:#f7d87b;stop-opacity:1" />
+      <stop
+         style="stop-color:#ebb313;stop-opacity:1"
+         offset="1"
+         id="stop10452-22-7-8-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4325"
+       id="linearGradient4331"
+       x1="514.31757"
+       y1="374.2059"
+       x2="514.31757"
+       y2="345.53546"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4351"
+       id="linearGradient4357"
+       x1="507.14996"
+       y1="370.6221"
+       x2="507.14996"
+       y2="349.11929"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.961482"
+     inkscape:cx="12.140019"
+     inkscape:cy="8.0000005"
+     inkscape:document-units="px"
+     inkscape:current-layer="g13862"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3947" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-129.51159,939.94639)"
+       style="display:inline"
+       id="g13862">
+      <g
+         id="g4256">
+        <rect
+           style="display:inline;fill:#fdf7eb;fill-opacity:1;stroke:url(#linearGradient3939);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect13693-3"
+           width="17.753738"
+           height="19.677061"
+           x="473.10382"
+           y="347.32736"
+           rx="3.1069043"
+           ry="3.1069043" />
+        <path
+           style="fill:url(#linearGradient4933);fill-opacity:1;stroke:url(#linearGradient4935);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 472.68093,354.495 33.22969,0 c 1.72122,0 3.1069,1.38903 3.1069,3.11442 l 0,13.39945 c 0,1.72538 -1.44501,2.66525 -3.1069,3.11442 l -33.22969,8.9812 c -1.66188,0.44917 -3.1069,-1.38903 -3.1069,-3.11442 l 0,-22.38065 c 0,-1.72539 1.38568,-3.11442 3.1069,-3.11442 z"
+           id="rect13693"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="sssssssss" />
+        <path
+           style="fill:none;stroke:url(#linearGradient3945);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 471.31191,354.49499 23.78261,0"
+           id="path13797"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         id="g4238">
+        <rect
+           ry="0"
+           rx="0"
+           y="374.24786"
+           x="500.47601"
+           height="10.826942"
+           width="21.018066"
+           id="rect10007-0-74-2-7-6"
+           style="display:inline;fill:url(#linearGradient10770-6);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8-8"
+           d="m 509.4754,374.25254 0,3.5838 12.01134,0 0,-3.5838 -12.01134,0 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7"
+           d="m 510.67013,374.23175 0,10.8213 3.63939,0 0,-10.8213 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94926554px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1-8"
+           d="m 521.45874,381.40617 -12.03934,0.1111 0.0351,3.58381 12.03934,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="370.73755"
+           x="499.25452"
+           height="17.791901"
+           width="11.41908"
+           id="rect10007-0-74-2-7"
+           style="display:inline;fill:url(#linearGradient10774-5);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5-1"
+           d="m 510.75632,385.0251 -12.03934,0.1111 0.035,3.5838 12.03935,-0.1111 -0.0351,-3.5838 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8"
+           d="m 510.72133,370.66192 -12.03935,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           ry="0"
+           rx="0"
+           y="367.15549"
+           x="491.81702"
+           height="24.955921"
+           width="11.811058"
+           id="rect10007-0-74-2"
+           style="display:inline;fill:url(#linearGradient10778-6);fill-opacity:1;stroke:none;stroke-width:1.50161433;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="370.66931"
+           x="478.51385"
+           height="17.908186"
+           width="13.428176"
+           id="rect10007-0"
+           style="display:inline;fill:#5079bc;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="374.93893"
+           x="468.54718"
+           height="9.2635088"
+           width="10.776635"
+           id="rect10007-0-7"
+           style="display:inline;fill:url(#linearGradient10782-3);fill-opacity:1;stroke:url(#linearGradient10784-2);stroke-width:1.48636866;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           ry="0"
+           rx="0"
+           y="374.18103"
+           x="478.56305"
+           height="10.763388"
+           width="13.378973"
+           id="rect10007-0-74"
+           style="display:inline;fill:url(#linearGradient10786-1);fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313"
+           d="m 503.55372,367.07095 -12.03935,0.1111 0.035,3.5838 12.03935,-0.11109 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-5"
+           d="m 503.57471,388.57378 -12.03934,0.1111 0.035,3.58381 12.03935,-0.1111 -0.0351,-3.58381 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9e7400;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           y="361.72815"
+           x="483.90643"
+           height="35.783813"
+           width="10.700533"
+           id="rect10007-6"
+           style="display:inline;fill:url(#linearGradient10790-8);fill-opacity:1;stroke:url(#linearGradient10792-6);stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           ry="5.3502665" />
+        <rect
+           y="369.51785"
+           x="482.11456"
+           height="19.98802"
+           width="3.5889285"
+           id="rect10007-6-6"
+           style="display:inline;fill:url(#linearGradient10790-8-2);fill-opacity:1;stroke:none;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="path4313-8-8-7-8"
+           d="m 503.58072,374.25075 0,10.78725 3.5848,0 0,-10.78725 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#c18e00;fill-opacity:0.64640886;fill-rule:evenodd;stroke:none;stroke-width:0.97351193px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      </g>
+      <rect
+         style="display:inline;opacity:0.756;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:3.58380508;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4323-4"
+         width="28.67045"
+         height="28.670467"
+         x="491.0228"
+         y="347.32739" />
+      <image
+         y="345.53546"
+         x="521.48517"
+         id="image4320"
+         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAitJREFU
+OI2Nk09IVFEUxn/3zSTDKAxqSAkGIWlQQhEa4YAQEhEkgS6iaBbSJlq1ceeiglIkyIXQpqBWLdxk
+hNiqhdFfamgRZRr0R5yG0WZ03tz3x/dOizfzxiyjD87inHu+73z3XK4SESqYvXqkmgDJ4WdqaeTm
+b7U/ICKICPcGmmUzfn5+KotXRkXcvIibl0JPvxR6+sN88fKoRAEeDXXKuZHjWO9SmHmbtWXNWs6i
+9eQ1ipYOh7meB1QNebZFFMAwFCR6iSUg1gyNFXe19Xhak0meRZSgJKBnkmcQQLr3YwBEFKBi1ajr
+JnV7D+8zjfjaxHJtbMfBch3scjiug1cyyw4iClRdMDbeTmo8y+7twrYI+LpI64tJAD4e7AMF7W+m
+AJg/fykQiIQCKrxfPBbFMMDTpbDmrDugqj2+NlEiAtbXcDOp8SwA3e0xjnW1YF9IBbrljgpdyjUl
+IqRGX4cCJw4l+JbNs6spwYG2Jr7nHI7u81GArVepicXRqz9CFwZAfbRQjjw7G+J07W1mR0MtmZzJ
+rYefEH8F319h7vkNvNJbntw/TU1xmpridLCDuUz1bZdWSqQ/LHK4owWloGhq/Fw6OCx8QZZfIsvz
+PL47jEAgMD3WG24meXFKDKCjbR0ETLMEXgkQFtIzLKRnOHVdwv4omzA70ac6ByelYLoggtYODyaG
+AOgfqxK3FKhg1XRR5dX/jViB2vgbN6JzcFIAXt0Z2JL8T4H/xS+UDxttKgiLRwAAAABJRU5ErkJg
+gg==
+"
+         style="image-rendering:optimizeSpeed"
+         preserveAspectRatio="none"
+         height="57.340881"
+         width="57.340881" />
+      <rect
+         style="opacity:1;fill:#fffbf0;fill-opacity:1;stroke:url(#linearGradient4331);stroke-width:3.58380532;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect4323"
+         width="25.086651"
+         height="25.086649"
+         x="494.60663"
+         y="347.32736" />
+      <path
+         id="path4333-6"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4357);stroke-width:7.16761017;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 507.14996,349.11928 0,21.50283 m -10.75142,-10.75142 21.50283,0" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_remove.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_remove.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_remove.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4852-7">
+      <stop
+         style="stop-color:#f03f51;stop-opacity:1"
+         offset="0"
+         id="stop4854-4" />
+      <stop
+         style="stop-color:#f5817d;stop-opacity:1"
+         offset="1"
+         id="stop4856-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4844-4">
+      <stop
+         style="stop-color:#c51325;stop-opacity:1"
+         offset="0"
+         id="stop4846-8" />
+      <stop
+         style="stop-color:#ca5d49;stop-opacity:1"
+         offset="1"
+         id="stop4848-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1049.7977"
+       x1="5.1118913"
+       gradientTransform="matrix(0.99598313,0,0,0.91431638,-0.09135729,89.514964)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4047"
+       xlink:href="#linearGradient4852-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="matrix(0.99598313,0,0,0.91431638,-0.09135729,89.514964)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4049"
+       xlink:href="#linearGradient4844-4"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="36.468748"
+     inkscape:cx="2.3790098"
+     inkscape:cy="7.9227098"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="display:inline;fill:url(#linearGradient4047);fill-opacity:1;stroke:url(#linearGradient4049);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.274029,1039.1745 c -0.466304,-0.428 -1.217065,-0.428 -1.683345,-10e-5 l -3.1002933,2.8463 -3.100269,-2.8462 c -0.4662334,-0.428 -1.2170654,-0.428 -1.683345,0 l -0.8566007,0.7866 c -0.4662589,0.4278 -0.4662469,1.117 3.63e-5,1.5451 l 3.1002192,2.8461 -3.1002237,2.8461 c -0.4663292,0.428 -0.4663174,1.1172 -1.35e-5,1.5452 l 0.8566469,0.7865 c 0.466254,0.4281 1.2170161,0.4281 1.6833447,0 l 3.100274,-2.846 3.1218141,2.8658 c 0.466256,0.4281 1.217017,0.4281 1.683346,0 l 0.856601,-0.7864 c 0.46628,-0.4281 0.461596,-1.113 -3.6e-5,-1.5453 l -3.121817,-2.8659 3.100274,-2.846 c 0.466301,-0.4281 0.466289,-1.1173 3.4e-5,-1.5452 z"
+       id="rect4043"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+    <image
+       y="1036.3622"
+       x="-16"
+       id="image4284"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAeFJREFU
+OI2lk79rU3EUxT/fGqpC2mBCkRf8AUpjySu0gpTCw0GhS1EEF7c6SLO6NDhlsLoER52E/gFdAoHO
+OpgXQiKk0PceUqrUpG0QbSVNY5Im9TrUF5Omi+TCXe4993Du+d6vEhH6iYG+pk8SbJmm5OZmxYnH
+TpXlxGOSm5uVLdNs9wc6h0tvFtGqg1RXs5wkceIxOVjNolUHKb1exCXxuIBGYQOpH+GfnMCvBCuT
+Jv/0sQxP32U/845mYRt90kApYSefplHYAMNAdZroxGNSef8BfXwKhfBjr8S3nSIXg5cJXNBQAraT
+w3vnNuFnLxTQTQBgR6JS+ZRm/MZNEABBoRAEaz3P0JiB/vaVcvE9BACZW1Ny5cx5hq5eOy4IHBS+
+8PWoxvTHrOrEenqmAX414awHqdRx0XLYhEazB9pzB3YkKlJr4fVpUDtE/qbXp/G71sSORLskd61g
+R6Kyv7KCHgoDUPr+md29OgH/ObSR6wiCve7gu3e/7UNbwebSspQTSfRQ+Ngwa42WMUPw5XNaxgyW
+tYZCoYfClBNJNpeWu+/AM3YJgJ+7BbZLZXwPH/xz+8kjbBArkSSoDXfhEZF2FlMpMQOjYs0vSGfd
+TWt+QczAqBRTqXb/1Gf8n+j7N/4BYHIA1ExHiVMAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_update_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_update_obj.svg
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_update.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4274">
+      <stop
+         id="stop4276"
+         offset="0"
+         style="stop-color:#15629b;stop-opacity:1" />
+      <stop
+         id="stop4278"
+         offset="1"
+         style="stop-color:#6994ad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4268">
+      <stop
+         id="stop4270"
+         offset="0"
+         style="stop-color:#c1ebca;stop-opacity:1" />
+      <stop
+         id="stop4272"
+         offset="1"
+         style="stop-color:#739ab3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6" />
+      <stop
+         style="stop-color:#a86e11;stop-opacity:1"
+         offset="1"
+         id="stop7596-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7584-9-3">
+      <stop
+         style="stop-color:#739ab3;stop-opacity:1"
+         offset="0"
+         id="stop7586-6-3" />
+      <stop
+         style="stop-color:#c1ebca;stop-opacity:1"
+         offset="1"
+         id="stop7588-9-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5"
+       id="linearGradient4873"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99194778,0,0,0.90415386,28.747558,98.91832)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1"
+       id="linearGradient4875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99194778,0,0,0.90415386,28.747558,98.91832)"
+       x1="23.107393"
+       y1="1040.0905"
+       x2="23.107393"
+       y2="1044.9022" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4268"
+       id="linearGradient4262"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99194778,0,0,-0.90415386,-2.747602,1988.8045)"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.373606"
+       y2="1039.7751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4274"
+       id="linearGradient4264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99194778,0,0,-0.90415386,-2.747602,1988.8045)"
+       x1="23.107393"
+       y1="1040.0905"
+       x2="23.107393"
+       y2="1044.9022" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="41.50087"
+     inkscape:cx="17.746156"
+     inkscape:cy="8.8506495"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4155" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="17"
+       id="image4216"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAYNJREFU
+OI2Nkk8og3EYxz8/HDTEHLyHndxdlCI3DhwkO0gur4Pbm5TiIhepnRTSyiguMmXt8irH1W6iuPqT
+snIxmuZts2Hv48BeNnvHt371fHue59vzfH+PEhHKEQtoAtC/cK9+JctQ45bom790hP4tEAto8rOp
+ezL0p4gqrhALaNI1No2nrbOkIJs853hvnYHFZMV16pzmER1Psw/yyZKC+toXcnnbdYI6gNTjG56G
+Vuy7OOauCQr803PYmQTmdoTR1ZSrmY4H9tMV5q7J6GpKvb0KdiZBNHRQtRkAEUFEiMx4pRiHp1ok
+PNXicCMYFSMYLeHF2BFwe0YwKvGHE0egnLveAcDESkT8wz5esjZWroDucMHKFb5NrIShpX3p7fBi
+PX8W+gd9IAorbXNxnSaVea8ukLTeec3bpJ8KKED49DJxZ3F09sjpsq7gxyFVQruxI+M9Gpq3kbWj
+G740uN2Y/P6Zv0xs0kMyu3UoTfqmVMpXnaAINbYhAHJg/LqJfwlUwwenxRkkxaNangAAAABJRU5E
+rkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <g
+       id="g4221">
+      <path
+         sodipodi:nodetypes="ccssscsccsszcc"
+         inkscape:connector-curvature="0"
+         id="path7582"
+         d="m 5.5000007,1038.7178 0,-1.4385 c 0,0 0.2030217,-0.8491 1.2113028,-0.1297 1.0082813,0.7193 2.1919159,1.8781 2.3672696,2.1977 0.1753525,0.3197 0.9206039,0.8791 -0.087678,1.7583 -1.0082811,0.879 -2.1042395,1.798 -2.1042395,1.798 0,0 -1.3866564,1.4086 -1.3866564,0.1695 l 0,-1.2109 c -1.649686,-0.033 -1.7527346,0.9812 -3.3800406,1.9981 -0.4029788,0.1131 -0.6199673,-1.9778 -0.6199673,-2.3734 0,-0.3955 0.1733855,-1.1246 0.7129624,-1.78 0.2911803,-0.3536 0.9984659,-0.8639 1.5189201,-0.9944 0.5204541,-0.1305 1.7681254,0.1497 1.7681254,0.1497 z"
+         style="fill:url(#linearGradient4873);fill-opacity:1;stroke:url(#linearGradient4875);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602"
+         d="m 6.0176775,1038.1899 0,-0.5395 c 0,0 -0.110485,-0.3397 0.220971,-0.2198 0.331456,0.1199 0.972272,0.5994 1.038563,0.6993 0.06629,0.1 0.751301,0.5394 0.596622,0.7392 -0.15468,0.1999 -1.458408,0.06 -1.458408,0.06 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="g4280"
+       transform="translate(-9.999967,1.1757519e-5)">
+      <path
+         sodipodi:nodetypes="ccssscsccsszcc"
+         inkscape:connector-curvature="0"
+         id="path7582-5"
+         d="m 20.499955,1049.005 0,1.4385 c 0,0 -0.203021,0.8491 -1.211302,0.1297 -1.008282,-0.7193 -2.191916,-1.8781 -2.36727,-2.1977 -0.175353,-0.3197 -0.920604,-0.8791 0.08768,-1.7583 1.008281,-0.879 2.104239,-1.798 2.104239,-1.798 0,0 1.386657,-1.4086 1.386657,-0.1695 l 0,1.2109 c 1.649686,0.033 1.752734,-0.9812 3.38004,-1.9981 0.402979,-0.1131 0.619968,1.9778 0.619968,2.3734 0,0.3955 -0.173386,1.1246 -0.712963,1.78 -0.29118,0.3536 -0.998466,0.8639 -1.51892,0.9944 -0.520454,0.1305 -1.768125,-0.1497 -1.768125,-0.1497 z"
+         style="fill:url(#linearGradient4262);fill-opacity:1;stroke:url(#linearGradient4264);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602-4"
+         d="m 19.958224,1045.7682 0,-0.5395 c 0,0 0.1105,-0.3397 -0.221,-0.2198 -0.3314,0.1199 -0.9722,0.5994 -1.0385,0.6993 -0.066,0.1 -0.7513,0.5394 -0.5966,0.7392 0.1546,0.1999 1.4584,0.06 1.4584,0.06 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_upgraded.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/iu_upgraded.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="iu_upgraded.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4749">
+      <stop
+         style="stop-color:#c4d8bf;stop-opacity:1"
+         offset="0"
+         id="stop4751" />
+      <stop
+         style="stop-color:#80b871;stop-opacity:1"
+         offset="1"
+         id="stop4753" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4741">
+      <stop
+         style="stop-color:#618d55;stop-opacity:1"
+         offset="0"
+         id="stop4743" />
+      <stop
+         style="stop-color:#618d55;stop-opacity:1"
+         offset="1"
+         id="stop4745" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4741"
+       id="linearGradient4747"
+       x1="1.0625"
+       y1="1050.0809"
+       x2="15.565599"
+       y2="1050.0809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.88889034,-0.90909099,0,957.9207,1051.1955)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4749"
+       id="linearGradient4755"
+       x1="9.8264799"
+       y1="1043.3352"
+       x2="10.004026"
+       y2="1044.891"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.88889034,-0.90909099,0,957.9207,1051.1955)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="50.690717"
+     inkscape:cx="17.500035"
+     inkscape:cy="8.0000174"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3966" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4755);fill-opacity:1;stroke:url(#linearGradient4747);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 13.500071,1042.8622 -3,0 -0.01,5.9708 c -9e-4,0.5937 -0.3829,1.0292 -0.9901003,1.0292 l -2,0 c -0.6071,0 -1.0097,-0.4063 -1,-1 l 0,-6 -3,0 5,-5 z"
+       id="rect3968"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsssscccc" />
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4203"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAARElEQVR42mNgoDVI7A39T5Hmhh2F
+/8kyBKYZhkkyBF3zkRv7wZgoQ3BpJsoQkCQyRrcdGRPtEpKcP2oADQwgOeoGBAAA/aq89fOEirgA
+AAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/metadata_repo_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/metadata_repo_obj.svg
@@ -1,0 +1,1314 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="metadata_repo_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5641">
+      <stop
+         style="stop-color:#1e6cbe;stop-opacity:1;"
+         offset="0"
+         id="stop5643" />
+      <stop
+         style="stop-color:#104276;stop-opacity:1;"
+         offset="1"
+         id="stop5645" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5411">
+      <stop
+         style="stop-color:#72828e;stop-opacity:1;"
+         offset="0"
+         id="stop5413" />
+      <stop
+         style="stop-color:#003358;stop-opacity:1;"
+         offset="1"
+         id="stop5415" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5630">
+      <stop
+         style="stop-color:#d8bc68;stop-opacity:1;"
+         offset="0"
+         id="stop5632" />
+      <stop
+         style="stop-color:#fff0c2;stop-opacity:1;"
+         offset="1"
+         id="stop5634" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-5">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-5" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6799-4-3">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-8">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-6">
+      <stop
+         style="stop-color:#c7e3e7;stop-opacity:1;"
+         offset="0"
+         id="stop4974-71" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-4-1-2">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6799-4-3-3">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-8" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-7">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-5" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-5-7">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-5-6" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-8-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-7">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-33" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4972-5-2-6">
+      <stop
+         style="stop-color:#85c2cb;stop-opacity:1;"
+         offset="0"
+         id="stop4974-7-3-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4976-1-9-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-8-8">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7-9" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-0">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-1" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-6"
+       id="linearGradient5572"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972"
+       id="linearGradient4283"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146582"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972"
+       id="linearGradient4288"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146582"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972"
+       id="linearGradient4321"
+       gradientUnits="userSpaceOnUse"
+       x1="5.1146582"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1"
+       id="linearGradient4382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6238641,0,0,1.6285353,-5.817902,-657.26294)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3"
+       id="linearGradient4384"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6238641,0,0,1.6285353,-5.817902,-662.30115)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9"
+       id="linearGradient4390"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8-8"
+       id="linearGradient4392"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96301391,0,0,0.30750995,-1.0449584,-1044.537)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2"
+       id="linearGradient4394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-5">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-3" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-8-8-0">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7-7" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-0">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-8" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1-4"
+       id="linearGradient4382-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-4.9210482,-731.7352)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       id="linearGradient4972-4-1-4">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-9" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-7"
+       id="linearGradient4384-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-4.9210482,-736.99747)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       id="linearGradient6799-4-3-7">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-9" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1-9"
+       id="linearGradient4382-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-6.197689,-731.7678)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       id="linearGradient4972-4-1-9">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-9"
+       id="linearGradient4384-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6960825,0,0,1.7009614,-6.197689,-737.03007)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       id="linearGradient6799-4-3-9">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-7" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-74" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-1"
+       id="linearGradient4394-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3892048,0,0,0.27549241,-31.899058,-1052.4756)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-1">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-2" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8-8-07"
+       id="linearGradient4392-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0464198,0,0,0.30750995,-29.951794,-1049.0796)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-8-8-07">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-0-7-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-5-3-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-4"
+       id="linearGradient4390-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3930703,0,0,0.26192631,-31.957849,1053.1869)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-4">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-26" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-4-1-5"
+       id="linearGradient4382-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.623864,0.69032316,0,1.6285353,32.3374,-665.37304)"
+       x1="5.1146584"
+       y1="1044.7372"
+       x2="12.520393"
+       y2="1044.7372" />
+    <linearGradient
+       id="linearGradient4972-4-1-5">
+      <stop
+         style="stop-color:#daedef;stop-opacity:1;"
+         offset="0"
+         id="stop4974-6-9-97" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4976-2-4-60" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6799-4-3-0"
+       id="linearGradient4384-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.623864,0.69032316,0,1.6285353,32.3374,-670.41122)"
+       x1="11.977677"
+       y1="1042.1279"
+       x2="5.926301"
+       y2="1051.2535" />
+    <linearGradient
+       id="linearGradient6799-4-3-0">
+      <stop
+         style="stop-color:#c89840;stop-opacity:1;"
+         offset="0"
+         id="stop6801-4-0-90" />
+      <stop
+         style="stop-color:#798da2;stop-opacity:1;"
+         offset="1"
+         id="stop6803-5-7-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5411"
+       id="radialGradient5417"
+       cx="13.94572"
+       cy="1045.8255"
+       fx="13.94572"
+       fy="1045.8255"
+       r="10.779004"
+       gradientTransform="matrix(1,0,0,0.98529514,0,15.378714)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5411"
+       id="radialGradient5419"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8121447,-1.9541983,0.96980008,0.27977302,-1035.1855,788.68965)"
+       cx="16.494715"
+       cy="1050.2904"
+       fx="16.494715"
+       fy="1050.2904"
+       r="10.779004" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9"
+       id="linearGradient5426"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8-8"
+       id="linearGradient5428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96301391,0,0,0.30750995,-1.0449584,-1044.537)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2"
+       id="linearGradient5430"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6"
+       id="linearGradient5430-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-6">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-35" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-9" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5475"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-9"
+       id="linearGradient5426-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-80" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-66"
+       id="linearGradient5430-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-66">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-23" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-8" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5475-9"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-6-9">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-35-8" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-9-1" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5525"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-9-2"
+       id="linearGradient5426-4-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-9-2">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-80-0" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-6-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-66-1"
+       id="linearGradient5430-1-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-66-1">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-23-1" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-8-6" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5525-6"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6893-5-8-0-4-9-2-6-9-6">
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="0"
+         id="stop6895-8-7-7-0-1-2-35-8-5" />
+      <stop
+         style="stop-color:#7795b6;stop-opacity:1;"
+         offset="1"
+         id="stop6897-2-6-9-2-4-3-9-1-1" />
+    </linearGradient>
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5592"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6-9-6"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5641"
+       id="linearGradient5647"
+       x1="30.45603"
+       y1="1028.9988"
+       x2="30.45603"
+       y2="1033.8717"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-12.948786,22.935422)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5641-4"
+       id="linearGradient5647-2"
+       x1="30.45603"
+       y1="1028.9988"
+       x2="30.45603"
+       y2="1033.8717"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-12.948786,22.935422)" />
+    <linearGradient
+       id="linearGradient5641-4">
+      <stop
+         style="stop-color:#1e6cbe;stop-opacity:1;"
+         offset="0"
+         id="stop5643-1" />
+      <stop
+         style="stop-color:#104276;stop-opacity:1;"
+         offset="1"
+         id="stop5645-2" />
+    </linearGradient>
+    <linearGradient
+       y2="1033.8717"
+       x2="30.45603"
+       y1="1028.9988"
+       x1="30.45603"
+       gradientTransform="matrix(0.71554797,0.15002359,0,0.70580829,-11.070338,316.74005)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5664"
+       xlink:href="#linearGradient5641-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9"
+       id="linearGradient5695"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2"
+       id="linearGradient5697"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-0-4-9-2-6"
+       id="linearGradient5699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       y2="1033.8717"
+       x2="30.45603"
+       y1="1028.9988"
+       x1="30.45603"
+       gradientTransform="matrix(0.71554797,0.15002359,0,0.70580829,-11.070338,316.74005)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5664-4"
+       xlink:href="#linearGradient5641-4-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5641-4-8">
+      <stop
+         style="stop-color:#1e6cbe;stop-opacity:1;"
+         offset="0"
+         id="stop5643-1-4" />
+      <stop
+         style="stop-color:#104276;stop-opacity:1;"
+         offset="1"
+         id="stop5645-2-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4204"
+       id="linearGradient4210"
+       x1="-708.08484"
+       y1="754.58435"
+       x2="-708.08484"
+       y2="746.83435"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-24.426411,-8.1168654)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4204">
+      <stop
+         style="stop-color:#8e6aae;stop-opacity:1"
+         offset="0"
+         id="stop4206" />
+      <stop
+         style="stop-color:#b29cc6;stop-opacity:1"
+         offset="1"
+         id="stop4208" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4229"
+       id="linearGradient4235"
+       x1="44.955429"
+       y1="1040.4005"
+       x2="42.943558"
+       y2="1042.4124"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-34.995489,-0.00370887)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4229">
+      <stop
+         style="stop-color:#713e9d;stop-opacity:1;"
+         offset="0"
+         id="stop4231" />
+      <stop
+         style="stop-color:#f2aaf1;stop-opacity:1"
+         offset="1"
+         id="stop4233" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4276"
+       id="linearGradient4235-4"
+       x1="44.955429"
+       y1="1040.4005"
+       x2="41.838699"
+       y2="1043.5171"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,48.995489,-0.00370887)" />
+    <linearGradient
+       id="linearGradient4276"
+       inkscape:collect="always">
+      <stop
+         id="stop4278"
+         offset="0"
+         style="stop-color:#f2aaf1;stop-opacity:1" />
+      <stop
+         style="stop-color:#f2aaf1;stop-opacity:1"
+         offset="0.44146144"
+         id="stop4282" />
+      <stop
+         id="stop4284"
+         offset="0.58899093"
+         style="stop-color:#f9f8d4;stop-opacity:1" />
+      <stop
+         id="stop4280"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="1044.7372"
+       x2="12.520393"
+       y1="1044.7372"
+       x1="5.1146584"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4507"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.7372"
+       x2="12.520393"
+       y1="1044.7372"
+       x1="5.1146582"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4509"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.7372"
+       x2="12.520393"
+       y1="1044.7372"
+       x1="5.1146582"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4511"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.7372"
+       x2="12.520393"
+       y1="1044.7372"
+       x1="5.1146582"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4513"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1044.7372"
+       x2="12.520393"
+       y1="1044.7372"
+       x1="5.1146584"
+       gradientTransform="matrix(1.6238641,0,0,1.6285353,-5.817902,-657.26294)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4515"
+       xlink:href="#linearGradient4972-4-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1051.2535"
+       x2="5.926301"
+       y1="1042.1279"
+       x1="11.977677"
+       gradientTransform="matrix(1.6238641,0,0,1.6285353,-5.817902,-662.30115)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4517"
+       xlink:href="#linearGradient6799-4-3"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4519"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(0.96301391,0,0,0.30750995,-1.0449584,-1044.537)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4521"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4523"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.98529514,0,15.378714)"
+       r="10.779004"
+       fy="1045.8255"
+       fx="13.94572"
+       cy="1045.8255"
+       cx="13.94572"
+       id="radialGradient5417-3"
+       xlink:href="#linearGradient5411"
+       inkscape:collect="always" />
+    <radialGradient
+       r="10.779004"
+       fy="1050.2904"
+       fx="16.494715"
+       cy="1050.2904"
+       cx="16.494715"
+       gradientTransform="matrix(1.8121447,-1.9541983,0.96980008,0.27977302,-1035.1855,788.68965)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5419-5"
+       xlink:href="#linearGradient5411"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4527"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(0.96301391,0,0,0.30750995,-1.0449584,-1044.537)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4529"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4531"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8"
+       id="linearGradient4533"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8"
+       id="linearGradient4535"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6893-5-8-8"
+       id="linearGradient4537"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       x1="9.2662354"
+       y1="5.3933983"
+       x2="5.8030186"
+       y2="5.3933983" />
+    <linearGradient
+       gradientTransform="translate(-12.948786,22.935422)"
+       gradientUnits="userSpaceOnUse"
+       y2="1033.8717"
+       x2="30.45603"
+       y1="1028.9988"
+       x1="30.45603"
+       id="linearGradient4539"
+       xlink:href="#linearGradient5641"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5641"
+       id="linearGradient4541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71554797,0.15002359,0,0.70580829,-11.070338,316.74005)"
+       x1="30.45603"
+       y1="1028.9988"
+       x2="30.45603"
+       y2="1033.8717" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2820342,0,0,0.26192632,-2.8911185,1046.2126)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4543"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549242,-2.8370137,-1046.8387)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4545"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="5.3933983"
+       x2="5.8030186"
+       y1="5.3933983"
+       x1="9.2662354"
+       gradientTransform="matrix(1.2784768,0,0,0.27549241,-2.8370135,-1044.4678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4547"
+       xlink:href="#linearGradient6893-5-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5641"
+       id="linearGradient3174"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71554797,0.15002359,0,0.70580829,-11.070338,316.74004)"
+       x1="30.45603"
+       y1="1028.9988"
+       x2="30.45603"
+       y2="1033.8717" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4522"
+       x="-0.11748909"
+       width="1.2349782"
+       y="-0.21204029"
+       height="1.4240806">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.44291996"
+         id="feGaussianBlur4524" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#b4b4b4"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="36.46875"
+     inkscape:cx="19.230818"
+     inkscape:cy="9.338279"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4250" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="layer1-2"
+       inkscape:label="Layer 1"
+       transform="matrix(0.97206288,0,0,0.90809292,2.2543771,95.252775)">
+      <path
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0"
+         id="path5639"
+         d="m 8.4826024,1036.9266 4.1149606,0 0,14.45 -2.057481,-2.45 -2.0574796,2.5 c 0,0 -0.00585,-9.6999 0,-14.5 z"
+         style="display:inline;fill:#71baff;fill-opacity:1;stroke:url(#linearGradient3174);stroke-width:1.04048264px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <path
+       transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,0,0)"
+       style="display:inline;opacity:0.787;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter4522)"
+       d="m -734.87988,740.13159 4.58648,4.67284 c 0.21828,0.2224 1.69601,-1.64915 1.68708,-1.33766 l -0.0775,2.70571 c -0.009,0.3115 -0.44481,0.75193 -0.7564,0.7564 l -2.70571,0.0388 c -0.31159,0.004 1.01498,-1.15795 0.81415,-1.39624 l -4.11055,-4.87732 c -0.20082,-0.23828 0.34421,-0.7849 0.5625,-0.5625 z"
+       id="rect3394-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="fill:#8861aa;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 11.549897,1043.3622 7,1047.9652 l 0,-4.603 z"
+       id="path4212"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4235);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 11.549897,1043.3622 7.0095,1038.7593 7,1043.3622 Z"
+       id="path4212-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:#ad86cf;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 2.5,1043.3622 4.4905,4.6029 L 7,1043.3622 Z"
+       id="path4212-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:url(#linearGradient4235-4);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 2.5,1043.3622 6.9905,1038.7593 7,1043.3622 Z"
+       id="path4212-4-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <image
+       y="1036.3622"
+       x="17"
+       id="image4424"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAa9JREFU
+OI2Nk0FIVFEUhr87OptoZniaG2EWwkAEbYJcuAlaTbQMwYVkhItmq7YJdBESgVCZCyGZAhUXwSCB
+SPiKliJBoxTTZiSDFi1UShkyeO/c0+LVa5x5j5kfDveeyz0f9/7nXqOqtKPM6ErTxqPnw6azreq/
+mhoZCufTSy8BSMRtdosVdYuVlseLBLjFig5kstT2Peoham0QauMB6/NlHchkSXWlyXU71PY91ubL
+OnuzH7E2CD8ANQFKTzf1Sk+OVFca+vfocxxy3Q7eUYLUzgH5851YEawV1PdPA5YeuprvvRgWk+4D
+CCCOQ+LkDJ+W33HtQhIRQbwAEHbh1+8ab3a/BMl7gB2q1eqp62WyHagq4gvWazhB4f4N8/XHx1i3
+k+dOuHz7Oq/Kx4j4iOc1ezA+M2I+f99qKvbOHpK+eonVDz8REawI6keYCDA5VzDbe2/D/Dj5jcm5
+grkz6wZ3F8EXQUWiAQDTC3fNVvU1h+zy4Nm4+bdurUXlfwuhzsRGzby4ZxrX1FoeL5YYuzXYGhCl
+J4slZGPCdOQfha8z9i9ESTYmTP0IYNr9znH6A74rx147b6JuAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient4210);stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3394"
+       width="6.6615601"
+       height="6.6615601"
+       x="-736.1416"
+       y="739.35547"
+       rx="0.56249994"
+       ry="0.56249994"
+       transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,0,0)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/obj/profile_obj.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/obj/profile_obj.svg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="profile_obj.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17410">
+      <stop
+         style="stop-color:#e0ebf6;stop-opacity:1;"
+         offset="0"
+         id="stop17412" />
+      <stop
+         style="stop-color:#f3f5f6;stop-opacity:1"
+         offset="1"
+         id="stop17414" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17159">
+      <stop
+         style="stop-color:#ffeece;stop-opacity:1"
+         offset="0"
+         id="stop17161" />
+      <stop
+         style="stop-color:#e1eaba;stop-opacity:1"
+         offset="1"
+         id="stop17163" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17410"
+       id="linearGradient17441"
+       gradientUnits="userSpaceOnUse"
+       x1="-9.733428"
+       y1="12.635066"
+       x2="-3.9386158"
+       y2="6.8402538" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17159"
+       id="linearGradient17443"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.59076155,0.59076155,-0.59076155,0.59076155,17.040411,1049.6082)"
+       x1="-20.742412"
+       y1="7.9916593"
+       x2="-10.422931"
+       y2="7.9916593" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="44.063994"
+     inkscape:cx="8.506094"
+     inkscape:cy="7.4696588"
+     inkscape:document-units="px"
+     inkscape:current-layer="g17418"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5126" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline;fill:none"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="matrix(0.8261236,0,0,0.8261236,1.7832208,183.40446)">
+      <g
+         transform="matrix(1.2065384,0,0,1.2065384,-22.98457,-221.37405)"
+         id="g17594"
+         style="fill:none">
+        <g
+           id="g17418"
+           transform="matrix(0.96836657,0,0,0.96836657,20.738144,33.659982)">
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:url(#linearGradient17441);fill-opacity:1;stroke:#3f7fbf;stroke-width:0.5091278;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-5"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(1.0450409,-1.0450409,1.0450409,1.0450409,2.1256839,1029.9689)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14"
+             d="m 11.53513,1045.8134 c 0.07294,0.9455 0.07325,1.9032 9.05e-4,2.8489 l -2.3011454,-1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2"
+             d="m -1.0914354,1048.6741 c -0.07294,-0.9455 -0.07325,-1.9032 -9.07e-4,-2.849 l 2.301146,1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3"
+             d="m 6.6521976,1053.557 c -0.9455,0.073 -1.9032,0.073 -2.8489,9e-4 l 1.4186,-2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2"
+             d="m 3.7914976,1040.9305 c 0.9455,-0.073 1.9032,-0.073 2.849,-9e-4 l -1.4186,2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-2"
+             d="m 10.697423,1050.6965 c -0.616993,0.7202 -1.2939698,1.3976 -2.013837,2.0151 l -0.6240538,-2.6302 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-1"
+             d="m -0.2537278,1043.791 c 0.61699309,-0.7202 1.2939701,-1.3976 2.0139059,-2.0152 l 0.6240542,2.6303 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3-6"
+             d="m 1.7691159,1052.7193 c -0.7201883,-0.6169 -1.39738442,-1.2941 -2.0151129,-2.0138 l 2.6302251,-0.6241 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2-8"
+             d="m 8.6745793,1041.7682 c 0.7201883,0.6169 1.3973847,1.2941 2.0151837,2.0139 l -2.6302252,0.624 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:#1d4984;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-76"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(0.31739531,-0.31739531,0.31739531,0.31739531,4.2814936,1041.9971)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4"
+             d="m 11.535129,1046.4091 c 0.07294,0.5517 0.07325,1.1106 9.06e-4,1.6624 l -2.3011454,-0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5"
+             d="m -1.0914359,1048.0784 c -0.072942,-0.5517 -0.073247,-1.1106 -9.07e-4,-1.6625 l 2.3011463,0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51"
+             d="m 6.0564977,1053.557 c -0.5517,0.073 -1.1106,0.073 -1.6624,9e-4 l 0.8278,-2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7"
+             d="m 4.3871977,1040.9305 c 0.5517,-0.073 1.1106,-0.073 1.6624,-9e-4 l -0.8277,2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-1"
+             d="m 10.276129,1051.1178 c -0.3385343,0.4417 -0.7335171,0.8371 -1.1748536,1.1761 l -1.0418139,-2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-1"
+             d="m 0.16742503,1043.3698 c 0.33853445,-0.4416 0.73351722,-0.8371 1.17492367,-1.1762 l 1.0418137,2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51-5"
+             d="m 1.3478924,1052.2981 c -0.44172887,-0.3385 -0.83693085,-0.7337 -1.17612997,-1.1749 l 2.21246567,-1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7-2"
+             d="m 9.0958029,1042.1894 c 0.4417296,0.3385 0.8369322,0.7337 1.1761311,1.1749 l -2.2123961,1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:none;stroke:#3f7fbf;stroke-width:0.7180745;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="M -2.4748735,9.7465248 A 4.3089318,4.3089318 0 0 1 -6.7838054,14.055457 4.3089318,4.3089318 0 0 1 -11.092737,9.7465248 4.3089318,4.3089318 0 0 1 -6.7838054,5.437593 4.3089318,4.3089318 0 0 1 -2.4748735,9.7465248 Z"
+             transform="matrix(1.0202099,-1.0202099,1.0202099,1.0202099,2.1992508,1030.3794)" />
+          <path
+             sodipodi:nodetypes="cccccssc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-7"
+             d="m 6.0190516,1046.4513 -4.6356786,-3.9985 -1.80221867,-0.8517 0.85667548,1.7973 4.00338379,4.6307 c 0.2002055,0.2002 0.4771321,0.3237 0.7840021,0.3237 0.61367,0 1.1076548,-0.494 1.1076828,-1.1077 -5.64e-5,-0.3068 -0.1127546,-0.5927 -0.3138469,-0.7938 z"
+             style="color:#000000;fill:url(#linearGradient17443);fill-opacity:1;stroke:#4d607b;stroke-width:0.80260861;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <image
+             y="1038.406"
+             x="14.021823"
+             id="image4444"
+             xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAjhJREFU
+OI2lk09Ik3EYxz+LaFArCGHgQHxFUXBDAqGIDluxi4Qh1WHRYa8QhB0shru4gwtch5TBIOgSbBKh
+F20EHqrBu6A/iAkxVNiYNDVUxnRQ4weCvk+H5WzUpXwuv9/l+/D9PM/3sYgIR6ljR1IDxw8+Ho8u
+94fv4uywU9oThp9/o1FlUA4XJzcWsXZ2MXy5ifbmVsvvDSwHCC/ffJL45CwAAX8baBoNykZoLEkk
+2MdCsUIiDZoGCd1Ta1JDcHbYAXgVvUF0Ik85Z6VFcwLQojm5ef4CYR123qXQE2n5o0FpTwj427gW
+mGY62kd8cpa3778Q8LdhCohA9GGK634vhQLkVlekDsETTktYh3LOSnxylhfjV7k9VEUaD/djb3DU
+uJOf50gXqig1B40qQ4Oy4b54jv5bVfGzcS8A3oEpitsbmAKmQLfdxu5yph5BOVyExpLogxHOnsgC
+cGcoxZPHbi65TuMdmMIU0AcjhMaSKIerKhQRRARfMCaZpXnZLCvZ2lGSLeSlqWdUfMGYNPWMyszr
+j7K5o2SrrCSzNC++YExE5NCBtbOLhWKFfRP2BU6dcZB66uPD4g9iD67g7LBjCuybsFCsYO3sqneQ
+LeTFPWKI8dWQXj0kayUlayUl67/etZKSXj0kccMQ94gh2UK+3kF7c6tF0w5XdTCwe0OR6hpNCIx4
+mZlIoWnUElmLMlTXooMk0gBzdNttAHwvLh0m0e2tS6Llb9eYW12RR8Y6u8v/cAv/Wz8BBiUqWhPx
+5/kAAAAASUVORK5CYII=
+"
+             style="image-rendering:optimizeSpeed"
+             preserveAspectRatio="none"
+             height="16.576546"
+             width="16.576546" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/ovr/added_overlay.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/ovr/added_overlay.svg
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="added_overlay.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4208">
+      <stop
+         style="stop-color:#63942e;stop-opacity:1"
+         offset="0"
+         id="stop4210" />
+      <stop
+         style="stop-color:#d6d93e;stop-opacity:1"
+         offset="1"
+         id="stop4212" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5591-4">
+      <stop
+         style="stop-color:#e0e566;stop-opacity:1;"
+         offset="0"
+         id="stop5593-0" />
+      <stop
+         style="stop-color:#1c4c30;stop-opacity:1"
+         offset="1"
+         id="stop5595-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5583-2">
+      <stop
+         style="stop-color:#1c4c30;stop-opacity:1"
+         offset="0"
+         id="stop5585-3" />
+      <stop
+         style="stop-color:#398c52;stop-opacity:1"
+         offset="1"
+         id="stop5587-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.0575686,0,0,1.1019588,2.1439271,1040.5246)"
+       y2="5.2974758"
+       x2="1.7550378"
+       y1="10.742326"
+       x1="1.7550378"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5620"
+       xlink:href="#linearGradient5583-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4208"
+       id="linearGradient4214"
+       x1="5"
+       y1="1051.3622"
+       x2="5"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="65.16215"
+     inkscape:cx="9.6074015"
+     inkscape:cy="7.9444"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1980"
+     inkscape:window-height="1363"
+     inkscape:window-x="36"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3971" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)">
+    <image
+       y="1044.3622"
+       x="8"
+       id="image4205"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAABHNCSVQICAgIfAhkiAAAAKhJREFU
+GJV9j70KwWEchZ/f+yeDi7AbRJksMllM3IALsNjlDtwBrsBgwyKDbMpsM4uUfIT3PQYlUs52Tk9P
+HZPEv8Q+S6FTkyxgFrFoDgzAfQKKQ7+yJzj3bci1y8IDkePgPZftkWyrLOQwSaQbRdVLZ8AAEckI
+zuhPky/D42r0RgmCGcXMifkqicwDtxew7s4MIFXNC+e57M5shkv7eRHunsnYQP69PQEGTT4vTueW
+6wAAAABJRU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="8"
+       width="8" />
+    <path
+       style="display:inline;fill:url(#linearGradient4214);fill-opacity:1;stroke:url(#linearGradient5620);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 3.5,1045.8622 2,0 0,2 2,0 0,2 -2,0 0,2 -2,0 0,-2 -2.0000001,0 0,-2 2.0000001,0 z"
+       id="path5581"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/ovr/removed_overlay.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/ovr/removed_overlay.svg
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8"
+   height="8"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="removed_overlay.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4844-4">
+      <stop
+         style="stop-color:#c51325;stop-opacity:1"
+         offset="0"
+         id="stop4846-8" />
+      <stop
+         style="stop-color:#ca5d49;stop-opacity:1"
+         offset="1"
+         id="stop4848-8" />
+    </linearGradient>
+    <linearGradient
+       y2="1038.5814"
+       x2="4.7528968"
+       y1="1051.0466"
+       x1="4.7528968"
+       gradientTransform="matrix(0.49949328,0,0,0.49794456,0.1913394,528.84434)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3057"
+       xlink:href="#linearGradient4852-7-4-1"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4852-7-4-1">
+      <stop
+         style="stop-color:#707070;stop-opacity:1"
+         offset="0"
+         id="stop4854-4-0-2" />
+      <stop
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="1"
+         id="stop4856-0-3-9" />
+    </linearGradient>
+    <linearGradient
+       y2="1037.7"
+       x2="8.6566515"
+       y1="1050.7386"
+       x1="8.6566515"
+       gradientTransform="matrix(0.49949328,0,0,0.49794456,0.1913394,528.84434)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3059"
+       xlink:href="#linearGradient4844-4-5-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4844-4-5-9">
+      <stop
+         style="stop-color:#2b2b2b;stop-opacity:1;"
+         offset="0"
+         id="stop4846-8-7-9" />
+      <stop
+         style="stop-color:#404040;stop-opacity:1;"
+         offset="1"
+         id="stop4848-8-6-9" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="50.690717"
+     inkscape:cx="-3.7434494"
+     inkscape:cy="8.0000174"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1044.3622)">
+    <image
+       y="1044.3622"
+       x="-9"
+       id="image4206"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAABHNCSVQICAgIfAhkiAAAALJJREFU
+GJV9zqFuhTAAQNHbpaoYEoqsaTD823jZC/Il2yewwJ+BbkkQGGqwBOhEkyd39RFXxBj5LwnQtm3c
+9508z2k+v+iHjm3bKMuSD4AQAlVVIYQAQAhBXdeEEBLQWjOOI0VR8P3zIssypmlCa53Ao3lynifO
+ObTWrOvKcRw8mmcC/dBxXRdKKbz3KKW475t+6BLw3mOMQUrJbzcgpcQYg3MuAWst8zy/J2OMLMuC
+tZY/T0ZG+4SEDRAAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="8"
+       width="8" />
+    <path
+       style="display:inline;fill:url(#linearGradient3057);fill-opacity:1;stroke:url(#linearGradient3059);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 6.8941854,1046.0369 c -0.2338559,-0.233 -0.6103686,-0.233 -0.8442127,0 l -1.5548203,1.55 -1.5548091,-1.55 c -0.2338203,-0.233 -0.6103686,-0.233 -0.8442116,0 l -0.4295916,0.4283 c -0.2338321,0.2331 -0.2338258,0.6083 1.91e-5,0.8415 l 1.5547831,1.5501 -1.5547868,1.5499 c -0.2338667,0.2332 -0.2338612,0.6085 -5.4e-6,0.8416 l 0.4296143,0.4284 c 0.2338303,0.2331 0.6103431,0.2331 0.8442099,0 l 1.5548126,-1.5501 1.5656142,1.5608 c 0.2338309,0.2333 0.6103437,0.2333 0.844212,0 l 0.4295914,-0.4281 c 0.233842,-0.2332 0.2314932,-0.6063 -1.9e-5,-0.8417 l -1.5656143,-1.5608 1.5548107,-1.55 c 0.2338537,-0.2331 0.2338486,-0.6085 1.76e-5,-0.8416 z"
+       id="rect4043-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccccssccsccsccss" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/wizban/install_wiz.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/wizban/install_wiz.svg
@@ -1,0 +1,1325 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="install_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5134"
+       inkscape:collect="always">
+      <stop
+         id="stop5136"
+         offset="0"
+         style="stop-color:#446190;stop-opacity:1;" />
+      <stop
+         id="stop5138"
+         offset="1"
+         style="stop-color:#a4b4c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5034">
+      <stop
+         style="stop-color:#e2cefd;stop-opacity:1"
+         offset="0"
+         id="stop5036" />
+      <stop
+         id="stop5044"
+         offset="0.50000155"
+         style="stop-color:#d5b9fe;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2cefd;stop-opacity:1"
+         offset="1"
+         id="stop5038" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5024">
+      <stop
+         style="stop-color:#c9c7ff;stop-opacity:1"
+         offset="0"
+         id="stop5026" />
+      <stop
+         id="stop5032"
+         offset="0.41626066"
+         style="stop-color:#aca8fd;stop-opacity:1" />
+      <stop
+         style="stop-color:#bcb9fa;stop-opacity:1"
+         offset="1"
+         id="stop5028" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5016">
+      <stop
+         style="stop-color:#dee6ee;stop-opacity:1"
+         offset="0"
+         id="stop5018" />
+      <stop
+         style="stop-color:#c7d2e0;stop-opacity:1"
+         offset="1"
+         id="stop5020" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4928">
+      <stop
+         style="stop-color:#f1f2ec;stop-opacity:1"
+         offset="0"
+         id="stop4930" />
+      <stop
+         style="stop-color:#d2d5c4;stop-opacity:1"
+         offset="1"
+         id="stop4932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4536">
+      <stop
+         style="stop-color:#446190;stop-opacity:1;"
+         offset="0"
+         id="stop4538" />
+      <stop
+         style="stop-color:#b8c4d4;stop-opacity:1"
+         offset="1"
+         id="stop4540" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4524">
+      <stop
+         style="stop-color:#828da3;stop-opacity:1"
+         offset="0"
+         id="stop4526" />
+      <stop
+         style="stop-color:#8897ab;stop-opacity:1"
+         offset="1"
+         id="stop4528" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4514">
+      <stop
+         style="stop-color:#4b5875;stop-opacity:1"
+         offset="0"
+         id="stop4516" />
+      <stop
+         id="stop4522"
+         offset="0.3333365"
+         style="stop-color:#828da3;stop-opacity:1" />
+      <stop
+         style="stop-color:#49607e;stop-opacity:1"
+         offset="1"
+         id="stop4518" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4470">
+      <stop
+         style="stop-color:#f8f9fb;stop-opacity:1"
+         offset="0"
+         id="stop4472" />
+      <stop
+         style="stop-color:#9eb8d8;stop-opacity:1"
+         offset="1"
+         id="stop4474" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4462">
+      <stop
+         style="stop-color:#a0adc0;stop-opacity:1"
+         offset="0"
+         id="stop4464" />
+      <stop
+         style="stop-color:#a3afc2;stop-opacity:1"
+         offset="1"
+         id="stop4466" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient6406"
+       gradientUnits="userSpaceOnUse"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908" />
+    <linearGradient
+       id="linearGradient5517"
+       inkscape:collect="always">
+      <stop
+         id="stop5519"
+         offset="0"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+      <stop
+         id="stop5521"
+         offset="1"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5031"
+       x="-0.11202575"
+       width="1.2240515"
+       y="-1.0690457"
+       height="3.1380913">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.4343883"
+         id="feGaussianBlur5033" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient5041"
+       x1="98.407524"
+       y1="1065.2891"
+       x2="136.02242"
+       y2="1065.2891"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,-95.625351,-19.272328)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4462"
+       id="linearGradient4468"
+       x1="48"
+       y1="994.36218"
+       x2="88"
+       y2="1028.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-28.014084,-0.01639)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4470"
+       id="linearGradient4476"
+       x1="51"
+       y1="995.36218"
+       x2="84"
+       y2="1026.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-28.014084,-0.01639)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4514"
+       id="linearGradient4520"
+       x1="36"
+       y1="1037.3622"
+       x2="36"
+       y2="1029.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.1249998,0,-128.67002)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4524"
+       id="linearGradient4530"
+       x1="49"
+       y1="1039.3622"
+       x2="46"
+       y2="1034.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5134"
+       id="linearGradient4542"
+       x1="27"
+       y1="1042.3622"
+       x2="7"
+       y2="1020.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515675,8.628538e-5)" />
+    <linearGradient
+       gradientTransform="matrix(0.14667021,0,0,0.14667136,17.184701,879.66442)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4536"
+       id="linearGradient4542-7"
+       x1="27"
+       y1="1042.3622"
+       x2="7"
+       y2="1020.3622"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4792"
+       x="-0.16768435"
+       width="1.3353687"
+       y="-0.17985532"
+       height="1.3597106">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4794" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-4"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-0" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-0"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-5" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-5"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-9" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-49"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-01" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4928"
+       id="linearGradient4934"
+       x1="-11.097116"
+       y1="988.03119"
+       x2="1.5470241"
+       y2="994.73035"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4984"
+       x="-0.084"
+       width="1.168"
+       y="-0.084"
+       height="1.168">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.98"
+         id="feGaussianBlur4986" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5012"
+       x="-0.048"
+       width="1.096"
+       y="-0.048"
+       height="1.096">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.24000032"
+         id="feGaussianBlur5014" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5016"
+       id="linearGradient5022"
+       x1="-5.7292957"
+       y1="996.90344"
+       x2="4.3120389"
+       y2="1000.6044"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5024"
+       id="linearGradient5030"
+       x1="9.1587505"
+       y1="1035.391"
+       x2="12.099871"
+       y2="1039.3212"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515674,9.266038e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5034"
+       id="linearGradient5042"
+       x1="21.856897"
+       y1="1019.8043"
+       x2="27.984741"
+       y2="1023.2879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515674,9.266038e-5)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5062"
+       x="-0.050661981"
+       width="1.101324"
+       y="-0.14436312"
+       height="1.2887262">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.1205165"
+         id="feGaussianBlur5064" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5282"
+       x="-0.27631978"
+       width="1.5526396"
+       y="-0.34539973"
+       height="1.6907995">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.3026648"
+         id="feGaussianBlur5284" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#e7e7e7"
+     borderopacity="1"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.195458"
+     inkscape:cx="64.394526"
+     inkscape:cy="32.083835"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       transform="translate(0,-986.3622)"
+       y="986.36218"
+       x="76"
+       id="image4438"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAABHNCSVQICAgIfAhkiAAAEJhJREFU
+eJztnFuMXEdagL86dS7dPd09PTP2OPZknInjJHbsOE4cx0kEK0RYaQnkBQkQWhArIRBo30BCQivx
+tuIZXtA+EQmkSIs2CwmIRYCUBEKUy8Zhgh3Hji+JbzMTTzy37j63quLhnNPdp28z9vQkiPBL9kyf
+rlOn6qv//+uvv+qMMMYY/l96xBiIlSGMNUFoiJTB/qob9b9JtIZYKfwwARWpvB597WEZA1GsUNoQ
+xYIw1ijdv+zXFpZShlgpYi0ACEKIB1FK5WsFyxjQ2hDGCm0EIFAKgkizFcc9ElhLt5ZYWlodRVU7
+LtLx2D87A0AQGpTe+vw2Ms366bkbd1ReCIElEhOQ0rqje1VqLgaDMXAnE/pkrcrMvhnCeLjJ9ZMv
+3QwHQZKW2NL9SpvWfUpphADNnQG7G1CwA7Cu31jg1VdeH3W125Lnv/Us++dmt13PyGGdPXOJP/6j
+3+axRw8hhMay5NDyWiuMsVDaoA3oVEOUNmiVOGKlNbFOnLPWBoMhTmMgpQzKGIyGWOuWiUbK4IeK
+i58u8txjk1z4dGnbfdsxM/RciWe7iE2syxgHbTRZ/Ke1aU3hSiWglTbEOg8xUqYFMIo12hhEDLZl
+EUQxAAV3+EDdqewYLMsSjBUdOl1R98SjtUohWeiUVqwMjhQoA1om4KQUSNWeubS2kJYBNDHJAywh
+kEIQk/k03ROBb7tPI62tQ2QKSaSqlTh26PbjsuuzEGCJ4c2yuiqxdqwXXc/diUqVTjpsiWSWEl22
+mPV1M3/WDSVfx5e//t8RWNKi5auEEIhUU5LfRUvLcg3pVrEBYrUqbjddsLV7tytfigIboxHCakHr
+ln6meLeyiQVvS74kawdL3GUgeIfR/U7Kjkbw2oBFNuULkli7V4ZNWptlArrF9CkuGE0IsWMOPpMs
+XOhcjvRbmmjV+f3gurOgtS+VHZYvRcc7gRmTRepJnDX0viEZgSTFkta7hQRL94x8NzJSM+xuUCcM
+TRIqbAZoKzIM4k7KjvisZL2X+KLOma4TVD8/pXSSctF9TCxbO/Z/XmKeqsN+u6N3IYab9yBROll3
+GnbQwWuj0UokGjUghtJ9iGWgOrVHDZgBBmVaVJ9JIYnFhtAyEGuD1u1B64Y7YjPMf1baIC3RF0pn
+mZ5rgzTI9GY2t2OSsUrrVKY1KQ3TvpHACpph7rPSJjFB+sPolqyB3eY3KGzQ2qB0+zvd0cNYbz5L
+hnECqD3xbHoLsJNmqA1qC4FotxZ1a4pKsw39mHeb6lajiUFmvZmMFFY2QpnPuJM2ZR0fFoSqNPnX
+775N27al/ZvhsmOaFSuNvYUwTisLTZy71jnyrRyW6bzWBmowAzXFD7cfpnTKNmG1G1n0HAAKpQJa
+2GkHtmIXuqezbUD5NHOnZFnSVktM21/1S/qN4kTHHcLKnqiB/Kjtmy7QDGPum9nNRKWATMOFLLYy
+Jq9lQujctU5Ayc88JN31M2lNMtV3SnfYEN3h2nKYbBFWpiUK6Jz5fAC8sYDauEMNhwP315iZiilK
+n8AIwEvSxz2+JYl7BsGBXkCZ+bU3L9LWmV7N6zbBURwW2gIsRRuSnz44JIwaLC77BIHhyvUmABPV
+kH1TDgcPTKB0A6k9lDIElgBswljkfA/0dnIQIMibXnZdG0O2+d4vGAUwjMZ3DYGVaVMT8FuALlxp
+cvbCOje/SDRsV3mD2FQAePODdYJA8fqH53hkbpKnn6hSKZWR2qORPs6PIOoOvbOoPV0cdwOCPMTM
+/DLw2TYY9PdXo5IBsAwQ0damFc5caDJ/vokwEfv2aJ54OGJiPAQEjuOAnMaypllajrl4/hbvXbrE
+f5z+lGMHS/zScw9QsqdoAI6yiOgNLIHWdle3dnXDUcq0wxRtthSIjkL6wGqDMmaNMGrw2rsBjY0G
++/c47Ju2seU64JL3X4nUvDEO7x/n0NRBzty8yXsff8Sf/eBDvvPCQe6dnQSvitLQDEVubaf7+KpB
+kDQmp03Jd+2tr8xfhfGOhw6aDNT6RoO35gMAHry/hGP7RArsAYnHWLtov13lg7W97D+yj7evnuEv
+XnqXb79whMcOQ+SUCGI3uSduH/LI+p6LqbKdZ9OO0LshQa/5jRoU9MBSZD4qjNqgpibSTcu4gGP7
+vbUIB1sWaYSpRtQFYROCjcQHnZo9QqVq8eKP3+L3nId48L5ZQhuiWNJUnR1P70+1B+irQZl0Axp1
+ENotHbAMCazER334SUShWMRzJLECnwYFO4m0m2GJotvIVRSrAlZg0QjIgQLwyoZTuw+xvtbkr16e
+53u/X2Oj0eTGSpHl9YDV9Xxd3RJEgyEEzaDn2ihjq07pgJWZX8jntwV136NaLiQNCiJiVcKnAbS1
+qx6UGfM22jX4Nqaez9N4ZYNbBDFmeOEXjnN+9Rov/+Rj/uDbx5mddgmDCkHY2+GtyqBwoVOuLI7m
+oF0Kq61VQjS4dqNAtWxRcBwiDZ7XB5iU6GiZYGMFYbsIsUF02+CEky2t6gRV8MAtSH7zF3+WP/3L
+H/LclQUK3jgrqxG31wVBEDJs18t2Eh8XBCGel/zebDYpFout680goFz0AKinaaOxoosfxn1qvGtY
+0KlV62HI/qkJlNJYWhPjggcm1IQpsM8XbqDiJUpeHSF3Y6Jlmp9vEKwuMTdzmMpuk4NkF8Gy4aHa
+JE8enePf3lzgV741jmUVAT9dFg3esvrk7AU+OneFw4fmeP3N95ie2sXhQ3Ocnv+Yy1du8uxTx6lN
+lnj73XkATp08BsDb784zN7eHkyef3DasdCzbqrx0q0G1XMCzLBzHwXVsPE9QcBzsdNQuXPyC2xt5
+P6I2XILVRKNubpwFoDouKU1IijXwxgyOpxAy5Ikjs7xz9haeJ3CLUPCipBVaDfw3vW8PpYrk5Vde
+Y25uDxO1Gi+/8hqlSplvfOMEN5cWef+D88zN7eHUyWO8/8H51udRgIKWZrVNcG3dZnqPh+3aWMqg
+pIWwFIHUOEqzuLCItAT1sAzA4uoE674hiG9R1RUO7vMojRvW5HmmJw4iLY1SEYGvUiARjz1YJQxj
+Fm6sYBWnkhZoM9T/SMvi6VNPcerUSSCZMR87cai15nvkkYO58qM46dctdncSf3nV5+CBAq4twU6T
+97bENhq/mdh+pZCs9a4ulwBoNH3A53a0wT3uFGNjNvVolcUbNmPjYwCtk3omzUJM1caYv7DMZHWN
+85dX+eTSAmtBb5DbKRL4zm/8Mvv3Tff9Xuvhe4NqmwnAXJy1vJw0tlLyOhqQdE4Zi6DhU3RtcG3q
+YWI6hw7s5pvPHOHSjWX+5u/f4oOLqzztJI1eYIEZb2/fB1fLBb5YbTBZHaceaVYaTRr+5rNiteCw
+e7KW7L4AmPZwt3P5eShZMNsuN6K0chCEeI6dK5JV7nuKCS/RpkvhbQBOHXsAgAP7ppiolln4fBUo
+tO4WHWewTJ8N1mLRplK0qJWKOHL4mQS5Q/HTViUHK9SaUAlU1L6mFIBAxxAEkpX1pMF22rG35y/y
+zWeO8MHZa9xe26Ba9rDtZDq3bQ9LJOW0UTlwmRSkoexajBfHsJ3hGaM4Gk0IcLeSa93e3QVitc7S
+WkjZdZNFrIIwdSWiXqPRXGb1dkywVgK3wftnrvL+masEUUwQKI7d3w6W3GIBYUmMVi1omSyvNDh1
+ZE+rXG0ywm4M16zYV/zdP/0747XTSFti25Kjhx/i6MP35cpptbUjHBagzNZP2Nh0nZqzpWTl1gbW
++GTrmtpQbMQSkKhwjPW129Q3JNVyBa8SEMQeE5WA6XGL3bVklvQ8i92TUwjs3PEToxV1P2bpiw0m
+a7PYdgHwKbjupo3doNenXf7sGg/O7sXOre7z5j5IHy2rMOCb/pJqliTzM7sn4Mb1W4zL8aSBKaS1
+taSkY09T30g+VMbrzE3D+PgYcWxTr9dbFU/tnsGWyYtEAhuTNllYktNnblBwJVPVEtcW17h9K2Bh
+YWXTxtbjgPFyKXctCCPe+/Acjz98/6b3W9JGSAm2REqBMXd2BiKFlQy9MSUeuHeNV9+4wey+hwBa
+kNbXEke2cluy956HMdY5il77KbbtAQmsfffOUimNAQop09lUJY8yxLzx00scPzRBvV5nYXGdT69f
+4/r1ZP0WRe2shuO0R95JNacbFsDNW19w6J5JpJO/LmQJyzJYlkBIpwXKJhnATSKNQbAAXIRwOXBf
+ldrYOleuXGdycqYFyg8MfiMpXptQjFWmKY87YPuMFycAqIwXKHklpEw0SSm7BUtKhVKSC5cX+OjS
+Et//7gmuLa7RqEf4oUWx4OSgtBpoW1gyea5Wgx386U8XOXpP23U4noOkAVYRIR2k62HbEiEdyPzn
+HUYQKSxBZorGlDhxdJJXX/uQp+wk+OsEVSjFjFXWqFYbeGWbWmUX5VIVKR1W1yW+30AbhUT2BfbD
+f/6Yp4/tQkUNFhbXubnQoLG+0UoCdkICWqBcKUFKYl+xurJBueS18rTSdQjXG9wq2OyqVZG2hXTA
+8UpIt4jw3ESb7AJCiFHEWRaZdh19qMjpsyXmr87z0PSjOVAFT6SdgYKT76Bju2lWInHkWaiglERK
+xd/+ZJ7L15b58z95lkbgcPzgLh7Y0yQIHhzYQGn3n9ls2RtmVCpFHM/BLRWRjtvWJruAJcS2N/A7
+ntjWLqjxq89H/OCli5xfgv3lx1ugxiqruBUfaZu+cZOULkqFaAssDViJf3jjnc/40b+c4/vfPcFE
+bZJSIKm6Aj/YeqC5lXMN0nGxpI3juQjpYFmjO6HQVVOiXQCeM86vPT/Hiz++xpn6W5wonWSskjjh
+gtA4MsISHo6dlBdCYllOArArUH/pH9/hH16/yB/+1mGOHr6fWBVwvBJYCrcMWt15OnhYij2DlJ2J
+H9VZXdH7dx3yuztBtMqLP/qMT66u8/T9j3DgcJWyoxmrRkjpUiqW8NwCtl2g6dcJwjq+n5ji5Wur
+/PWr/82tlQbf+50TPH5shjAcJ9Y2SrfHSQ1Yy0F+ndc6qJz+Z9LCJp3Nu9eE3fV1rw37nc8a5s76
+wMret2kDE6LB6+/c5NXXFgE4cXgvD+93mZmZoeh5LVhx7HNtcYn5j5Z487+u8vGlBX7uyRl+99cf
+pVIutUABPbBkemywE1y3RnSD2+5CeiSwtAZjFMYolIpQagVpNwn8JqfPrfCv//kZVxeSuahaLjA5
+UWGj7nP52i0gyVr8zPFJfv6ZWXZNVvEjgdFFTAhh3PZzInXS0s57Aytdd7bPonbcIyQG2idEvwpY
+xiQvOUZxjB9qAj8kDnzQEa0DIG6M7SVPdhzF+U97NwJm7qnhpu+0xYFFENpEfvJWaZQmAC0pWwGk
+kCVsO0nuZZCyGbAfzKyMsQQWWaBr5SLxnYLVakV2SjeKDVGkUHGMijVBoFBRTMGVRL7EKdgtcLNT
+u3prjKAeJmUSSDEqgiiIciBURAtYMsvpHIxOiQds7GpiLGzSM9GDezkiyZlhdpw5Vio9kqjwQ528
+oxzG2DJAD9kpyfbrjIJIKVScX0/IjrcoLSl7NAj6axGAsByMjlpBKoBB5g5sf3lmmP7Xr3Bv5brn
+WvcLAcOOc3eLNjaWiDEiNasBU/1X7eA7h2lTsUTygOTdwfQaCTzZEfzZxoCdfye6810byJKK7Tog
+sUllzMjjo1GJBaM5b/l1kJF7xf/Lf7vsfwATg3L02Jgm8AAAAABJRU5ErkJggg==
+"
+       style="display:inline;image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5"
+       d="m 46.222683,1020.16 c 8.333975,-0.071 27.129514,0 35.462879,-0.1802 l -17.709438,18.6283 -35.372568,-1.6657 z"
+       style="display:inline;opacity:0.62999998;fill:url(#linearGradient6406);fill-opacity:1;stroke:none;filter:url(#filter5062)"
+       transform="matrix(0.70870669,0,0,0.20224267,4.9701057,830.67497)" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4476);fill-opacity:1;stroke:url(#linearGradient4468);stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4460"
+       width="39"
+       height="34.000019"
+       x="19.485916"
+       y="993.84576" />
+    <path
+       style="fill:url(#linearGradient4530);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1"
+       d="m 51.55265,1039.9958 -29.999998,0 3,-6 23.937878,-0.1336 z"
+       id="path4512"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4520);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4510"
+       width="16"
+       height="9.0000172"
+       x="28"
+       y="1029.3622" />
+    <g
+       transform="matrix(0.92787456,0,0,0.92766861,-334.80763,585.97703)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:0.30075619;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430-2"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(3.3253216,0,0,3.3245835,49.654056,-2426.2108)" />
+    <g
+       transform="matrix(3.1391206,0,0,3.5217855,49.654056,-2426.2108)"
+       style="font-style:normal;font-weight:normal;font-size:15.56941891px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="text3782-3" />
+    <g
+       id="g11331-3-1-1-00"
+       style="display:inline"
+       transform="matrix(0,-0.14879357,0.14879357,0,3.0151033,1093.2759)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-1" />
+    </g>
+    <g
+       id="g7590-7-0"
+       style="display:inline"
+       transform="matrix(1.122791,0,0,1.122791,51.605476,-118.01412)" />
+    <g
+       id="g7827-7-5"
+       style="display:inline"
+       transform="matrix(0.45489265,0,0,0.45489265,119.65899,561.31682)" />
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,71.714017,852.06346)"
+       style="display:inline"
+       id="g11331-3-1-1-0">
+      <g
+         id="g13408-8-4"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#384569;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 56.989486,995.8587 -35.499999,0 0,30.5"
+       id="path4478"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#819dc4;stroke-width:0.99999982px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 22,1024.8622 33.5,0 0,-28.5"
+       id="path4478-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#c5ccd6;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 20.985916,1025.8458 35.5,0 0,-30.5"
+       id="path4478-1-4"
+       inkscape:connector-curvature="0" />
+    <circle
+       style="display:inline;opacity:1;fill:#ffffeb;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4984)"
+       id="path4534-9"
+       cx="17.5"
+       cy="1030.8622"
+       r="14"
+       transform="matrix(1.1084537,0,0,1.1084624,0.35349044,-111.8097)" />
+    <ellipse
+       style="opacity:1;fill:url(#linearGradient5041);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5031)"
+       id="path5009"
+       cx="21.588707"
+       cy="1046.0166"
+       rx="15.364794"
+       ry="1.6100959" />
+    <ellipse
+       style="display:inline;opacity:1;fill:#eceee6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4534-4"
+       cx="19.751431"
+       cy="1030.8623"
+       rx="13.99989"
+       ry="14" />
+    <path
+       style="display:inline;fill:#faf8ff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0)"
+       d="m 19.57989,1030.4338 0,-13.577 c 6.933977,-2e-4 13.67501,6.9493 13.576826,10.0041 z"
+       id="path4620-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:#faf8ff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-4)"
+       d="m -13.666785,1005.1109 1.161185,-12.9517 c 4.0695527,0.23247 10.7443039,6.19437 11.87981528,9.2895 z"
+       id="path4620-5-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       transform="matrix(-0.99999218,0,0,-1,5.9137479,2036.4825)" />
+    <path
+       style="display:inline;fill:url(#linearGradient5022);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-0)"
+       d="m -4.8580548,1007.0312 -1.7458573,-12.74883 c 7.24929196,-0.95759 12.7683084,3.82096 13.5094793,7.37643 z"
+       id="path4620-5-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       transform="matrix(-0.14456141,-0.98949567,0.98948793,-0.14456254,-977.63999,1171.806)" />
+    <path
+       style="display:inline;fill:url(#linearGradient4934);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-49)"
+       d="m -9.0220443,997.69719 -2.1437267,-11.87986 c 7.4203185,-2.43164 15.217233,4.86601 14.9167613,8.93224 z"
+       id="path4620-5-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       transform="matrix(0,1,-0.99999218,0,1018.3411,1039.9465)" />
+    <path
+       style="fill:url(#linearGradient5042);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796)"
+       d="m 19.937173,1030.7464 4.376741,-12.7731 c 3.367335,0.5614 5.452204,3.0464 7.41366,5.7166 z"
+       id="path4620"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <ellipse
+       style="display:inline;opacity:0.46100003;fill:#828877;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5012)"
+       id="path4534-2-9"
+       cx="19.751431"
+       cy="1030.8623"
+       rx="5.9999614"
+       ry="6.0000081" />
+    <path
+       style="display:inline;fill:#eceab4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-5)"
+       d="m 19.66921,1030.0766 -8.038911,-9.7363 c 0.819785,-0.058 5.009981,-3.5206 7.770945,-2.769 z"
+       id="path4620-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <ellipse
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4542-7);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4534-2"
+       cx="19.751431"
+       cy="1030.8623"
+       rx="2.0533831"
+       ry="2.0533991" />
+    <path
+       style="fill:url(#linearGradient5030);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4792)"
+       d="m 19.401245,1031.7289 -11.433118,5.27 c 0.8910204,2.5032 2.747862,3.9513 4.823347,5.27 l 6.609771,-10.0041"
+       id="path4622"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <rect
+       style="opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect5068"
+       width="2"
+       height="2"
+       x="43"
+       y="1026.8622" />
+    <rect
+       style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect5068-8"
+       width="2"
+       height="2"
+       x="47"
+       y="1026.8622" />
+    <rect
+       style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect5068-85"
+       width="2"
+       height="2"
+       x="51"
+       y="1026.8622" />
+    <rect
+       style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect5068-85-3"
+       width="2"
+       height="2"
+       x="55"
+       y="1026.8622" />
+    <ellipse
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient4542);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4534"
+       cx="19.751431"
+       cy="1030.8623"
+       rx="13.99989"
+       ry="14" />
+    <rect
+       style="opacity:0.656;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5282)"
+       id="rect5140"
+       width="20"
+       height="16"
+       x="25"
+       y="1000.3622"
+       transform="matrix(1.2408001,0,0,1.1760011,-6.0200014,-176.06482)" />
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/wizban/revert_wiz.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/wizban/revert_wiz.svg
@@ -1,0 +1,1257 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="revert_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient5113"
+       inkscape:collect="always">
+      <stop
+         id="stop5115"
+         offset="0"
+         style="stop-color:#a1adb2;stop-opacity:1" />
+      <stop
+         style="stop-color:#484d50;stop-opacity:0.44705882;"
+         offset="0.54978573"
+         id="stop5119" />
+      <stop
+         id="stop5117"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4600">
+      <stop
+         style="stop-color:#f5f4f4;stop-opacity:1"
+         offset="0"
+         id="stop4602" />
+      <stop
+         style="stop-color:#aca6d1;stop-opacity:1"
+         offset="1"
+         id="stop4604" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4588">
+      <stop
+         style="stop-color:#aca6d1;stop-opacity:1"
+         offset="0"
+         id="stop4590" />
+      <stop
+         id="stop4596"
+         offset="0.42751902"
+         style="stop-color:#aca6d1;stop-opacity:1" />
+      <stop
+         style="stop-color:#c9c2da;stop-opacity:1"
+         offset="1"
+         id="stop4592" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5904"
+       inkscape:collect="always">
+      <stop
+         id="stop5906"
+         offset="0"
+         style="stop-color:#c5c6c6;stop-opacity:1" />
+      <stop
+         id="stop5908"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5898"
+       inkscape:collect="always">
+      <stop
+         id="stop5900"
+         offset="0"
+         style="stop-color:#c0c1c1;stop-opacity:1" />
+      <stop
+         id="stop5902"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4581">
+      <stop
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0"
+         id="stop4583" />
+      <stop
+         style="stop-color:#9f9f9f;stop-opacity:1"
+         offset="1"
+         id="stop4585" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4461">
+      <stop
+         style="stop-color:#d8d8d8;stop-opacity:1"
+         offset="0"
+         id="stop4463" />
+      <stop
+         id="stop4488"
+         offset="0.18565373"
+         style="stop-color:#848484;stop-opacity:1" />
+      <stop
+         id="stop4486"
+         offset="0.36054265"
+         style="stop-color:#848484;stop-opacity:1" />
+      <stop
+         style="stop-color:#b4b4b4;stop-opacity:1"
+         offset="1"
+         id="stop4465" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4994"
+       id="linearGradient6375-6"
+       x1="50.702839"
+       y1="1052.4476"
+       x2="19.083021"
+       y2="1011.338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1849336,0,0,0.66623436,-14.611709,336.57322)" />
+    <linearGradient
+       id="linearGradient4994"
+       inkscape:collect="always">
+      <stop
+         id="stop4996"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop4998"
+         offset="1"
+         style="stop-color:#d2f1ff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4902"
+       id="linearGradient4238"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.1864665,0,0,3.1937368,-16.514189,-2320.1195)"
+       x1="10.632975"
+       y1="1039.059"
+       x2="10.632975"
+       y2="1051.5835" />
+    <linearGradient
+       id="linearGradient4902"
+       inkscape:collect="always">
+      <stop
+         id="stop4904"
+         offset="0"
+         style="stop-color:#777777;stop-opacity:0.74901962" />
+      <stop
+         style="stop-color:#aeaeae;stop-opacity:0.74901962"
+         offset="0.33183977"
+         id="stop4469" />
+      <stop
+         id="stop4906"
+         offset="1"
+         style="stop-color:#939195;stop-opacity:0.93333334" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4461"
+       id="linearGradient4467"
+       x1="60.069771"
+       y1="1001.3622"
+       x2="60.069771"
+       y2="997.19556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999996,0,0,1.2,-33.999595,-197.27328)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient4547"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3158111,0,0,1.3158111,-46.947849,-316.29485)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient4547-0"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.2632053,-1.2632053,0,1280.6373,958.56999)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4581"
+       id="radialGradient4587"
+       cx="68.5"
+       cy="1004.8622"
+       fx="68.5"
+       fy="1004.8622"
+       r="1.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-33.999595,1.9991657)" />
+    <radialGradient
+       gradientTransform="translate(-28.999595,1.9991657)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4581"
+       id="radialGradient4587-5"
+       cx="68.5"
+       cy="1004.8622"
+       fx="68.5"
+       fy="1004.8622"
+       r="1.5"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       gradientTransform="translate(-23.999595,1.9991657)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4581"
+       id="radialGradient4587-0"
+       cx="68.5"
+       cy="1004.8622"
+       fx="68.5"
+       fy="1004.8622"
+       r="1.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5904"
+       id="linearGradient5890"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.1052631,0,0,-1.2903226,134.31659,2338.3296)"
+       x1="41"
+       y1="1007.8622"
+       x2="60.03624"
+       y2="1007.8358" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5898"
+       id="linearGradient5892"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.3684211,2.232687,0,-2202.74,1093.4675)"
+       x1="41"
+       y1="1007.8622"
+       x2="59.944244"
+       y2="1007.8496" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient6406"
+       gradientUnits="userSpaceOnUse"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908" />
+    <linearGradient
+       id="linearGradient5517"
+       inkscape:collect="always">
+      <stop
+         id="stop5519"
+         offset="0"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+      <stop
+         id="stop5521"
+         offset="1"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4344"
+       x="-0.027383927"
+       width="1.0547678"
+       y="-0.085576579"
+       height="1.1711532">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.57051052"
+         id="feGaussianBlur4346" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4588"
+       id="radialGradient4594"
+       cx="97.263908"
+       cy="1030.1702"
+       fx="97.263908"
+       fy="1030.1702"
+       r="8.5639986"
+       gradientTransform="matrix(0.61643491,-0.00397629,0.00390627,0.6055797,33.282911,406.55415)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4600"
+       id="radialGradient4606"
+       cx="138.94159"
+       cy="1032.0073"
+       fx="138.94159"
+       fy="1032.0073"
+       r="3.736028"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-43.157564,-1.0306284)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4668"
+       x="-0.12"
+       width="1.24"
+       y="-0.12"
+       height="1.24">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.3736028"
+         id="feGaussianBlur4670" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4814"
+       x="-0.1075394"
+       width="1.2150788"
+       y="-0.12403573"
+       height="1.2480715">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.59922692"
+         id="feGaussianBlur4816" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4868"
+       x="-0.20310421"
+       width="1.4062084"
+       y="-0.30803791"
+       height="1.6160758">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.49605655"
+         id="feGaussianBlur4870" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4899"
+       x="-0.10440006"
+       width="1.2088001"
+       y="-0.10439994"
+       height="1.2087999">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.0442745"
+         id="feGaussianBlur4901" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4953"
+       x="-0.14381381"
+       width="1.2876276"
+       y="-0.15414436"
+       height="1.3082887">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.96600426"
+         id="feGaussianBlur4955" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5031"
+       x="-0.11202575"
+       width="1.2240515"
+       y="-1.0690457"
+       height="3.1380913">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.4343883"
+         id="feGaussianBlur5033" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient5041"
+       x1="98.407524"
+       y1="1065.2891"
+       x2="136.02242"
+       y2="1065.2891"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-72.132292,-19.229144)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5113"
+       id="linearGradient4547-2"
+       x1="41"
+       y1="1007.8622"
+       x2="71.199471"
+       y2="1008.7954"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53573978,0,0,0.53573978,-15.144387,486.91037)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient4547-4"
+       x1="41"
+       y1="1007.8622"
+       x2="69.500023"
+       y2="1007.5228"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.4736849,-1.4736849,0,1502.7712,949.94107)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient4547-2-6"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5263158,0,0,1.5263158,-44.578946,-516.45362)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#e7e7e7"
+     borderopacity="1"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.832768"
+     inkscape:cx="64.091421"
+     inkscape:cy="32.083835"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       transform="translate(0,-986.3622)"
+       y="986.36218"
+       x="82"
+       id="image4399"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAABHNCSVQICAgIfAhkiAAAD0BJREFU eJztm9lzG0d+xz/dPTMAQfCASIoiJZESrVumLPle7ZZTrtgPqcpuJVWb9UNe9jX/zL5vnnJtVSpV edpU8rAbu7JO1pJ8yLZkKbJkWRJFiuJNgDgG00ceBhdJAAQvH3K+VUNiBj3d01/8+nf2COec4/+x CdaBMY4wspQjR2Qc3rf9UN8lGOswBsLIEumYoEb84MmyDrR2aGuJNETaYmzztj9YsrRxaOOwFqxz lKP4vB1+UGRZB9Y6Iu2oaurIOMqRpRPF/YMhK9Kx5FRJqkqTsZ3bt2eeLG1iRV03+oLIOCLdQjG1 wTNLlqksN7vBM9opUfAMklW1bpuWlxOUtcXujCfgGSOrauE2udlOEEZ28/Vt4pkgy7rYP7IONpm1 PSIKWpC1uLDEP/zj3+++928A77zzDgcGDzU1/c6xZ0RBC7JyxTyTk5N7M8I+o1gsNb1eJWov0Zys 1SwLCwt7OtB+YfjQyKZrzkF5hxavHZqSVSjkmZ+f3/PB9gO5XHbdeZWo/cilNJes7PdHsgr5fO2z s/sjUVU0Jev48Qmmp6f3bdC9xIEDA/GHfVp6jWhKVibTz5mzZ3nt1Vf3dfDd4uq1a3Sl0jigrPc/ h9mULE/5+J6/74M3olgsMjPzBIDnnptgaWmJ5eUVurqSjI6ObjoH8D2fwFfob4Ao+A45pblcjk8/ /QSIyXo6t8itLz7j4NAgo6Ojm84bsY3Ewa7QlCxtom9m9EYYwdpaXVkXC2usreVJdvc2Pa+iHJlv 7BFFs4LF0tISd+/d+17orN7eDKNHJwBonErjrDbO0DZp52p/1kdMxjpcxW40lSxnoVwq8GBqCgAV rG8mRF2f+Z7cdL9SEifWX5eyci42nO8Cxhi0Lu+6HwAc6Aoxxjqs20xyS501v7jCjcXbtfOk14uf cgjpEXgKleiqfecHCTxP4duIZG6V3NARkp7C84OGNqo+aMP12jWlNl3bCivWo2fbd8VwgDGxlBnj akWKds5sS7Kc1SBhcHCQdGYAVZmMUrFESK8+4erkRTFHOPeArDpLplts+n7T4DsgqBGqWIK+VMft rYtJMbZSnHDrl99WaEqWsRprNMmgl3RmgJGj4x11ZogIgb50Cs83uyajE0Tl9svQVZaXNvESs9WL O0Bb18FPOZRSKNGuVR0GCMOQqjbq9L6dQusikG7+LLYuRW6PHPuWZEVaA/Gy286kIydIEC+x/Sar +oyNiLOlbMq97wWak2XiWSaCBIlOF3QFNtoj69QhIh3hXFzBMRWXaz+IglZOqYswOsIDlO9vS0JM FCfjlNi7ZSgr/XgN/VUjnHKkCKPvQLiT7koA9YfdCkKHRFrTW+m10/tawRPxoQRINpM/cnCQVCqJ r0Sso/aZs5ZkmcrIgbc9ixZVwo+dSlUjQX7lsy9jX1aK9WwMj4wQKEXgC4wVGOOIrIstzT6gJVlC KvwgUZtAp9BRxTCI7d1XHccXkJAxQUo4POFYXVsju1qmrA264j32dCfwEl2kEwkSPhgLWgqkgYj4 fK91V2uygiQpJEm5vQGjHQa2noCkrBLlEFozNbvM47kskTb4nqInlWB+pUCmJ0m+WCbShkhbelIJ jgz3M9ifQkqBFI6yBm3EnhLWkizf97HJBNJPbEtCIh0SCIMUquP7lIClLx7zxysPOPvyEfrGerl1 fx5rLeMj/Qz2pznQ24V1jl//6xVenxzjhVOjLK8WWMwWmF/Oc/3ODJmeJBdPjxL4EiEALOXN3sWO 0VbBp/ztKx6lFB/+8687bt/d3c3gcFyhSfcPMP0ox9Xf30VkAt7680nGjmSwtrrBzBH4sQ51xuJ5 isH+NJmeFPPLazxZXOM/r93j8oVxUl0JnAPnBOU9Sng1z5QKn0QlBkx4nTuXCSmQwmPswqWOH6Cv Z4ChvjQH+gP+7W+v85OfPc+pC4fIr+S5+ttbXAXOv36ME88P44xl8sQhxkcOUNqw3DN9XYSRZmY+ yx+u3+eNSxN0JRNY52r7H3aL5pKlHNIPSARxALydZIrvK45MvkJSba3gPQFpBUnlmJtbJuqWTN2Z Iz3USzLwePsXl8iv5bj50Twfv3uX8dMHOffKGD2pgMiCNhZX2emRy4d88r/TBJ7HYCbFh7emeOPF CTwlMRXJ3G3Ys2VaWXrettwApQSBhG4VW7Z2aFTm125MMXRugLv/M8NPf3mETz9+QrFQZGh8gB+/ NQFMcOP6E/7jnz4imfKZuDDMc2dGSaSS5PIlbt+fI/A8fvYn51jJFfj0zhPuTS1wcuwgxqp4r+g2 o5GNaO1nhQXuXb8GgO91lqqPtEZI1ZEz6onYafWE44uv5wgjzcXTI3jTIY8fZTl/aYibV2ZYKy5R HO3l8OFuXrk8xouvjjEzvcrMvXl+86v3uPiTCV5+8zkmTx6irztJISxjrCMIFLfvz3Hi6CBKSpSk Fg7tFC1ZUIkUQWaI7mSy487ypRJ+dgmIl267ZRiHQw4p4O6jBTK9Kfp7UoyfGeaLKw84duISx84O c/vGLOcnh5lfKrA8F4dS3T0JTr94lPOvjvO7f7nOR+/BxTcmmF3K1vZlDR/o4d7UAlOzyxw+dAAh wFpTcyWa7tMS7R3wlmSlkwEnz5zB+glUi+TdRmSXFshNfV3zwNtBCZBCsJzLkc2HHD98AGMdw8f7 +fjdiNWlAiYs88KLI8w+WuTe/fVl+t6+JBPnhnj7F5f4za/e4+zLRwkCj2IpQhtLOhWQ8D0ez2U5 eiiDcAZnI6yNH8xttJBCIaRpS1hT3a2kRyLwCKSixxP0eXR0dEuH58t1IUurQwqHxLK8HEtLXzqB sxZjHSdeOsqXn8+SGuhm8GCZXF4zdizD2LEMI8fydHmC7GqJ+7diX+ziTya4+vsvSSWCmoevtSUI FNNzq0ghECK+biONjTTOmNrRKdoaOuUJPCWRFf2y1eErgZB1g9C+vUAhyBVCjLXkCiFPl9YwxnL4 xAEefzlLpi9BFCU5M6k5MtbL4XHFQO8wyb6uGmHz80VGxjOsrRTxKu5OvlhmOVfEWkdYNmAtzljQ Ec7o2tEIIQVC7nAZKj+BVPHX23FNpR/gV6Rnq/uccDXd8f71BwAM9KW4fGGcI6cOMfXlHEcmhkCM MjAo0LqPQs4n3bVCWPJBl1mayzJ2vJ4tnV/O8/nduLId+IrA83DCgrUYt/mJpO+BDCoef3s0Jata xVI4vEqs1Sl84WqWrv19AlGh01jLz//0Qu0bbQ2nLhxi6s4c42dHMGGcNlcqfmLhJYF6QTbM18cZ ynTzF2+ex5OKLx/Nc/fRwmb9BMgggfK9WEe5zmoWLZehUoqgtgRFR4fvSVBxTTG2dG3aV8ZJp2Lj USiFaGsIyxFGWw6O9vDwzhxdgUB5K+QLIdlVixeUcLq+26+n2+POZzOMHjtAKYzQ2rK8WiRXKFEo RZgGs6eEQygPlUziBQnEFtavY7Ig/u2llMhKw60OgIQn8SU1QloeFbEfHIjrj4/nshQrkzPWslYM mTg3zEfv3UDrHGt5x+paidycIJR1yzj9KMf9m0944fI4i9kC2li0sayulZhdyHFooCeOK6UEz8fv SsWluR3k25qSpbWmXCrgeyCxHSt4gFDbWKpo31YQS95gb5qeVILpuVWgWpVxrOZLXHxjgrs3s9y6 ZikXLLMPV5lfLLG22E0hXyZaynLvk4e8+fOL5MqaUqgrfVgKpYiy1owM9iKFBOnhBUnELtK3LQsW 2Vw+HqQDRV2F0JpCdqmy1LaKKQXOgRBwcmyQazenWFjJ099Tr3Q/fLrMX/7NZT77r6/497+7SjKd IAg8ymVNaS0kmU7wZ3/9Et0HU3w1vYjvKZwDi6mRf3p8CCs8LLap7toONpFljCFXyDE/95SrV69s q7NCPs/iYpZPrn7QUftMZpC+3m5OHe7hsy897jxY4LXJo8zMZ3kws8yFkyM8ml1i4uXDnP/RGDNf r7A8m0V2BYwdT9M3lOHp4irTlfYAx0YzFEplcoWQQwM9pLoShBEt3yHcDmq7aIwxhKEmCjUzT2f4 43//AWjIfDo6E7HGH2+L9plMP0fHjzJ65AhFHfC7K3fJ9HaxuFpgoC/FW6+dYnahrp+Sifpvq42l FOqaAh/q7+a379+mK+FjrEVry1+9/QI93SnCyBBGrKtIV8v26/7TvlgtnHPOGIOODGEYEkURJjKU SoZIR+hyHD7YJgXNvUCqp5uedJJ0b4r3P5/izoMFEoHHL3/6Mo+frrCULa5rf+P+ND96/jira6Xa xLQxvHT6MJ9/Ncu1m/HOnx9fHOfcxChh5AgjV8tn7ZosiCWr+vLixiiz3Tt5tpIkqsZczduIyv+G 0KI6hATP8/E98JTk3Q/vcfvrOQb6UhwbzeBvqC5dufGI1yfHGOrvZqZB6hZXCzxdXCMsa54/cYjL LxynHFnCCMoNdcXdkFWTa6UUG72OKkfV3Vi2cmFjh86Ba1h/Tb93cU/VqH9TG8A5yVuvnuBgJs0H Nx7y8e1pBvpSZHpTZPoS69orTxJpy0quyOxijnJkCHzFm688x8mxg/H7zsaxlxsDm+78q6JRoJyr v221c7JoSpZ1sTuhVCVmVI5iIeKDmw/56vFibStkuivBWjGsFX/XiiEQhzVnjh3k9fNHQXlobSvV nXi8xgzpnizDTolqSUYrstz6vpqRZWzcv3AGIUEIiScsUsW6ZmYhx/zqGtOzudo9QaAY6EsxOtjL 6GA3kRZobSlFETrU6+JAJRxG1tNMSjqM86hvPlQ7J6sdUc06bEdW7TtXjQMd1up4i6OxaG3QoQYd 1QwKgBfE28uTSYXyFULGW84bUTVG2kUU8wZdjigUi7jKC07Cl3hSIT0PT0mc9PA9gZNxQlMoD1HZ QyakqOeyWoRBbclyTaRgN2TFWxJjokzZETmNDjXlskWXi5ioTLkc1ibrJ3yCRIAXxCRt3JvfaK0b 71s3wT0kbBNZG4naDVn1ncDrJcs5izW2EtpotK5Y4nK8fJQpE+mISDuEbe6yVJN8VmtkkxpBlZja eVCPDEQQP4t0Eie89SRBZ5LlqhPfwMZektVKwVfHtBZcQ2hibd2cGWtqpa9m3kwr98WJOmlSNJb0 66Rsy3XYquF+Q1Syb1I6QFa5RTZkL2WV6MqfVpZs4/6GjdZQNrGGnaBmD+oD7p6xfd4d+a2hTtYe StW3KKD7Cgnf3ItC33fs/p2QjXiGif8/w2JPQg8HctsAAAAASUVORK5CYII= "
+       style="display:inline;image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <ellipse
+       style="opacity:1;fill:url(#linearGradient5041);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5031)"
+       id="path5009"
+       cx="45.082684"
+       cy="1046.0598"
+       rx="15.364914"
+       ry="1.6100959" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-5"
+       d="m 61.725004,1022.8099 c 8.333975,-0.071 16.668598,0 25.001963,-0.1802 l -22.750843,15.9784 -29.322882,0.1009 z"
+       style="display:inline;opacity:0.62999998;fill:url(#linearGradient6406);fill-opacity:1;stroke:none;filter:url(#filter4344)"
+       transform="matrix(1.4111948,0,0,0.94753947,-46.400984,56.684021)" />
+    <g
+       transform="matrix(0.92787456,0,0,0.92766861,-334.80763,585.97703)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:0.30075619;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430-2"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(3.3253216,0,0,3.3245835,49.654056,-2426.2108)" />
+    <g
+       transform="matrix(3.1391206,0,0,3.5217855,49.654056,-2426.2108)"
+       style="font-style:normal;font-weight:normal;font-size:15.56941891px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="text3782-3" />
+    <g
+       id="g11331-3-1-1-00"
+       style="display:inline"
+       transform="matrix(0,-0.14879357,0.14879357,0,3.0151033,1093.2759)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-1" />
+    </g>
+    <g
+       id="g7590-7-0"
+       style="display:inline"
+       transform="matrix(1.122791,0,0,1.122791,51.605476,-118.01412)" />
+    <g
+       id="g7827-7-5"
+       style="display:inline"
+       transform="matrix(0.45489265,0,0,0.45489265,119.65899,561.31682)" />
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,71.714017,852.06346)"
+       style="display:inline"
+       id="g11331-3-1-1-0">
+      <g
+         id="g13408-8-4"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4"
+       d="m 7.000405,1009.361 41,3e-4 c 0,0 -0.06713,15.3717 0,29 l -41,0 z"
+       style="display:inline;fill:url(#linearGradient6375-6);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-1"
+       d="m 6.5,997.86533 c 18.334725,0.1145 42.000815,0 42.000815,0 l 0,40.99577 -42.000815,0 z"
+       style="fill:none;stroke:url(#linearGradient4238);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-1"
+       d="m 7.000405,1003.3613 41,10e-5 c 0,0 -0.06713,3.1803 0,5.9999 l -41,0 z"
+       style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-1-6"
+       d="m 7.000405,998.36133 41,1e-4 c 0,0 -0.0671,3.18027 0,5.99987 l -41,0 z"
+       style="display:inline;fill:url(#linearGradient4467);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-1-1-8"
+       d="m 33.000405,1005.3613 3,10e-5 c 0,0 -0.005,1.5901 0,2.9999 l -3,0 z"
+       style="display:inline;fill:url(#radialGradient4587);fill-opacity:1;stroke:none" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7.000406,1009.8613 25.000411,0"
+       id="path4539"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547-0);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7.500406,1010.3613 0,24.0009"
+       id="path4539-4"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-1-1-8-5"
+       d="m 38.000405,1005.3613 3,10e-5 c 0,0 -0.005,1.5901 0,2.9999 l -3,0 z"
+       style="display:inline;fill:url(#radialGradient4587-5);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect4001-3-4-1-1-8-3"
+       d="m 43.000405,1005.3613 3,10e-5 c 0,0 -0.005,1.5901 0,2.9999 l -3,0 z"
+       style="display:inline;fill:url(#radialGradient4587-0);fill-opacity:1;stroke:none" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient5890);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 48.000816,1037.8622 -40,0"
+       id="path4539-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient5892);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 47.500818,1037.3623 0,-26.0001"
+       id="path4539-4-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547-2);stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 6.8209441,1026.8622 17,1026.8622"
+       id="path4539-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547-4);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 17.5,1010.3622 0,28"
+       id="path4539-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:url(#linearGradient4547-2-6);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 18.000001,1021.8622 29,0"
+       id="path4539-7-8"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g4989"
+       transform="translate(-52.44312,0.92005475)">
+      <circle
+         transform="matrix(0.79058864,-0.79058943,0.79058864,0.79058943,0.69906687,-88.946113)"
+         id="path6139-1-6"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter4899);enable-background:accumulate"
+         cx="-646.4776"
+         cy="769.27448"
+         r="12.003155" />
+      <circle
+         transform="matrix(0.7071064,-0.70710716,0.7071064,0.70710716,0,0)"
+         id="path6139-1"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#c6d1e0;fill-opacity:1;stroke:#8fa5c2;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         cx="-659.59735"
+         cy="797.53235"
+         r="12.003155" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4520"
+         d="m 97.534732,1018.3622 0,3.4847"
+         style="fill:none;fill-rule:evenodd;stroke:#8fa5c2;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4520-2"
+         d="m 97.523212,1037.8014 0,4.2255"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#8fa5c2;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4520-2-4"
+         d="m 109.749,1030.3004 -3.80681,0"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#8fa5c2;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4520-2-3"
+         d="m 85.780522,1030.397 4.2255,0"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#8fa5c2;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <g
+         transform="translate(-22.350035,-0.61001096)"
+         id="g4582">
+        <path
+           style="display:inline;fill:none;fill-rule:evenodd;stroke:#8fa5c2;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 111.34557,1022.6438 2.46405,2.464"
+           id="path4520-8"
+           inkscape:connector-curvature="0" />
+        <path
+           style="display:inline;fill:none;fill-rule:evenodd;stroke:#8fa5c2;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 125.08301,1036.3975 2.98788,2.9879"
+           id="path4520-2-6"
+           inkscape:connector-curvature="0" />
+        <path
+           style="display:inline;fill:none;fill-rule:evenodd;stroke:#8fa5c2;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 128.42394,1022.4486 -2.69182,2.6918"
+           id="path4520-2-4-3"
+           inkscape:connector-curvature="0" />
+        <path
+           style="display:inline;fill:none;fill-rule:evenodd;stroke:#8fa5c2;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 111.54398,1039.4651 2.98788,-2.9878"
+           id="path4520-2-3-1"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         transform="matrix(1.33762,0,0,1.3432956,-30.269727,-350.89875)"
+         sodipodi:nodetypes="ssssss"
+         inkscape:connector-curvature="0"
+         id="path4517-4"
+         d="m 101.52912,1028.2953 c 0,3.0376 -2.462439,5.5001 -5.499997,5.5001 -3.037559,0 -5.499989,-2.4625 -5.499989,-5.5001 0,-1.4133 -5.90837,-8.4027 -5.03233,-9.3768 1.0068,-1.1197 8.90805,3.8769 10.532319,3.8769 3.037558,0 5.499997,2.4623 5.499997,5.4999 z"
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4953)" />
+      <path
+         sodipodi:nodetypes="ssssss"
+         inkscape:connector-curvature="0"
+         id="path4517"
+         d="m 103.39548,1029.7841 c 0,3.0376 -2.46243,5.5 -5.499988,5.5 -3.03756,0 -5.49999,-2.4624 -5.49999,-5.5 0,-1.4133 -5.90837,-8.4028 -5.03233,-9.3769 1.0068,-1.1197 8.90805,3.8769 10.53232,3.8769 3.037558,0 5.499988,2.4624 5.499988,5.5 z"
+         style="opacity:1;fill:url(#radialGradient4594);fill-opacity:1;stroke:#9178b3;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <circle
+         r="3.736028"
+         cy="1030.5258"
+         cx="96.621414"
+         id="path4598"
+         style="opacity:1;fill:url(#radialGradient4606);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4668)" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4672"
+         d="m 88.505214,1021.3789 7.343226,3.6716 c 6.38579,0.6687 6.50341,4.0352 5.60404,7.923"
+         style="fill:none;fill-rule:evenodd;stroke:#f5f3f9;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4814)" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4818"
+         d="m 89.213771,1022.6672 5.861699,3.8649"
+         style="fill:none;fill-rule:evenodd;stroke:#aca6d1;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4868)" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/wizban/uninstall_wiz.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/wizban/uninstall_wiz.svg
@@ -1,0 +1,1463 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="uninstall_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4453"
+       inkscape:collect="always">
+      <stop
+         id="stop4455"
+         offset="0"
+         style="stop-color:#f6be4a;stop-opacity:1" />
+      <stop
+         id="stop4457"
+         offset="1"
+         style="stop-color:#f6edba;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4437">
+      <stop
+         style="stop-color:#ba9a39;stop-opacity:1"
+         offset="0"
+         id="stop4439" />
+      <stop
+         style="stop-color:#ae8829;stop-opacity:1"
+         offset="1"
+         id="stop4441" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5134"
+       inkscape:collect="always">
+      <stop
+         id="stop5136"
+         offset="0"
+         style="stop-color:#446190;stop-opacity:1;" />
+      <stop
+         id="stop5138"
+         offset="1"
+         style="stop-color:#a4b4c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5034">
+      <stop
+         style="stop-color:#e2cefd;stop-opacity:1"
+         offset="0"
+         id="stop5036" />
+      <stop
+         id="stop5044"
+         offset="0.50000155"
+         style="stop-color:#d5b9fe;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2cefd;stop-opacity:1"
+         offset="1"
+         id="stop5038" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5024">
+      <stop
+         style="stop-color:#c9c7ff;stop-opacity:1"
+         offset="0"
+         id="stop5026" />
+      <stop
+         id="stop5032"
+         offset="0.41626066"
+         style="stop-color:#aca8fd;stop-opacity:1" />
+      <stop
+         style="stop-color:#bcb9fa;stop-opacity:1"
+         offset="1"
+         id="stop5028" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5016">
+      <stop
+         style="stop-color:#dee6ee;stop-opacity:1"
+         offset="0"
+         id="stop5018" />
+      <stop
+         style="stop-color:#c7d2e0;stop-opacity:1"
+         offset="1"
+         id="stop5020" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4928">
+      <stop
+         style="stop-color:#f1f2ec;stop-opacity:1"
+         offset="0"
+         id="stop4930" />
+      <stop
+         style="stop-color:#d2d5c4;stop-opacity:1"
+         offset="1"
+         id="stop4932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4536">
+      <stop
+         style="stop-color:#446190;stop-opacity:1;"
+         offset="0"
+         id="stop4538" />
+      <stop
+         style="stop-color:#b8c4d4;stop-opacity:1"
+         offset="1"
+         id="stop4540" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4524">
+      <stop
+         style="stop-color:#828da3;stop-opacity:1"
+         offset="0"
+         id="stop4526" />
+      <stop
+         style="stop-color:#8897ab;stop-opacity:1"
+         offset="1"
+         id="stop4528" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4514">
+      <stop
+         style="stop-color:#4b5875;stop-opacity:1"
+         offset="0"
+         id="stop4516" />
+      <stop
+         id="stop4522"
+         offset="0.3333365"
+         style="stop-color:#828da3;stop-opacity:1" />
+      <stop
+         style="stop-color:#49607e;stop-opacity:1"
+         offset="1"
+         id="stop4518" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4470">
+      <stop
+         style="stop-color:#f8f9fb;stop-opacity:1"
+         offset="0"
+         id="stop4472" />
+      <stop
+         style="stop-color:#9eb8d8;stop-opacity:1"
+         offset="1"
+         id="stop4474" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4462">
+      <stop
+         style="stop-color:#a0adc0;stop-opacity:1"
+         offset="0"
+         id="stop4464" />
+      <stop
+         style="stop-color:#a3afc2;stop-opacity:1"
+         offset="1"
+         id="stop4466" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient6406"
+       gradientUnits="userSpaceOnUse"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908" />
+    <linearGradient
+       id="linearGradient5517"
+       inkscape:collect="always">
+      <stop
+         id="stop5519"
+         offset="0"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+      <stop
+         id="stop5521"
+         offset="1"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5031"
+       x="-0.11202575"
+       width="1.2240515"
+       y="-1.0690457"
+       height="3.1380913">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.4343883"
+         id="feGaussianBlur5033" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient5041"
+       x1="98.407524"
+       y1="1065.2891"
+       x2="136.02242"
+       y2="1065.2891"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,-95.625351,-19.272328)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4462"
+       id="linearGradient4468"
+       x1="48"
+       y1="994.36218"
+       x2="88"
+       y2="1028.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-28.014084,-0.01639)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4470"
+       id="linearGradient4476"
+       x1="51"
+       y1="995.36218"
+       x2="84"
+       y2="1026.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-28.014084,-0.01639)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4514"
+       id="linearGradient4520"
+       x1="36"
+       y1="1037.3622"
+       x2="36"
+       y2="1029.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.1249998,0,-128.67002)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4524"
+       id="linearGradient4530"
+       x1="49"
+       y1="1039.3622"
+       x2="46"
+       y2="1034.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5134"
+       id="linearGradient4542"
+       x1="27"
+       y1="1042.3622"
+       x2="7"
+       y2="1020.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515675,8.628538e-5)" />
+    <linearGradient
+       gradientTransform="matrix(0.14667021,0,0,0.14667136,17.184701,879.66442)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4536"
+       id="linearGradient4542-7"
+       x1="27"
+       y1="1042.3622"
+       x2="7"
+       y2="1020.3622"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4792"
+       x="-0.16768435"
+       width="1.3353687"
+       y="-0.17985532"
+       height="1.3597106">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4794" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-4"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-0" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-0"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-5" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-5"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-9" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-49"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-01" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4928"
+       id="linearGradient4934"
+       x1="-11.097116"
+       y1="988.03119"
+       x2="1.5470241"
+       y2="994.73035"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4984"
+       x="-0.084"
+       width="1.168"
+       y="-0.084"
+       height="1.168">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.98"
+         id="feGaussianBlur4986" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5012"
+       x="-0.048"
+       width="1.096"
+       y="-0.048"
+       height="1.096">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.24000032"
+         id="feGaussianBlur5014" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5016"
+       id="linearGradient5022"
+       x1="-5.7292957"
+       y1="996.90344"
+       x2="4.3120389"
+       y2="1000.6044"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5024"
+       id="linearGradient5030"
+       x1="9.1587505"
+       y1="1035.391"
+       x2="12.099871"
+       y2="1039.3212"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515674,9.266038e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5034"
+       id="linearGradient5042"
+       x1="21.856897"
+       y1="1019.8043"
+       x2="27.984741"
+       y2="1023.2879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515674,9.266038e-5)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5062"
+       x="-0.050661981"
+       width="1.101324"
+       y="-0.14436312"
+       height="1.2887262">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.1205165"
+         id="feGaussianBlur5064" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5282"
+       x="-0.27631978"
+       width="1.5526396"
+       y="-0.34539973"
+       height="1.6907995">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.3026648"
+         id="feGaussianBlur5284" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4527"
+       id="linearGradient4533"
+       x1="29.521629"
+       y1="29.827848"
+       x2="31.546745"
+       y2="39.175972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-0.41994314,1068.4388)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4527">
+      <stop
+         style="stop-color:#fbe093;stop-opacity:1"
+         offset="0"
+         id="stop4529" />
+      <stop
+         id="stop4445"
+         offset="0.5360797"
+         style="stop-color:#f6be4a;stop-opacity:1" />
+      <stop
+         style="stop-color:#fadc84;stop-opacity:1"
+         offset="1"
+         id="stop4531" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4437"
+       id="linearGradient4443"
+       x1="21.818333"
+       y1="1041.7073"
+       x2="37.309193"
+       y2="1027.6471"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4453"
+       id="linearGradient4451"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-8.6400594,2067.7057)"
+       x1="35.85693"
+       y1="1035.3833"
+       x2="38.551533"
+       y2="1038.062" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4483"
+       x="-0.035450512"
+       width="1.070901"
+       y="-0.036566069"
+       height="1.0731321">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.30606006"
+         id="feGaussianBlur4485" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4503"
+       x="-0.044383361"
+       width="1.0887667"
+       y="-0.052252434"
+       height="1.1045049">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.1559278"
+         id="feGaussianBlur4505" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#e7e7e7"
+     borderopacity="1"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.2071921"
+     inkscape:cx="72.663009"
+     inkscape:cy="33"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       y="0"
+       x="75"
+       id="image4434"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAABHNCSVQICAgIfAhkiAAAE6ZJREFU
+eJztnGmQHVd1gL/b69vmzZt5M9LMaButSLZl2dqwjbEdLCfYjglFsaXCUoRQCUUVqcQkZKtQqSRF
+qBAqUKnkBz9SYCgSYhNwCBhsAg4UGEm2bAvJkqxdlkbLbG+Zt3T3vTc/+u3bvJElQxU5Va153X26
++96vzz333HNvS2itNf8vbaI1BFLjBYqSpwmkxvp5F+oXSZTSBFJR9EJQgWy2o196WFqDH0ik0niB
+6AipKr+0sKTSeL5EaQFAyYNAqp7X/FLB0hqUboQkCCSUvN6QqnLdYJ04doLzcwuv6h6m0Z/eIgax
+qMTjMVauWLOo3nWDVfLh1Pm5vvWFAIFAiLBZmP2SqohsIKa0Yml9/NzPF9ZSxBDtkAxDNOmYRjM8
+qVrNKTwvpcIQBhqNusZR0WsCa9++g+x/9vBr8ai+5YE3386aydVLuuY1gbX/2cN8+pMfY2I83WQx
+ZoPxNPbWSoU7Smtk5besKFR7LF82nKvER+H5+m8/0BVd1XTtoePn2bNthJdPX1pSPV6zZjgxniYR
+tTEqzckQ7U2k2o2rhiZWBaKUQimN1CHMKshGiFWAVXiWWQVn1IC9GnnNYBmGwDIFUbf+SNMQNRgQ
+OmYAKavQQihKC5QKdQ2lUAKkFkBVP7yHbYY6phGGBJYZ/rUtQdWnLRZL9ZKrgvXs4+9mbupQbX9o
+/EaSy3awbMMDDI7c2PNas81xh/tSaQxhoLTCNEUNgCEEDTwxDAOlZO2cJDxpmQaBVG0v4FrKVcGa
+vXSWeCzO6PAy0hu2If04hcJlDn37g0TTO7jp3k+2XWOKsHKNIoSB1t3ftGGImv/qJY1wr6csLZip
+yBve9VU27/kcpN/Ikb1PMqgusWLtbna/+WGGR2Ls++qvMpc70/vBhkYIWdtvtbh2/asq6jWVq7Ks
+WHIlseRKhsd3k15zN/uf+ii74iOI5CZWrN1NLJbm+Z/8BWL4E2gRAdrjJqVEBVhv61pMrmeza5VX
+/bqGx3cTTe/gwpmjUAi74sTEDiZv2EUs/0TzwxaxHgBD/PwtqJv0VbLM9CGe/PwdHPjWRzqeTwxP
+4hXn0UEGAFvOs/LGd5IqPUU2Ex5TDTFRVZRqh6eWaGWvlVVBH7Ay04fY99i7ESrHK0ee6KiTXnM3
+5VIW7WdrxyIDE8RiceLBMbxSqUm/sYLVJrhYpVXb8ObVi1jc0JukJ6zThx5l32PvJhaLs/2et3bV
+ywXFjsfdwcmm/caerRo8VrdO0k9PCLwmPSH0gHX60KMc/M7HicXi7Ny2neTwzV1vkjn6XdxIMtzx
+ch11Aj+0DKVVzw2aK986GO5mYdVgcynNcqn+sWNvePrQozz3jY+xddvNrB5bhoiv6HqD8y99jfzU
+93jdDTc1HReGQ7lYB6daom3TbG8DTZCafFszoKraYlmFanq4OkZsjN77BSWVpvr4NliNoNasWo+I
+jyCsQXwz1aRXyL7C8b3/wuUTj3PnTWHULuzQuszEKoLiLIX5syw4m4DDCMNEaY1BJWLv0XQaB9Lh
+eLE+Prxa6WdsWAUTDrNoy4k1waqC2nHbXYyPpDEG11e0YjWdZx59L7m5EwiVY2wkXQcVTyOsQXAG
+EJFVXHnpG0jRnAJRWhBI1RbJN+vomi6IGqDW5tXJn/myvcftV4rl8Dm9jLUG6/ShRznwzb/kjW/5
+PYYGEhBbHvqfoACE4cB9r9+F9mYhPQQM1W5iDIzXrWpoCwAXjv8v58Wv1CundVhxw0DpXlmH7pmH
+8HhLJ9HFQrvN0LSKEL0BNYoF8OJTf86JZ/+TOx98H0NDy/CjqwCwnYaKTP247WIjOR5alJ1EWIOY
+y3aCiDN79vvMXjrLPO/ABpxIpKHXqzj6jsXpbBlVcLXmqZqzoI2+qB+ragS8lGSqBXB875e557f+
+hujAcoiMgZcFVahrBQVEfATDccDLoX0PYTuAC4BIbsJMrAI7QSlznOee+BTzg38IOXBct7mgfTaR
+Rsuq5rF6id9Foercr4VYAMKMcebQT7j1gc+CvoTvZdsUhTUIhO9eOKEzF5FxrPQEWqfATjB3/nme
+e+JTrN35MLlzk9jFLJFIBK9UQkpNEFRSK4sMe5qa2iIZ1EapHgtaMqPXSiyAuz/wKE//69uB3+fW
+B/6ByIBHKXO8QSuGlZ4A3TJbI0K/JfPnOLjvB0yfP8CmB/6JkeHtvDR/mCFMTNMgPTwQ6lXq108Q
+2RQ6tMDpdX0nQL5UtePFsqzcU7HUZR4WwPCyGxqAPcwt9/8VdmQM5s6FDr7SG86erU86zExnccpz
+nL8yA8DyDe/gpns/ie3GKJc91q5JMXUpD8DrtmykmiDtJypv9EetFtQIqjUf36jbj1VprgIWhMB+
+7cPf5Yf/9rs8/+1PcOv9f4YWNyAv7w+B6Tl+8NgjTGx6IwCx1GqMoVu58eZdDI6sB/ywAHoex4GB
+qEKPhj3EzVvHiLgK8MAEXzoEUi3qvzpZUCOEbn6qm1StqipLnSlrirNiyZW86f1f4X++8Js889if
+8Pq3fhxr+QaCS/UmedvbHwGCyuajdRmt8wjKzC8UyGYCgkDiySLlkiKeMNi5dYR4dA4lYyjlAB6m
+cCgHdWCtYLpZRqdYqt1X1SP3azFRUZW2CN52kzVgP/36p3j9gx/BWr4B9BwDoxOEkIpoXUZQZna+
+wIHDWS5czjOTCd9czPEpeDaXZjK1+27fWGb9ZIpN64YxjBhKaQxDUPQsPF/1bDaNFtQPJGjuBa+V
+o+84NmwE9tyT/8iO+34DgIGh9UARdJbMQoH9L2Q5cb7EirTFunHJ7bdohqJl4o6NZw1jmhsplgc5
+emqaQyem+I8nLwAXeM9DG1g5EUHKOFEHpDIJZHuz6gSmtfJBBx+2mKQGon3ptUrXtHIjsAPf/xG3
+vukhYqnVoLMcOpHnxZcLjCbh7p0OUbsAmMTt+kIQExOt49jaYcvoGtZFJymu0jxz4giffWQ/O7eM
+8dB9Y0SsGL4VQ0kHX9ahtPqzfgC1xlSdesFXIz2H3lVgppNi6uRJRidW8OyhIsdOZlk7Fmes4sC1
+jvT9wFuX3cB7tj7IqdPn+dwXT1IOCgxECkRdrzbvV/YlQaWi9U03bPXjUPFNDbPP1e1ax1mL5ils
+N8bWe/+A1NhGLgQ7mM5KxkcHse3el2ojgiFs5IJNOS8oZupvfTSV5n07PwDA5754EtMGx/BwbL8y
+QaqbtpJXh1csyxocP9AUyrIGp+gFTSCLZVnbqlIul9rK2q8sMrujCB06zPkbmM57pJLVDEQZgCCI
+UKJE1IYFP97UFH1lN92tnKsDdgcUH7rjLfzdt77EVx9/gV+/byPS85ibhSsFs2ulfD/oq2LFcne9
+xlnxpUgfsHxQOc5e8EklYzi2iedLAlzwwHXClLLWEYSoV1CICJSpWVUVlDsQNo3oYDjk+eADD/D3
+X/kaO7eOsGblCuLxGJMZSb4/Jk3i++3NrtsEyOxcpuPxXtIDVmhVWpe5cFkh7CjJRARfChy8JmBA
+zbryMwXygEpk8IsaK7OiIyg3ETbLm0ZHuXP7Rr755Dl+571D5HMlMjnNXLZIyatmVc2OJbRNRSRi
+kVtQ5HKzDKdStWtm5jKsWJ5ioSTxvIBCsciykWE838fzAiyr8z1fBSwfQZlzFyWDQxEcy8QwBcq0
+MS0HGXh4fghsfvYKCwtXGIhUshX5LPlZIJPFNcZYuWqoZk1uQuNGTUwHDAfe+eAuPvrXL3Px4hyp
+5AhZ0wbqkyBSdu7Jjh07w979h0mPpDh1/DTJVIq1q8d44cUj5Ao+N25ejem4nDp+um1/7YZJ3nDH
+9msFK7Sq2fkCgbJIxiMopbGlxBcmIAEHB4/zr8xQWPAZjLfcIgNe3oDERaYLs2xYsR43amInwLA1
+pgFKS0YHXTaO2fzsWJk9d0niWUkhYrFQKvcs/OTaVZQ9jzOnz7Nnzx213zt2b+OGLevZu/cgmfkM
+9z94F/F4gr3PHKC4UOD+B+8inR5ZEqhFYIVycUZhuxHsitlKZSICiWlZOEFANoByZSoss5AiU3CY
+y8WAHLposC6RYHDUwR3wKVtXGBweQUmFkgFeWaJ0OKbcsnk9h4+cYM9dY5hu2GyV0k1rRTvJunWT
+rFs3idYajWZy7Wp0JX++a9fWJt277rl9yYAapQussICCMpmsJho3caxKBbTGtkyUUkjb5MqVaVwr
+ClaUmUyJ2WzYAxZKZWCOYqnAm5alCXSJqek8TrQCXfq1p2klWbtiiC//dx6/NM+ZM0WOnl7gyNGz
+ZL3ent4S8N53vYXVE8MA+HJpM6dLGYz3sKxKFkF6LBsewHWspp6luuBMBiWGklGKnk9pxmI4CQ/t
+2Y3rmHzp8X2cOneZo6d8RlOhfnbwEq7TPtzwAr/yN4TjlwMKfsDCQqFNt1Xirs3wYDj71H3CtvF3
+S9p6KTn4XnJ2WrJunYFrm4DZlgFKRKrDE5tCIcONWycZTESQUnHLDas5de4yc3kYbZhJEw3Lh3TL
+9JZjWcRcie1ajA0mFq3ANcwaLyqLwhpNKoJA1oYOOgibUbV1yLxB3tCUZkMAh05MsWndGI5l8Pzh
+swAMJcB2LHwvwNQRDGGhdHgD0WHdle1YJOIaK+KS8nuP6Tzf58rMDPFEfcg1lBzEcUJ3oJVEUw8T
++l0S0El6wKpH3xeuZEjFkgR1N4PnQakEC3KQ0nyWKzOCqIxRKBT4/L8/DUBuocRAPMLK5WFa2XUh
+kghHAEaL33as5mg/4g4QixSBGL0kKJX56f6DHDt2ErsSma+YGOf2W7e06coOq3ZaRRsCQ1h0+mCu
+C6zwbWtchgYCprMFCpVRTHVBTLESBtlmlLMzOebnFBAnPZEh5hgUPJtVowarRusFHEyna7+FUX/b
+WkleOjHF9vUJtI5gCEnE9kkMxHCd3g6+0zccly9Pk5nLE40sIfA0bYRlYigDuly2eDNMJ9l/ZJrN
+E68D6pBylYFxPjeIDAQwRXJwgeGkZiiZJB6Lk1uYwfcClC4RjcVZnh6u3bexNxSGyf6XLrJrS5LZ
+TJFXLpU5cvwyp45f7quey1cOtR07cOQwOzZv6HmdZYbWbNohBgMDYdodrQp6wrIQwmX1RBKYZWrq
+CqnUaA0SQCbrU8hbxKIposkFLGOGmNvugwbiaZYvH246ZlYKKqXP9HyOMxcy/PFvr+TSJcV8Pkd2
+Pk/JX0C25Oqra09N08CyzMr0WjusTLbM1Pw8I3Zz+sioxIum2wDKtDEcB9Gl+fUBq17pm9YO8MKp
+Y2wXI5WChFZRyIcp4dSQIjEQI55cj7DnGXCiuDGXVCGOsH0sK4IwTKT0a5AaoX39qZNsX5/ANhNk
+cnPkFwTZQvdUSr8fQV24OM3wxES9RpXrTNfGMm1M20K4EUzTBVFB0c9ah3YxABuNy85tCfYemub0
+hbMMJcaBOijHNqgGsdGISWIgRTwWJxpNUoxlyS2Eo3utZEdgR49P8fS+l/nT92/mlQsLnL+S58K5
+K+QyuVr07tihNVQHv9V9gGg8Rj5XICiVsSL12e9YxGZuDgZMlzXL0ximgWGZmK6NG4mCaWNaNqbt
+onR/8BfxWWFTdG2X++8a4LHvHmYr4TqIKqhYIiAxkCGeLGGbZapT+gCGsDFNl8AvoowAQzU79nzJ
+4zOP/ISH7pxk1y3j5HMu48NruG2zT1D2Wwtz1WK5dpM1mW4MYdoYxtLyWj21tTYRIgoCNq+FzWsX
+OHjqO6yK7CIWTdVAATimxnJFEwzLMjFNm8BvXkYppU/R1/ztPz/F8GCED79rLZlyBCUG0KbCjdmY
+7jWE1dLkwjX1S18VvQhaUQEWNse37VnD1546w76f/ZCtK3cDowDEk6VKjxJW0BDNfkkYBlqpmnWd
+v1zmM194mljE4tN/tI2STuHYcZS2iNrNX1XoLumZxaQ1pgotycAwzKsOTLvCqs/WCpRyMQzQBrxt
+zxrGUw6P/2gvl4uD7NywARDYZgFhmNh2vSBCWLi2SeBbSDz8ouSJHx/jse8d5e33TvChd26mrFL4
+XixsspaF22H5ZKtI1T1+qvacrRW7FoudRaf/BKPxiNKVNImWCF1CUkKIPFMXr/Bf37vEiyfnmFyx
+jG0bh1m7JsX4aALXSuJGoiipmMtOc/DoFD89eJnnDp8l4lo8/L71bFqTpiwj+H4EFdh4viAIZFsG
+02hcJAYI06ytwql+oqKxF/3Sot+BdK8p/Z6w/EBS8gLK5TKe9BDVyQKzSEQUcSKSV6ZL7D0wy+HT
+Bc5dnK3do9QwYRBxLXZsSnHPbWk2rUkjPQMvMCmULAJPEJQDyn5DLFWJgayGXrMaODbCrIKsA2y2
+p0b/eV1gVfeU1pQ8n7InKZYX8AuScjHMXFpG6JvicYlpKhxLYjoKb6HI6enmlMrwYJSRVAzpGUgl
+8HyLsm/UIBWLAUqqWgxkNMCoQoP2aLsKTZsuphEWWlRy9YZhX39YuvJPmHUMP872pcT3Fb7v4ZcK
+eL5AlvP1Sjjh5a6tMM3OjkHKEEQjpLKvUUHdebdG1tAdEDRbFdBmWY2g4HrA0tW/7SuXlAo/HZFK
+o7SqTTsprZGBjxDN+fLGsR+A9EJgnt/dgXfyT9C8UrDxUzrTEATKavr87tUm//qC1WhVtf1FHlp/
+QPvB5s95q2vf636s2xis31XG3fSuJ6x6ia9hxrG1wIYIF/+bZv1xQZfwyaqEDv1Cey3FgKWvgPtl
+lV/cLyF/AeX/APNVjfGOk5dMAAAAAElFTkSuQmCC
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <g
+       transform="matrix(0.92787456,0,0,0.92766861,-334.80763,585.97703)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:0.30075619;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430-2"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(3.3253216,0,0,3.3245835,49.654056,-2426.2108)" />
+    <g
+       transform="matrix(3.1391206,0,0,3.5217855,49.654056,-2426.2108)"
+       style="font-style:normal;font-weight:normal;font-size:15.56941891px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="text3782-3" />
+    <g
+       id="g11331-3-1-1-00"
+       style="display:inline"
+       transform="matrix(0,-0.14879357,0.14879357,0,3.0151033,1093.2759)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-1" />
+    </g>
+    <g
+       id="g7590-7-0"
+       style="display:inline"
+       transform="matrix(1.122791,0,0,1.122791,51.605476,-118.01412)" />
+    <g
+       id="g7827-7-5"
+       style="display:inline"
+       transform="matrix(0.45489265,0,0,0.45489265,119.65899,561.31682)" />
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,71.714017,852.06346)"
+       style="display:inline"
+       id="g11331-3-1-1-0">
+      <g
+         id="g13408-8-4"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <ellipse
+       style="opacity:1;fill:url(#linearGradient5041);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5031)"
+       id="path5009"
+       cx="21.588707"
+       cy="1046.0166"
+       rx="15.364794"
+       ry="1.6100959" />
+    <g
+       id="g4521"
+       transform="translate(6.2329079,0.01643584)">
+      <path
+         transform="matrix(0.70870669,0,0,0.20224267,4.9701057,830.67497)"
+         style="display:inline;opacity:0.62999998;fill:url(#linearGradient6406);fill-opacity:1;stroke:none;filter:url(#filter5062)"
+         d="m 46.222683,1020.16 c 8.333975,-0.071 27.129514,0 35.462879,-0.1802 l -17.709438,18.6283 -35.372568,-1.6657 z"
+         id="rect4001-3-4-5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         y="993.84576"
+         x="19.485916"
+         height="34.000019"
+         width="39"
+         id="rect4460"
+         style="opacity:1;fill:url(#linearGradient4476);fill-opacity:1;stroke:url(#linearGradient4468);stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4512"
+         d="m 51.55265,1039.9958 -29.999998,0 3,-6 23.937878,-0.1336 z"
+         style="fill:url(#linearGradient4530);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1" />
+      <rect
+         y="1029.3622"
+         x="28"
+         height="9.0000172"
+         width="16"
+         id="rect4510"
+         style="opacity:1;fill:url(#linearGradient4520);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4478"
+         d="m 56.989486,995.8587 -35.499999,0 0,30.5"
+         style="fill:none;fill-rule:evenodd;stroke:#384569;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4478-1"
+         d="m 22,1024.8622 33.5,0 0,-28.5"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#819dc4;stroke-width:0.99999982px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4478-1-4"
+         d="m 20.985916,1025.8458 35.5,0 0,-30.5"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#c5ccd6;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         y="1026.8622"
+         x="43"
+         height="2"
+         width="2"
+         id="rect5068"
+         style="opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1026.8622"
+         x="47"
+         height="2"
+         width="2"
+         id="rect5068-8"
+         style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1026.8622"
+         x="51"
+         height="2"
+         width="2"
+         id="rect5068-85"
+         style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1026.8622"
+         x="55"
+         height="2"
+         width="2"
+         id="rect5068-85-3"
+         style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="matrix(1.2408001,0,0,1.1760011,-6.0200014,-176.06482)"
+         y="1000.3622"
+         x="25"
+         height="16"
+         width="20"
+         id="rect5140"
+         style="opacity:0.656;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5282)" />
+    </g>
+    <g
+       style="display:inline"
+       id="g8662"
+       transform="matrix(-0.74565918,0.74221622,0.74316719,0.74661456,-731.92164,214.87529)">
+      <path
+         style="fill:url(#linearGradient4533);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4443);stroke-width:0.94988102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 40.244943,1041.4693 c -0.24182,0.7378 -4.40107,-3.7831 -4.40107,-3.7831 -12.608129,11.8645 -23.639522,-2.7899 -13.392575,-10.4071 1.603395,-1.1919 -3.274598,13.2754 8.85868,6.3613 0,0 -4.890976,-4.2929 -4.186894,-5.3539 0.390532,-0.5886 13.008987,-0.7195 13.731155,0.03 0.722169,0.75 -0.343071,12.3401 -0.609296,13.1524 z"
+         id="path4522"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscszsc" />
+      <path
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#fefeeb;stroke-width:0.94988102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4483)"
+         d="m 40.029866,1028.5266 c 0.335464,3.4409 -0.540551,10.8513 -0.558812,11.097 -0.130143,-0.1351 -3.471725,-2.9728 -3.471725,-2.9728 -8.256342,6.6256 -14.064589,4.3406 -15.782066,0.9534 -1.920574,-3.7877 0.368338,-8.6621 1.441156,-8.1716"
+         id="path4449"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4451);stroke-width:0.94988102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4503)"
+         d="m 22.915973,1035.265 c 1.319182,1.5207 4.851335,1.724 10.215246,-1.3613 -3.722931,-2.2 -4.848283,-5.098 -4.899966,-5.234"
+         id="path4522-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+    </g>
+    <g
+       id="g4507"
+       transform="translate(2.1231354,0.62550812)">
+      <circle
+         transform="matrix(1.1084537,0,0,1.1084624,0.35349044,-111.8097)"
+         r="14"
+         cy="1030.8622"
+         cx="17.5"
+         id="path4534-9"
+         style="display:inline;opacity:1;fill:#ffffeb;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4984)" />
+      <ellipse
+         ry="14"
+         rx="13.99989"
+         cy="1030.8623"
+         cx="19.751431"
+         id="path4534-4"
+         style="display:inline;opacity:1;fill:#eceee6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620-5"
+         d="m 19.57989,1030.4338 0,-13.577 c 6.933977,-2e-4 13.67501,6.9493 13.576826,10.0041 z"
+         style="display:inline;fill:#faf8ff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0)" />
+      <path
+         transform="matrix(-0.99999218,0,0,-1,5.9137479,2036.4825)"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620-5-0"
+         d="m -13.666785,1005.1109 1.161185,-12.9517 c 4.0695527,0.23247 10.7443039,6.19437 11.87981528,9.2895 z"
+         style="display:inline;fill:#faf8ff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-4)" />
+      <path
+         transform="matrix(-0.14456141,-0.98949567,0.98948793,-0.14456254,-977.63999,1171.806)"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620-5-5"
+         d="m -4.8580548,1007.0312 -1.7458573,-12.74883 c 7.24929196,-0.95759 12.7683084,3.82096 13.5094793,7.37643 z"
+         style="display:inline;fill:url(#linearGradient5022);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-0)" />
+      <path
+         transform="matrix(0,1,-0.99999218,0,1018.3411,1039.9465)"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620-5-2"
+         d="m -9.0220443,997.69719 -2.1437267,-11.87986 c 7.4203185,-2.43164 15.217233,4.86601 14.9167613,8.93224 z"
+         style="display:inline;fill:url(#linearGradient4934);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-49)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620"
+         d="m 19.937173,1030.7464 4.376741,-12.7731 c 3.367335,0.5614 5.452204,3.0464 7.41366,5.7166 z"
+         style="fill:url(#linearGradient5042);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796)" />
+      <ellipse
+         ry="6.0000081"
+         rx="5.9999614"
+         cy="1030.8623"
+         cx="19.751431"
+         id="path4534-2-9"
+         style="display:inline;opacity:0.46100003;fill:#828877;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5012)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620-3"
+         d="m 19.66921,1030.0766 -8.038911,-9.7363 c 0.819785,-0.058 5.009981,-3.5206 7.770945,-2.769 z"
+         style="display:inline;fill:#eceab4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-5)" />
+      <ellipse
+         ry="2.0533991"
+         rx="2.0533831"
+         cy="1030.8623"
+         cx="19.751431"
+         id="path4534-2"
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4542-7);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4622"
+         d="m 19.401245,1031.7289 -11.433118,5.27 c 0.8910204,2.5032 2.747862,3.9513 4.823347,5.27 l 6.609771,-10.0041"
+         style="fill:url(#linearGradient5030);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4792)" />
+      <ellipse
+         ry="14"
+         rx="13.99989"
+         cy="1030.8623"
+         cx="19.751431"
+         id="path4534"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient4542);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/icons/wizban/update_wiz.svg
+++ b/bundles/org.eclipse.equinox.p2.ui/icons/wizban/update_wiz.svg
@@ -1,0 +1,1463 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="75"
+   height="66"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="update_wiz.svg"
+   inkscape:export-filename="/Users/d021678/git/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/wizban/newclass_wiz2.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4453"
+       inkscape:collect="always">
+      <stop
+         id="stop4455"
+         offset="0"
+         style="stop-color:#f6be4a;stop-opacity:1" />
+      <stop
+         id="stop4457"
+         offset="1"
+         style="stop-color:#f6edba;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4437">
+      <stop
+         style="stop-color:#ba9a39;stop-opacity:1"
+         offset="0"
+         id="stop4439" />
+      <stop
+         style="stop-color:#ae8829;stop-opacity:1"
+         offset="1"
+         id="stop4441" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5134"
+       inkscape:collect="always">
+      <stop
+         id="stop5136"
+         offset="0"
+         style="stop-color:#446190;stop-opacity:1;" />
+      <stop
+         id="stop5138"
+         offset="1"
+         style="stop-color:#a4b4c8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5034">
+      <stop
+         style="stop-color:#e2cefd;stop-opacity:1"
+         offset="0"
+         id="stop5036" />
+      <stop
+         id="stop5044"
+         offset="0.50000155"
+         style="stop-color:#d5b9fe;stop-opacity:1" />
+      <stop
+         style="stop-color:#e2cefd;stop-opacity:1"
+         offset="1"
+         id="stop5038" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5024">
+      <stop
+         style="stop-color:#c9c7ff;stop-opacity:1"
+         offset="0"
+         id="stop5026" />
+      <stop
+         id="stop5032"
+         offset="0.41626066"
+         style="stop-color:#aca8fd;stop-opacity:1" />
+      <stop
+         style="stop-color:#bcb9fa;stop-opacity:1"
+         offset="1"
+         id="stop5028" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5016">
+      <stop
+         style="stop-color:#dee6ee;stop-opacity:1"
+         offset="0"
+         id="stop5018" />
+      <stop
+         style="stop-color:#c7d2e0;stop-opacity:1"
+         offset="1"
+         id="stop5020" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4928">
+      <stop
+         style="stop-color:#f1f2ec;stop-opacity:1"
+         offset="0"
+         id="stop4930" />
+      <stop
+         style="stop-color:#d2d5c4;stop-opacity:1"
+         offset="1"
+         id="stop4932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4536">
+      <stop
+         style="stop-color:#446190;stop-opacity:1;"
+         offset="0"
+         id="stop4538" />
+      <stop
+         style="stop-color:#b8c4d4;stop-opacity:1"
+         offset="1"
+         id="stop4540" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4524">
+      <stop
+         style="stop-color:#828da3;stop-opacity:1"
+         offset="0"
+         id="stop4526" />
+      <stop
+         style="stop-color:#8897ab;stop-opacity:1"
+         offset="1"
+         id="stop4528" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4514">
+      <stop
+         style="stop-color:#4b5875;stop-opacity:1"
+         offset="0"
+         id="stop4516" />
+      <stop
+         id="stop4522"
+         offset="0.3333365"
+         style="stop-color:#828da3;stop-opacity:1" />
+      <stop
+         style="stop-color:#49607e;stop-opacity:1"
+         offset="1"
+         id="stop4518" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4470">
+      <stop
+         style="stop-color:#f8f9fb;stop-opacity:1"
+         offset="0"
+         id="stop4472" />
+      <stop
+         style="stop-color:#9eb8d8;stop-opacity:1"
+         offset="1"
+         id="stop4474" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4462">
+      <stop
+         style="stop-color:#a0adc0;stop-opacity:1"
+         offset="0"
+         id="stop4464" />
+      <stop
+         style="stop-color:#a3afc2;stop-opacity:1"
+         offset="1"
+         id="stop4466" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4541">
+      <stop
+         style="stop-color:#a1adb2;stop-opacity:1"
+         offset="0"
+         id="stop4543" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4545" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4974" />
+      <stop
+         style="stop-color:#f5f8fd;stop-opacity:1"
+         offset="1"
+         id="stop4976" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop4966" />
+      <stop
+         style="stop-color:#e8eefa;stop-opacity:1"
+         offset="1"
+         id="stop4968" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:1"
+         offset="0"
+         id="stop4958" />
+      <stop
+         style="stop-color:#dee6f8;stop-opacity:1"
+         offset="1"
+         id="stop4960" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter8854">
+      <feFlood
+         flood-opacity="0.933333"
+         flood-color="rgb(244,248,254)"
+         result="flood"
+         id="feFlood8856" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite8858" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="1.2"
+         result="blur"
+         id="feGaussianBlur8860" />
+      <feOffset
+         dx="-1"
+         dy="3"
+         result="offset"
+         id="feOffset8862" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite8864" />
+    </filter>
+    <linearGradient
+       id="linearGradient6122">
+      <stop
+         style="stop-color:#c0c0c0;stop-opacity:1"
+         offset="0"
+         id="stop6124" />
+      <stop
+         id="stop6132"
+         offset="0.5"
+         style="stop-color:#adadad;stop-opacity:1" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1"
+         offset="1"
+         id="stop6126" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7087">
+      <stop
+         style="stop-color:#17325d;stop-opacity:1;"
+         offset="0"
+         id="stop7089" />
+      <stop
+         id="stop7091"
+         offset="0.25"
+         style="stop-color:#b4d0e2;stop-opacity:1" />
+      <stop
+         id="stop7093"
+         offset="0.5"
+         style="stop-color:#b7d2e4;stop-opacity:1" />
+      <stop
+         style="stop-color:#acc9de;stop-opacity:1"
+         offset="0.75"
+         id="stop7095" />
+      <stop
+         style="stop-color:#3e72a7;stop-opacity:1"
+         offset="1"
+         id="stop7097" />
+    </linearGradient>
+    <mask
+       id="mask7366"
+       maskUnits="userSpaceOnUse">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         id="path7368"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+    </mask>
+    <linearGradient
+       id="linearGradient7584-5">
+      <stop
+         id="stop7586-4"
+         offset="0"
+         style="stop-color:#f9cd5f;stop-opacity:1" />
+      <stop
+         id="stop7588-5"
+         offset="1"
+         style="stop-color:#fbf0b4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7592-1">
+      <stop
+         id="stop7594-6"
+         offset="0"
+         style="stop-color:#bd8416;stop-opacity:1" />
+      <stop
+         id="stop7596-9"
+         offset="1"
+         style="stop-color:#a66b10;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-6-6-2-6-7-98-9-4-1">
+      <stop
+         style="stop-color:#5aad60;stop-opacity:1;"
+         offset="0"
+         id="stop10800-5-2-1-8-20-4-0-2-1-9-0-0-1-1" />
+      <stop
+         id="stop10806-6-8-5-3-9-2-2-7-0-4-2-7-8-9"
+         offset="0.5"
+         style="stop-color:#5bb26a;stop-opacity:1;" />
+      <stop
+         style="stop-color:#a4c589;stop-opacity:1"
+         offset="1"
+         id="stop10802-1-5-3-0-4-6-8-5-5-6-69-6-4-0" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask7366-4">
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path7368-2"
+         d="m -16.593048,1040.862 9.990206,0 0,10.0018 -2.983353,3.0385 -5.966213,0 c -0.53033,-0.022 -1.04064,-0.5519 -1.04064,-1.0385 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7087"
+       id="linearGradient9331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-20,0)"
+       x1="4.7776356"
+       y1="1039.8118"
+       x2="4.7776356"
+       y2="1041.911" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-18,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9333"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-16,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9335"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-14,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9337"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1041.911"
+       x2="4.7776356"
+       y1="1039.8118"
+       x1="4.7776356"
+       gradientTransform="translate(-12,4.7e-5)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient9339"
+       xlink:href="#linearGradient7087"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1042.7973"
+       x2="163.22012"
+       y1="1042.7973"
+       x1="88.220117"
+       id="linearGradient68073"
+       xlink:href="#linearGradient4956"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2669"
+       x2="163.22012"
+       y1="1032.2668"
+       x1="94.469681"
+       id="linearGradient68075"
+       xlink:href="#linearGradient4964"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(-80,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1032.2668"
+       x2="152.72206"
+       y1="1032.2668"
+       x1="88.220116"
+       id="linearGradient68077"
+       xlink:href="#linearGradient4972"
+       inkscape:collect="always" />
+    <filter
+       id="filter8854-9"
+       inkscape:label="Drop Shadow"
+       style="color-interpolation-filters:sRGB">
+      <feFlood
+         id="feFlood8856-0"
+         result="flood"
+         flood-color="rgb(244,248,254)"
+         flood-opacity="0.933333" />
+      <feComposite
+         id="feComposite8858-2"
+         result="composite1"
+         operator="in"
+         in2="SourceGraphic"
+         in="flood" />
+      <feGaussianBlur
+         id="feGaussianBlur8860-3"
+         result="blur"
+         stdDeviation="1.2"
+         in="composite1" />
+      <feOffset
+         id="feOffset8862-2"
+         result="offset"
+         dy="3"
+         dx="-1" />
+      <feComposite
+         id="feComposite8864-3"
+         result="composite2"
+         operator="over"
+         in2="offset"
+         in="SourceGraphic" />
+    </filter>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2"
+         offset="0"
+         style="stop-color:#7564b1;stop-opacity:1" />
+      <stop
+         style="stop-color:#5d4aa1;stop-opacity:1"
+         offset="0.5"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2"
+         offset="1"
+         style="stop-color:#9283c3;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7540-2-3-8-7">
+      <stop
+         id="stop7542-8-7-5-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.47623286"
+         id="stop7544-8-2-0-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0.5"
+         id="stop7546-1-7-9-5" />
+      <stop
+         id="stop7548-98-9-2-4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7272-66-4-5-5-5-8">
+      <stop
+         style="stop-color:#8f6c10;stop-opacity:1"
+         offset="0"
+         id="stop7274-6-0-1-7-4-7" />
+      <stop
+         style="stop-color:#c9a645;stop-opacity:1"
+         offset="1"
+         id="stop7276-66-6-3-9-1-4" />
+    </linearGradient>
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10540"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1030.3411"
+       x2="-10.159802"
+       y1="1030.3411"
+       x1="-22.453552"
+       gradientTransform="matrix(0,1,-1,0,1014.0344,1046.6478)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10542"
+       xlink:href="#linearGradient7540-2-3-8-7"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="1023.2569"
+       x2="-15.945988"
+       y1="1037.4661"
+       x1="-15.945988"
+       gradientTransform="matrix(0.95585117,0,0,0.95585117,-0.71992063,45.488394)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient10544"
+       xlink:href="#linearGradient7272-66-4-5-5-5-8"
+       inkscape:collect="always" />
+    <mask
+       id="mask10620"
+       maskUnits="userSpaceOnUse">
+      <path
+         transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)"
+         d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
+         sodipodi:ry="10.625"
+         sodipodi:rx="10.625"
+         sodipodi:cy="468.23718"
+         sodipodi:cx="388.125"
+         id="path10622"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
+         sodipodi:type="arc" />
+    </mask>
+    <linearGradient
+       id="linearGradient4528-9-5-7-9-7-3">
+      <stop
+         id="stop4530-0-5-0-5-8-4"
+         offset="0"
+         style="stop-color:#e0c576;stop-opacity:1;" />
+      <stop
+         id="stop4532-7-9-3-3-6-1"
+         offset="1"
+         style="stop-color:#9e7916;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6281-8-0-1-6-6-4-2-8-0">
+      <stop
+         style="stop-color:#f7f9fb;stop-opacity:1"
+         offset="0"
+         id="stop6283-0-2-2-1-2-0-1-6-0" />
+      <stop
+         style="stop-color:#ffd680;stop-opacity:1"
+         offset="1"
+         id="stop6285-5-0-9-7-6-9-9-1-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4972-7"
+       id="linearGradient4978"
+       x1="88.220116"
+       y1="1032.2668"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4972-7">
+      <stop
+         style="stop-color:#b8ccf1;stop-opacity:0.10196079"
+         offset="0"
+         id="stop4974-8" />
+      <stop
+         style="stop-color:#6e97e2;stop-opacity:0.10196079"
+         offset="1"
+         id="stop4976-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4964-3"
+       id="linearGradient4970"
+       x1="118.38584"
+       y1="1032.1835"
+       x2="163.22012"
+       y2="1032.2668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220117,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4964-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.349"
+         offset="0"
+         id="stop4966-1" />
+      <stop
+         style="stop-color:#91ade6;stop-opacity:1"
+         offset="1"
+         id="stop4968-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4956-2"
+       id="linearGradient4962"
+       x1="88.220116"
+       y1="1042.7972"
+       x2="163.22012"
+       y2="1042.7972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-88.220116,-999.2669)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4956-2">
+      <stop
+         style="stop-color:#fcfdfe;stop-opacity:0.25641027"
+         offset="0"
+         id="stop4958-5" />
+      <stop
+         style="stop-color:#98aae7;stop-opacity:0.40392157"
+         offset="1"
+         id="stop4960-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         id="stop3829"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.60149658"
+         id="stop3835" />
+      <stop
+         id="stop3831"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1-0">
+      <stop
+         id="stop10800-5-2-1-8-20-6-4-9-8-2-9"
+         offset="0"
+         style="stop-color:#f3faed;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7f4da;stop-opacity:1"
+         offset="0.65917557"
+         id="stop10806-6-8-5-3-9-24-8-4-3-2-4" />
+      <stop
+         id="stop10802-1-5-3-0-4-8-4-2-9-2-5"
+         offset="1"
+         style="stop-color:#67bf1f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4541"
+       id="linearGradient5885"
+       x1="41"
+       y1="1007.8622"
+       x2="60"
+       y2="1008.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,1034.3618,967.36133)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient6406"
+       gradientUnits="userSpaceOnUse"
+       x1="49.217129"
+       y1="1041.0833"
+       x2="75.020309"
+       y2="1023.2908" />
+    <linearGradient
+       id="linearGradient5517"
+       inkscape:collect="always">
+      <stop
+         id="stop5519"
+         offset="0"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+      <stop
+         id="stop5521"
+         offset="1"
+         style="stop-color:#c5c3d4;stop-opacity:0.72941178" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5031"
+       x="-0.11202575"
+       width="1.2240515"
+       y="-1.0690457"
+       height="3.1380913">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.4343883"
+         id="feGaussianBlur5033" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5517"
+       id="linearGradient5041"
+       x1="98.407524"
+       y1="1065.2891"
+       x2="136.02242"
+       y2="1065.2891"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,-95.625351,-19.272328)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4462"
+       id="linearGradient4468"
+       x1="48"
+       y1="994.36218"
+       x2="88"
+       y2="1028.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-28.014084,-0.01639)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4470"
+       id="linearGradient4476"
+       x1="51"
+       y1="995.36218"
+       x2="84"
+       y2="1026.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-28.014084,-0.01639)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4514"
+       id="linearGradient4520"
+       x1="36"
+       y1="1037.3622"
+       x2="36"
+       y2="1029.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.1249998,0,-128.67002)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4524"
+       id="linearGradient4530"
+       x1="49"
+       y1="1039.3622"
+       x2="46"
+       y2="1034.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5134"
+       id="linearGradient4542"
+       x1="27"
+       y1="1042.3622"
+       x2="7"
+       y2="1020.3622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515675,8.628538e-5)" />
+    <linearGradient
+       gradientTransform="matrix(0.14667021,0,0,0.14667136,17.184701,879.66442)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4536"
+       id="linearGradient4542-7"
+       x1="27"
+       y1="1042.3622"
+       x2="7"
+       y2="1020.3622"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4792"
+       x="-0.16768435"
+       width="1.3353687"
+       y="-0.17985532"
+       height="1.3597106">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4794" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-4"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-0" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-0"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-5" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-5"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-9" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4796-0-49"
+       x="-0.16895473"
+       width="1.3379095"
+       y="-0.1559574"
+       height="1.3119148">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.8300248"
+         id="feGaussianBlur4798-1-01" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4928"
+       id="linearGradient4934"
+       x1="-11.097116"
+       y1="988.03119"
+       x2="1.5470241"
+       y2="994.73035"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4984"
+       x="-0.084"
+       width="1.168"
+       y="-0.084"
+       height="1.168">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.98"
+         id="feGaussianBlur4986" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5012"
+       x="-0.048"
+       width="1.096"
+       y="-0.048"
+       height="1.096">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.24000032"
+         id="feGaussianBlur5014" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5016"
+       id="linearGradient5022"
+       x1="-5.7292957"
+       y1="996.90344"
+       x2="4.3120389"
+       y2="1000.6044"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5024"
+       id="linearGradient5030"
+       x1="9.1587505"
+       y1="1035.391"
+       x2="12.099871"
+       y2="1039.3212"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515674,9.266038e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5034"
+       id="linearGradient5042"
+       x1="21.856897"
+       y1="1019.8043"
+       x2="27.984741"
+       y2="1023.2879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99999218,0,0,1,2.2515674,9.266038e-5)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5062"
+       x="-0.050661981"
+       width="1.101324"
+       y="-0.14436312"
+       height="1.2887262">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.1205165"
+         id="feGaussianBlur5064" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5282"
+       x="-0.27631978"
+       width="1.5526396"
+       y="-0.34539973"
+       height="1.6907995">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.3026648"
+         id="feGaussianBlur5284" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4527"
+       id="linearGradient4533"
+       x1="29.521629"
+       y1="29.827848"
+       x2="31.546745"
+       y2="39.175972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-0.41994314,1068.4388)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4527">
+      <stop
+         style="stop-color:#fbe093;stop-opacity:1"
+         offset="0"
+         id="stop4529" />
+      <stop
+         id="stop4445"
+         offset="0.5360797"
+         style="stop-color:#f6be4a;stop-opacity:1" />
+      <stop
+         style="stop-color:#fadc84;stop-opacity:1"
+         offset="1"
+         id="stop4531" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4437"
+       id="linearGradient4443"
+       x1="21.818333"
+       y1="1041.7073"
+       x2="37.309193"
+       y2="1027.6471"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4453"
+       id="linearGradient4451"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-8.6400594,2067.7057)"
+       x1="35.85693"
+       y1="1035.3833"
+       x2="38.551533"
+       y2="1038.062" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4483"
+       x="-0.035450512"
+       width="1.070901"
+       y="-0.036566069"
+       height="1.0731321">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.30606006"
+         id="feGaussianBlur4485" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter4503"
+       x="-0.044383361"
+       width="1.0887667"
+       y="-0.052252434"
+       height="1.1045049">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.1559278"
+         id="feGaussianBlur4505" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#e7e7e7"
+     borderopacity="1"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16.52"
+     inkscape:cx="60.956417"
+     inkscape:cy="33"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1392"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4112"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="old"
+     style="display:inline">
+    <image
+       y="0"
+       x="75"
+       id="image4431"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABCCAYAAAAfQSsiAAAABHNCSVQICAgIfAhkiAAAE4xJREFU
+eJztnGmMHMd1gL++59zZeylytaJFiqJ46CCpSBYsib7lxEcUyAHsKDB8QE5+2U6QH45jJIAD2EEA
+B8gPW3YAA05sx0nkyPEh2IpiST4kMZJIkeIp6uAud5fH7JI7O2d315EfPdM7szOzOyRFWobzgOX0
+Ud1d9fV7r17Vq6ahtdb8v7SJ1iCkIhDgB4pQauxfd6XeSKIUhFLiByCkJpStevRbD0trCIRESAMp
+dUdIDfmthSWVRkiFkAZgxKa2kvxWwdIalNYEoURpE4i0yQ9VT9dfFlhB4HNycppq8MbvO4Qqs+7q
+LT2VvWyadWqhxCsnFy74Otu22o9ZZtsxIdu1QQh5wc8DWHd1b+UuC6xq1cf3xQVd0wypExzTXDqm
+lGorI6SK73Gx0Fat42W5K1CpLVX4qw/+++V6zEXJtRvHefc77rjg666Ig8/1pfnqP/4lhmFiGpEf
+MwyjrZzWGqUNtFZIHcU9qh4zCxGZnVQ6/oNIo4RqLSOURsql843rhFQ8dWCKB+7ZyJ4Dr8TPDcIQ
+13FWbccV6w1tyyTh2lhmO6SGNAAASK1R9QZLpcCzkIo2kFLpGFLQgFUH2Dge3aO7aS6WygwP9K/e
+hlVLdJDQL1BenKF/pLdeBMAyTZKehW21O3AApaOGKdUAVP+VGqlMpNZYUiMVWFqjTINAKEzLQNfL
+WqbRAhzAsoxYyy5VLgrWwcf/hnD+GbLju7nh7i/2fJ1pGpgdNEspjWmYMbBOYhkGWAAmQrZqiWEu
+AVtJOnUcFyIXdXVQXWD9Le+gOP0ER578bG8PslohmU0+qwHQNMyOMJebbsPfmZfW9guWi36cnUhz
+672fYuHMiz0Dix9qGCitMQ2jBdobXS753dz+3vt7BmYaZtP2Mk0z2zXtjSaXBEucL2KY/dz+gc9d
+ALA3JohepGdY+dk98Z8K8wAYooo48xKGlebW935pVWBKK5TW8V90rP7b5KBVD8761yFde8PQL/DS
+3m9TmHycQv4YQ4NppDMUn896QyCqAIj5Q9gjt7Hr3i/z3MN/Ru3pvwb7Qx3vq5SOzUz9hk3SdoR1
+6OmvMPXcg0xs3MamW9/G8LqPA6DV0sDYMPsJ509i1IH554/gDtzC7fd9nWceegDDfxDSH+n40EvV
+nGgm/Mqbcwus0C/w7MOfwDCrvO3DX8TNDNZrV0CrBcT5IvhzGFYabRcxRBVtJ+Nqi8Ikdv82dn3g
+2zz3X38E5W8yvwzYSrEUdAbZCDTVsuBS1W/VS4y1XGzbuuABdwusvY98GsvLcNv7Ph9VQpYRcwfR
+pSkIyyi/CIDpZcFJYyRG2m4oq5PYiUF2vfNzPPatT1IqvydqmNSxCTabYkNW0zapm4Y+RMMeWDLl
+5ZF7J+k0rbOaKKWQKqprDOvQ019h8dw07/zo16IDwUuI2X3osBKDUrVCfBMToAssff5pXjrwOHZq
+DMKmc00DYKl0HGx2a2g01Gk/p7QB9KZNvQ51lF4Co5RG6WhmNZJow4bI/Kaee5CdH/x7IPI/ZuEA
+OqygSqdRtQKGX4rNTQFmZk1kgqIKdgYAIziBVctz7PAzzM7meSl8gMzoaFRp1f5WO4HotXGdinWD
+vppG+dKg6jc0tvvzbYCZo4+SG9vGyOh2dDiJVXoFDS2gTpcV+cVIs5JJ2Lx+Ir6JFiXM8gn8coFX
+jx/g9PmQycSfYHmJ1sZ0aGG3gW63GYioQSubYGPGQfToy4weX5ANcObVR7hm5+9jUEMsnIgqVIli
+qTPnFjl6YpY1172dq25+C4mBcV7+5Rco1AT9doiWZXQtjyqd5tDRg0hniE1vf5BTe17GcZZgad3Z
+pLqaoG536lKptjffBqqLFl2Mv1ouNsDUwcfZ+e4/R4dn0KIEMvJRp2ZP8vJZyV1//Ajp/vH4ouP0
+xdu6kkf5RQ7UQe36wLeZm6+SyeUoVvy4nNJGDKAXWQ4JliYHpdYst+peHPylSuzgrcQgwflJLDuD
+9ucAOHpilnc88AscL9fxYlXLIwrTHDxxMgbleDlsV7aAgsh0lOxtwNDs3xqAGtvNwKXSaNVZY4F6
+0vTSNaohMSzDdLHEYlSpsMKp2ZOMb72vOyh/FnH+GE/uPUr/2EQMqptI3dnJd5JugBqXd4v8u4F5
+vbQuhhWG51B2H5ZYxHBSlEITMznc9cIzR5/n+ZnpJlB9NHfn2ZQX91g7dmxFqagxhrGyduk4aNXx
+9cshNRrfHIzGc/IrOPcglGSSXlTuIjJANkCmv49qpYx3ARdOt4BKA8HSTZ2Q0aFkvH/NxDBOfTZZ
+KNXmbzqJ0u0gtGqFtfz3cosNML71Piaf/yGbbtqJtPuwrDRDY2s5efrZjhdteetfsTB7iHWb34Xt
+mmhdxTAiH6VVQCJRYWQoMqPz5wpMrPXw3Cg6FcJFGpqw6cUuN6vmxi8H1LzdnOEBOmpTI6sThJee
+S7QBrt3xMX7+L7/L4DWbGe5PQ2KEXN8w+/c+QugXmnyRBiT9IxvIDV+NYfhoFWBQAw0nz0TDoTAs
+E4YBrpNkw1qX0VGLhFvE1GlCo0KobXRgEAirJQOzvJGd9puPN/uo5emw19u5Qx1Wun+cG+76PAce
++QLv/MPPIu0+vL61jK8b54lv3cfu+x+q+6QArQMMw8fQi4RCcOy1KoeOl5nJ1wAIw2gWolRVQJFa
+RbFh3ObmzZLt2waxLRtLOUAWkEhltuQEl8tqcKA1XwjdRwGhuDRzjR38+ps+CMDDX/8Ltt31Ia7b
+fCM37LwHnv8Jj339TnIj15Md3c623Z8gFCWOvVZl/9FIkyaGBVs3mozmfHIO+PZaTGuEai3FiVNl
+jr+c53uPneTHTy3wrl1ZduyIxpSWdtHao6rMOOfXDU58bAVIQEtytWGCr5cYy5dJLuQPc/jxv6Vw
+5iC5kevJ5aJMraouMD0zzVs++h888UyBWqi4dtxkIBetaci4EbicI2JYgmFk0UDVbPwyPPnCMZ6d
+OsS6IYOP3LcBy8lRqnj4gUuxBv4yv7LcBzWbbCctas4+N+8HoYy16pXpeT5899UtGembt24hl4sC
+7ZXi5jZYDSkvTJOffJpyJY+qzmFbVZR7NSfVbgDGR0Jcu4Zty66wfDmEOufilyEoRQ5/suDzyL5H
+ySXLPHD/DTGwxUqCYjXsqDkXA6gBqSGvB6yu08rp/nHS/ffGPV2xNM+v9ktSCY9sKurZNEmEqMbA
+mkWTgkprTOUXDdaYCT628/184/kf8A9fO8BnPnkjlu5DCCjVNIvloGvP1WjwqfnF7i0CKtWw67mz
+58orXruSrJCRjno+w/AJw3PsO2aTStgkXRch3HoZH3eVnHZDq/zi0mSfl9X86e738dUnfsg3H3qF
+T3/sRvqzmo2kqNVSPVS7e7B8OWWFpkq0DkAHzM5EEWU2m0DU532ESDeVrVEiG5uiYaVQ0kbV7I6g
+3EykIR99z27+7jvf579/McX2G0aYWyhxbr7MYkWh6ws5DLPz2gggLuPYkQZX6mvCUp5NLVQEYX0/
+4VGp+QghSXhOy1qvC5EusJa0qhpUmCym6cs5eJamRkCoHIzQj4G5dj1sKBeYA3xnHh1k8Grplrs2
+QHn1w+PJHO++fTv/+bMX2XXTECkvoOzZ2DWfeHmXlFgdchPVQLB33xFu2jzB/qNTlEsVbr5pI2dn
+zzObn2dgoJ9rJoaZnJpjcnqWzeuvZv01I/zviy8BcOP2Ta8XLGKtOnvKIIkgm3KQAhK4GNJAmybC
+VwiRpigWKRXOUqsJxtMLFJ2rkPOLLJ5dIGn1MzaytgWUl7RwEmB5cM/bb+RHv3qeQ0fybNwwRiYB
+5wvRFG9DOnX+tmVSLlX4/o//ByFD1q5dz6OPPgnA6Ng6Trw2ybGjhwC4fvNWjhx/lRcOHgBgx86b
+LxjUCrDqJkCNyXkYGUzgWC62qREqxBIaKV1qBBSLNc5OF8mmKy13KAZRE6tygXNqkU1jm1ogWY4G
+Q9HnanZt28Bzh86xccMYAKmExWIlYDW5886dwM54X4juEDZvXr/q/VaTrrAiE1RUagH9ucjpmlIh
+rATClFHCwYLpqRkAiuUxsukz7M9PUChpUqLEqJGhb9TE6xMsytNMDF+FYUiUVASiMVYM+J2tQ3z5
+n4/xkfs2cL6Q5/iJkMmpOYJwdWBr1gxw265bLglCIrX6qj/oCGsp0CgUQ1IJj6RrRbGNZWJDvLis
+cK5EKmEBWRYrAfmz41QDQRgWWaTIy9Wz/MGmN2GkFPmFV8kWzNgZh00x1EAuiR9ISuUq1cBkbr7A
+5PQs58oVVhPXcbn+2qV8gFQaA41meaqteXtZ/rHHUdCKHX9hMQRcHNvEsVsfJJXmnKrgedGJxXq7
+7tx5HddODPPzPQfZe/Q0e45Pcv366M2dnT9LfzbT9pxcNurxJqdKJF3wEi596V5CiCsrK8JqBIEJ
+p3P3nTAsMgnIJGxemlKkEpodW8cRUvHWO7az9+hpCtWl8sIHKxfda/kaz7AeiNqmy0DGIJ3pDVay
+w7r5yyWrLpOs1HzQkekIrTBEVLnQUAjpIEomvoyOzS9KZvJFxgbTHDgW+bJcMgIAYDfNLlpd4ifH
+tXDtDAP9fsfzy6VQrfLTR3+GrmeSUkmPO3bd2FbOAKSKnqmXvahmg9V0h78iLMeOblOtRr9hA1QA
+YCL9HHNzRUCTEh5VBP/6g1/Ql84yOxflGCfWLhHqz2YwzKVHahUFjUG1tfKphI2XcMklV58xmM3P
+M3V6Hi8RvRBlJlk/Ps/oSDTWM6VEmDa2EohVprQtw13xfAdYS5xzfQ5nXjhLpcnPVutmVSmDYeeY
+L0QaVFpIkhz2gSSzcwUySZMNowmyiQhwKpvCdZdMSykZg3t5eh6AayYyzEwHVGoCv7Z6T9hNjhw+
+zMCtzWFESLd5UsuO6qB7MOcummWhtceawUgrZvMFBjLRbGmlPg4t1seyjjNG/kwEbCQdMrbeIpud
+oFg8j1ABYOG4FsMj61qeYNbNUCnJc0dOs/2aFJVqwGsz5zjySpHjx18jCBSyaRbBalpt7LrRtpts
+zxxUQsHk7DRXDQy1nWvcR9smthl1PNq2sAwXbVgrLqHoCgtAk2B8NMPhM2e5xci1QAKYm5NYxiAj
+Y1D1XyaVXXqS41qIaBTE+Lq1uE4UNojQQRtL/sg0LfYfm+We24YoFS2CQBOEAW7Sw7GjWKwRZjTC
+DqOHryFmZuYYdFpB2o6D5UXHbNOJtMpxsLAjUKtIV59lGC4YLps22Oz/6UmKqevic+XFKtXApVqN
+Kj/Sn8IaHibtRiacTWRwvCSZvir92Qx23bOHQuE4ISL0YmC/fHaSQtFnx42D5PNVTs/5lEsVgmp3
+B6/DsAWY8hV+PbvkJaBYhiKQOn2G9fWFKZ7nYnkepmfjukm0bWEaLoZpXWqcZdAwxfGxEdaNlDk8
+c5At67a1gRrM1fCyZYbSDuncEOlUhnSyH6lCCsUFhPAjR143u2ZgFVHlocde5N67rsJ1ktgmTKwZ
+YsBzYMPaFSue8ron7qzU0jnLNLAdBzeVxHK9WJts80ISf5Gs0BtasXbdfdsA33z4VVLyKjKp/hhU
+MqnwsmWcbBXbCtvCAbNpXykZ7zeAfffhFwB4/z3XYqk+EqbH6KCKAjIg7GFls/a7p7gMz8LExvMc
+TDcR+SYr2bX8arICrCXtGhvM8Xt3j/NvP3mK7WN3YBmDJJOKpBupftqU2HWrsK1owzIdHNtEikZs
+I6J1XXVgT+yZYs+BKb70mR2kvBFC6ZA0HAwHoD3KX0nEKkuGmk2usfLwYmSFKZrotGEk0cDWjfDm
+bXmePvgUbxq4mcHccKxVUS8lW2KoZpFKtmjd9356nIcf28en79/KdeuvxhdptEhgWBqraeq1LTWm
+Iy1SWBh6SaNsvaSBGgMDjWoKPF+v/5Gh412aJ+2lstA6gWXCe3ZvYWxkmu/+eC8LMsvt2ShStq0Q
+y2s1O9MysS0HwwyhXvH58xX+6aH9TJ2a44ufeTM7to7jizRSJdHawjQi19bQlOXf7DQicBOg3nsp
+Dc3FGoCbX5wBPS0ZWE06ZncaR+K0ulZoFJZZA11k+kye7/xomlP5CtevH2P7dTnWj2dw3RRJz8Nz
+01iWTaVaoOr77Nl3ksOv5fn5c6/x5i2DfOrjO8mksjEoKVt9XTez6ry+tL3Mpcw6XFAqLOajQTdH
+aMuAGdR4Zu8MT+5b5PjkHJlUimwmwdrhHMMDLq9Oz1OqKg4dn8YPJLt3rOFtd0yw6U05DNKE0kGE
+Dko7BEGItm28Lt/sGFZrXLVSTHTFYOn6Pw1Qqp7R9UOBIQOCUCCC+jDEquGaEgufogiZmVnk1dlC
+2wOuXZtjy3UZVOARShMRmlRqFsJXBMFSC1zXRBpOHKXbtoU2bez6BHxjWAKg69tWnHgwYxfQ8FmX
+H1aTVkmlCIQgFIqwVkEEAZWKRNSWBoq2Z2I74Fr16RWnQ7o9jBoUSAsREkMSYRibVSMWgs7QAKz6
++QY0ZVkYhtECrCGmaV1eWM1aFW1q0AqhQEhJKFSsXTUfpBCYemmwq+kecTcgAS3aBMTDD8syW/67
+AqspQu9Vq6J6XAHNataq6KGdr4oW1Oum7c7fNsPSon/dwyo7ZZlYjbkkQ8VzaAAtsemyXvBKOnh7
+tQKdpPHNYPQprxnB6+BzG5VSun0eaaWPA3rpDX8d329e4a+Mf7Pl/wA+lQa8zGx4FQAAAABJRU5E
+rkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="66"
+       width="75" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Background"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1"
+       d="M 75,0 75,66 1e-6,66 C 1e-6,41.2048 50.00969,0 75,0 Z"
+       style="display:inline;fill:url(#linearGradient4978);fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-0"
+       d="M 75,21.0607 75,66 1e-6,66 C 10.625001,47.804 43.509694,25.4357 75,21.0607 Z"
+       style="display:inline;opacity:0.40400002;fill:url(#linearGradient4962);fill-opacity:1;stroke:none" />
+    <g
+       id="g11331-3-1-1-7"
+       style="display:inline"
+       transform="matrix(0.27903303,0,0,0.27903303,-14.618136,-107.52874)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-2" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="rect4113-1-7"
+       d="M 75,4.0000001e-7 75,66 30.000003,66 C 30.000003,46.1545 47.70944,9.2500004 75,4e-7 Z"
+       style="display:inline;opacity:0.18399999;fill:url(#linearGradient4970);fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     inkscape:label="Foreground"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-986.3622)">
+    <g
+       transform="matrix(0.92787456,0,0,0.92766861,-334.80763,585.97703)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-width:0.30075619;stroke-opacity:1" />
+    </g>
+    <g
+       id="text6430-2"
+       style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(3.3253216,0,0,3.3245835,49.654056,-2426.2108)" />
+    <g
+       transform="matrix(3.1391206,0,0,3.5217855,49.654056,-2426.2108)"
+       style="font-style:normal;font-weight:normal;font-size:15.56941891px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="text3782-3" />
+    <g
+       id="g11331-3-1-1-00"
+       style="display:inline"
+       transform="matrix(0,-0.14879357,0.14879357,0,3.0151033,1093.2759)">
+      <g
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
+         id="g13408-8-1" />
+    </g>
+    <g
+       id="g7590-7-0"
+       style="display:inline"
+       transform="matrix(1.122791,0,0,1.122791,51.605476,-118.01412)" />
+    <g
+       id="g7827-7-5"
+       style="display:inline"
+       transform="matrix(0.45489265,0,0,0.45489265,119.65899,561.31682)" />
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,71.714017,852.06346)"
+       style="display:inline"
+       id="g11331-3-1-1-0">
+      <g
+         id="g13408-8-4"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <ellipse
+       style="opacity:1;fill:url(#linearGradient5041);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5031)"
+       id="path5009"
+       cx="21.588707"
+       cy="1046.0166"
+       rx="15.364794"
+       ry="1.6100959" />
+    <g
+       id="g4521"
+       transform="translate(6.2329079,0.01643584)">
+      <path
+         transform="matrix(0.70870669,0,0,0.20224267,4.9701057,830.67497)"
+         style="display:inline;opacity:0.62999998;fill:url(#linearGradient6406);fill-opacity:1;stroke:none;filter:url(#filter5062)"
+         d="m 46.222683,1020.16 c 8.333975,-0.071 27.129514,0 35.462879,-0.1802 l -17.709438,18.6283 -35.372568,-1.6657 z"
+         id="rect4001-3-4-5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         y="993.84576"
+         x="19.485916"
+         height="34.000019"
+         width="39"
+         id="rect4460"
+         style="opacity:1;fill:url(#linearGradient4476);fill-opacity:1;stroke:url(#linearGradient4468);stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4512"
+         d="m 51.55265,1039.9958 -29.999998,0 3,-6 23.937878,-0.1336 z"
+         style="fill:url(#linearGradient4530);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1" />
+      <rect
+         y="1029.3622"
+         x="28"
+         height="9.0000172"
+         width="16"
+         id="rect4510"
+         style="opacity:1;fill:url(#linearGradient4520);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4478"
+         d="m 56.989486,995.8587 -35.499999,0 0,30.5"
+         style="fill:none;fill-rule:evenodd;stroke:#384569;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4478-1"
+         d="m 22,1024.8622 33.5,0 0,-28.5"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#819dc4;stroke-width:0.99999982px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4478-1-4"
+         d="m 20.985916,1025.8458 35.5,0 0,-30.5"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#c5ccd6;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         y="1026.8622"
+         x="43"
+         height="2"
+         width="2"
+         id="rect5068"
+         style="opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1026.8622"
+         x="47"
+         height="2"
+         width="2"
+         id="rect5068-8"
+         style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1026.8622"
+         x="51"
+         height="2"
+         width="2"
+         id="rect5068-85"
+         style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="1026.8622"
+         x="55"
+         height="2"
+         width="2"
+         id="rect5068-85-3"
+         style="display:inline;opacity:1;fill:#384569;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="matrix(1.2408001,0,0,1.1760011,-6.0200014,-176.06482)"
+         y="1000.3622"
+         x="25"
+         height="16"
+         width="20"
+         id="rect5140"
+         style="opacity:0.656;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5282)" />
+    </g>
+    <g
+       style="display:inline"
+       id="g8662"
+       transform="matrix(0.74565918,-0.74221622,-0.74316719,-0.74661456,757.24766,1805.31)">
+      <path
+         style="fill:url(#linearGradient4533);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4443);stroke-width:0.94988102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 40.244943,1041.4693 c -0.24182,0.7378 -4.40107,-3.7831 -4.40107,-3.7831 -12.608129,11.8645 -23.639522,-2.7899 -13.392575,-10.4071 1.603395,-1.1919 -3.274598,13.2754 8.85868,6.3613 0,0 -4.890976,-4.2929 -4.186894,-5.3539 0.390532,-0.5886 13.008987,-0.7195 13.731155,0.03 0.722169,0.75 -0.343071,12.3401 -0.609296,13.1524 z"
+         id="path4522"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscszsc" />
+      <path
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#fefeeb;stroke-width:0.94988102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4483)"
+         d="m 40.029866,1028.5266 c 0.335464,3.4409 -0.540551,10.8513 -0.558812,11.097 -0.130143,-0.1351 -3.471725,-2.9728 -3.471725,-2.9728 -8.256342,6.6256 -14.064589,4.3406 -15.782066,0.9534 -1.920574,-3.7877 0.368338,-8.6621 1.441156,-8.1716"
+         id="path4449"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4451);stroke-width:0.94988102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4503)"
+         d="m 22.915973,1035.265 c 1.319182,1.5207 4.851335,1.724 10.215246,-1.3613 -3.722931,-2.2 -4.848283,-5.098 -4.899966,-5.234"
+         id="path4522-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+    </g>
+    <g
+       id="g4507"
+       transform="translate(2.1231354,0.62550812)">
+      <circle
+         transform="matrix(1.1084537,0,0,1.1084624,0.35349044,-111.8097)"
+         r="14"
+         cy="1030.8622"
+         cx="17.5"
+         id="path4534-9"
+         style="display:inline;opacity:1;fill:#ffffeb;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter4984)" />
+      <ellipse
+         ry="14"
+         rx="13.99989"
+         cy="1030.8623"
+         cx="19.751431"
+         id="path4534-4"
+         style="display:inline;opacity:1;fill:#eceee6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620-5"
+         d="m 19.57989,1030.4338 0,-13.577 c 6.933977,-2e-4 13.67501,6.9493 13.576826,10.0041 z"
+         style="display:inline;fill:#faf8ff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0)" />
+      <path
+         transform="matrix(-0.99999218,0,0,-1,5.9137479,2036.4825)"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620-5-0"
+         d="m -13.666785,1005.1109 1.161185,-12.9517 c 4.0695527,0.23247 10.7443039,6.19437 11.87981528,9.2895 z"
+         style="display:inline;fill:#faf8ff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-4)" />
+      <path
+         transform="matrix(-0.14456141,-0.98949567,0.98948793,-0.14456254,-977.63999,1171.806)"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620-5-5"
+         d="m -4.8580548,1007.0312 -1.7458573,-12.74883 c 7.24929196,-0.95759 12.7683084,3.82096 13.5094793,7.37643 z"
+         style="display:inline;fill:url(#linearGradient5022);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-0)" />
+      <path
+         transform="matrix(0,1,-0.99999218,0,1018.3411,1039.9465)"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620-5-2"
+         d="m -9.0220443,997.69719 -2.1437267,-11.87986 c 7.4203185,-2.43164 15.217233,4.86601 14.9167613,8.93224 z"
+         style="display:inline;fill:url(#linearGradient4934);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-0-49)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620"
+         d="m 19.937173,1030.7464 4.376741,-12.7731 c 3.367335,0.5614 5.452204,3.0464 7.41366,5.7166 z"
+         style="fill:url(#linearGradient5042);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796)" />
+      <ellipse
+         ry="6.0000081"
+         rx="5.9999614"
+         cy="1030.8623"
+         cx="19.751431"
+         id="path4534-2-9"
+         style="display:inline;opacity:0.46100003;fill:#828877;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter5012)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4620-3"
+         d="m 19.66921,1030.0766 -8.038911,-9.7363 c 0.819785,-0.058 5.009981,-3.5206 7.770945,-2.769 z"
+         style="display:inline;fill:#eceab4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4796-5)" />
+      <ellipse
+         ry="2.0533991"
+         rx="2.0533831"
+         cy="1030.8623"
+         cx="19.751431"
+         id="path4534-2"
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient4542-7);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4622"
+         d="m 19.401245,1031.7289 -11.433118,5.27 c 0.8910204,2.5032 2.747862,3.9513 4.823347,5.27 l 6.609771,-10.0041"
+         style="fill:url(#linearGradient5030);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4792)" />
+      <ellipse
+         ry="14"
+         rx="13.99989"
+         cy="1030.8623"
+         cx="19.751431"
+         id="path4534"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient4542);stroke-width:1;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ProvUIImages.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ProvUIImages.java
@@ -38,32 +38,32 @@ public class ProvUIImages {
 	// bundle-relative icon path
 	public final static String ICON_PATH = "$nl$/icons/"; //$NON-NLS-1$
 	//objects
-	public final static String IMG_ARTIFACT_REPOSITORY = "obj/artifact_repo_obj.png"; //$NON-NLS-1$
-	public final static String IMG_METADATA_REPOSITORY = "obj/metadata_repo_obj.png"; //$NON-NLS-1$
-	public final static String IMG_IU = "obj/iu_obj.png"; //$NON-NLS-1$
-	public final static String IMG_DISABLED_IU = "obj/iu_disabled_obj.png"; //$NON-NLS-1$
-	public final static String IMG_ADDED = "obj/iu_add.png"; //$NON-NLS-1$
-	public final static String IMG_REMOVED = "obj/iu_remove.png"; //$NON-NLS-1$
-	public final static String IMG_CHANGED = "obj/iu_update_obj.png"; //$NON-NLS-1$
-	public final static String IMG_NOTADDED = "obj/iu_notadd.png"; //$NON-NLS-1$
+	public final static String IMG_ARTIFACT_REPOSITORY = "obj/artifact_repo_obj.svg"; //$NON-NLS-1$
+	public final static String IMG_METADATA_REPOSITORY = "obj/metadata_repo_obj.svg"; //$NON-NLS-1$
+	public final static String IMG_IU = "obj/iu_obj.svg"; //$NON-NLS-1$
+	public final static String IMG_DISABLED_IU = "obj/iu_disabled_obj.svg"; //$NON-NLS-1$
+	public final static String IMG_ADDED = "obj/iu_add.svg"; //$NON-NLS-1$
+	public final static String IMG_REMOVED = "obj/iu_remove.svg"; //$NON-NLS-1$
+	public final static String IMG_CHANGED = "obj/iu_update_obj.svg"; //$NON-NLS-1$
+	public final static String IMG_NOTADDED = "obj/iu_notadd.svg"; //$NON-NLS-1$
 
-	public final static String IMG_UPDATED_IU = "obj/iu_update_obj.png"; //$NON-NLS-1$
-	public final static String IMG_UPGRADED_IU = "obj/iu_upgraded.png"; //$NON-NLS-1$
-	public final static String IMG_DOWNGRADED_IU = "obj/iu_downgraded.png"; //$NON-NLS-1$
-	public final static String IMG_ADDED_OVERLAY = "ovr/added_overlay.png"; //$NON-NLS-1$
-	public final static String IMG_REMOVED_OVERLAY = "ovr/removed_overlay.png"; //$NON-NLS-1$
-	public final static String IMG_PATCH_IU = "obj/iu_patch_obj.png"; //$NON-NLS-1$
-	public final static String IMG_DISABLED_PATCH_IU = "obj/iu_disabled_patch_obj.png"; //$NON-NLS-1$
-	public final static String IMG_PROFILE = "obj/profile_obj.png"; //$NON-NLS-1$
-	public final static String IMG_CATEGORY = "obj/category_obj.png"; //$NON-NLS-1$
-	public final static String IMG_INFO = "obj/iu_info.png"; //$NON-NLS-1$
-	public final static String IMG_COPY = "obj/copy_edit.png"; //$NON-NLS-1$
+	public final static String IMG_UPDATED_IU = "obj/iu_update_obj.svg"; //$NON-NLS-1$
+	public final static String IMG_UPGRADED_IU = "obj/iu_upgraded.svg"; //$NON-NLS-1$
+	public final static String IMG_DOWNGRADED_IU = "obj/iu_downgraded.svg"; //$NON-NLS-1$
+	public final static String IMG_ADDED_OVERLAY = "ovr/added_overlay.svg"; //$NON-NLS-1$
+	public final static String IMG_REMOVED_OVERLAY = "ovr/removed_overlay.svg"; //$NON-NLS-1$
+	public final static String IMG_PATCH_IU = "obj/iu_patch_obj.svg"; //$NON-NLS-1$
+	public final static String IMG_DISABLED_PATCH_IU = "obj/iu_disabled_patch_obj.svg"; //$NON-NLS-1$
+	public final static String IMG_PROFILE = "obj/profile_obj.svg"; //$NON-NLS-1$
+	public final static String IMG_CATEGORY = "obj/category_obj.svg"; //$NON-NLS-1$
+	public final static String IMG_INFO = "obj/iu_info.svg"; //$NON-NLS-1$
+	public final static String IMG_COPY = "obj/copy_edit.svg"; //$NON-NLS-1$
 
 	// wizard graphics
-	public final static String WIZARD_BANNER_INSTALL = "wizban/install_wiz.png"; //$NON-NLS-1$
-	public final static String WIZARD_BANNER_UNINSTALL = "wizban/uninstall_wiz.png"; //$NON-NLS-1$
-	public final static String WIZARD_BANNER_UPDATE = "wizban/update_wiz.png"; //$NON-NLS-1$
-	public final static String WIZARD_BANNER_REVERT = "wizban/revert_wiz.png"; //$NON-NLS-1$
+	public final static String WIZARD_BANNER_INSTALL = "wizban/install_wiz.svg"; //$NON-NLS-1$
+	public final static String WIZARD_BANNER_UNINSTALL = "wizban/uninstall_wiz.svg"; //$NON-NLS-1$
+	public final static String WIZARD_BANNER_UPDATE = "wizban/update_wiz.svg"; //$NON-NLS-1$
+	public final static String WIZARD_BANNER_REVERT = "wizban/revert_wiz.svg"; //$NON-NLS-1$
 
 	/**
 	 * Returns the image descriptor for the given image ID. Returns


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundles `org.eclipse.equinox.p2.ui`, `org.eclipse.equinox.p2.ui.admin`,
`org.eclipse.equinox.p2.ui.admin.rcp`,
`org.eclipse.equinox.p2.ui.discovery`,
`org.eclipse.equinox.p2.ui.importexport`,
`org.eclipse.equinox.p2.ui.sdk` and `org.eclipse.equinox.p2.ui.sdk.scheduler` except for the following as it is not available as SVG yet:

org.eclipse.equinox.p2.ui.importexport/icons/obj16/install-handler.svg
______________________________________________________________________
I deleted the constants `T_TOOL`, `FIND_CLEAR` and `FIND_CLEAR_DISABLED` in class `org.eclipse.equinox.internal.p2.ui.discovery.DiscoveryImages` as the specified GIFs do not exist and the constants are not used. The bundle is exported as `x-internal=true`.
_________________________________________________________________________
I changed one icon path `icons/install_wiz.png` in the class  `org.eclipse.equinox.internal.p2.ui.sdk.scheduler.migration.MigrationWizard` to `icons/wizban/install_wiz.svg` as the former path did not lead to any icon in the specified bundle `org.eclipse.equinox.p2.ui`.

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.