### PR TITLE
Stop using NLS.bind needlessly

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Profile.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Profile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2023 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  * This
  * program and the accompanying materials are made available under the terms of
@@ -32,7 +32,6 @@ import org.eclipse.equinox.p2.metadata.expression.IExpression;
 import org.eclipse.equinox.p2.metadata.index.IIndex;
 import org.eclipse.equinox.p2.query.IQuery;
 import org.eclipse.equinox.p2.query.IQueryResult;
-import org.eclipse.osgi.util.NLS;
 
 public class Profile extends IndexProvider<IInstallableUnit> implements IProfile {
 
@@ -80,7 +79,7 @@ public class Profile extends IndexProvider<IInstallableUnit> implements IProfile
 	public Profile(IProvisioningAgent agent, String profileId, Profile parent, Map<String, String> properties) {
 		this.agent = agent;
 		if (profileId == null || profileId.length() == 0) {
-			throw new IllegalArgumentException(NLS.bind(Messages.Profile_Null_Profile_Id, null));
+			throw new IllegalArgumentException(Messages.Profile_Null_Profile_Id);
 		}
 		this.profileId = profileId;
 		setParent(parent);

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/SurrogateProfileHandler.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/SurrogateProfileHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2007, 2017 IBM Corporation and others.
+ *  Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -100,7 +100,7 @@ public class SurrogateProfileHandler implements ISurrogateProfileHandler {
 			iuRequirements.add(MetadataFactory.createRequirement(iuMatcher, null, 0, 1, true));
 		}
 		iuDescription.addRequirements(iuRequirements);
-		iuDescription.setProperty(IInstallableUnit.PROP_NAME, NLS.bind(Messages.Shared_Profile, null));
+		iuDescription.setProperty(IInstallableUnit.PROP_NAME, Messages.Shared_Profile);
 
 		IInstallableUnit sharedProfileIU = MetadataFactory.createInstallableUnit(iuDescription);
 		return sharedProfileIU;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/ProvidedCapability.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/ProvidedCapability.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2023 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -48,7 +48,7 @@ public class ProvidedCapability implements IProvidedCapability, IMemberProvider 
 	private final Map<String, Object> properties;
 
 	public ProvidedCapability(String namespace, Map<String, Object> props) {
-		Assert.isNotNull(namespace, NLS.bind(Messages.provided_capability_namespace_not_defined, null));
+		Assert.isNotNull(namespace, Messages.provided_capability_namespace_not_defined);
 		this.namespace = namespace;
 
 		Assert.isNotNull(props);
@@ -72,7 +72,7 @@ public class ProvidedCapability implements IProvidedCapability, IMemberProvider 
 	}
 
 	public ProvidedCapability(String namespace, String name, Version version) {
-		Assert.isNotNull(namespace, NLS.bind(Messages.provided_capability_namespace_not_defined, null));
+		Assert.isNotNull(namespace, Messages.provided_capability_namespace_not_defined);
 		Assert.isNotNull(name, NLS.bind(Messages.provided_capability_name_not_defined, namespace));
 		this.namespace = namespace;
 		this.properties = Map.of(namespace, name, //

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/AbstractPublisherApplication.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/AbstractPublisherApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2017 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -309,7 +309,7 @@ public abstract class AbstractPublisherApplication implements IApplication {
 			processCommandLineArguments(args, info);
 			Object result = run(info);
 			if (result != IApplication.EXIT_OK) {
-				System.out.println(NLS.bind(Messages.message_publisherArguments, null));
+				System.out.println(Messages.message_publisherArguments);
 				for (String arg : args) {
 					System.out.println(arg);
 				}
@@ -348,7 +348,7 @@ public abstract class AbstractPublisherApplication implements IApplication {
 				Throwable th = result.getException();
 				if (th != null) {
 					System.out.println();
-					System.out.println(NLS.bind(Messages.message_resultException, null));
+					System.out.println(Messages.message_resultException);
 					th.printStackTrace(System.out);
 					System.out.println();
 				}


### PR DESCRIPTION
If the message doesn't have params defined calling NLS.bind(message, null) is simply a noop.