### PR TITLE
[Build] Try run mavenBuild-workflow with CMD shell on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   build:
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/mavenBuild.yml@master
+    uses: HannesWell/eclipse.platform.releng.aggregator/.github/workflows/mavenBuild.yml@mavenBuild-win-cmd


### PR DESCRIPTION
Test if executing the build with CMD under Windows helps to fix the test failures:
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3042
