### PR TITLE
Replace ECF feature imports with bundle imports

### DIFF
--- a/features/org.eclipse.equinox.p2.core.feature/build.properties
+++ b/features/org.eclipse.equinox.p2.core.feature/build.properties
@@ -13,4 +13,5 @@
 #     IBM Corporation - Ongoing development
 ###############################################################################
 bin.includes = feature.xml,\
-               feature.properties
+               feature.properties,\
+               p2.inf

--- a/features/org.eclipse.equinox.p2.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.core.feature"
       label="%featureName"
-      version="1.7.700.qualifier"
+      version="1.7.800.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
@@ -20,10 +20,11 @@
    </license>
 
    <requires>
-      <import feature="org.eclipse.ecf.core.feature" version="1.4.0" match="compatible"/>
-      <import feature="org.eclipse.ecf.filetransfer.feature" version="3.13.7" match="compatible"/>
-      <import feature="org.eclipse.ecf.filetransfer.httpclientjava.feature" version="2.0.0" match="compatible"/>
-      <import feature="org.eclipse.ecf.filetransfer.httpclient5.feature" version="1.0.0" match="compatible"/>
+      <import plugin="org.eclipse.ecf.provider.filetransfer.httpclient5" version="1.1.0" match="compatible"/>
+      <!-- specified in p2.inf
+      <import plugin="org.eclipse.ecf.provider.filetransfer.httpclient5.win32" version="1.1.0" match="compatible"/>
+      -->
+      <import plugin="org.eclipse.ecf.provider.filetransfer.httpclientjava" version="2.1.0" match="compatible"/>
    </requires>
 
    <plugin

--- a/features/org.eclipse.equinox.p2.core.feature/p2.inf
+++ b/features/org.eclipse.equinox.p2.core.feature/p2.inf
@@ -1,0 +1,4 @@
+requires.0.namespace = org.eclipse.equinox.p2.iu
+requires.0.name = org.eclipse.ecf.provider.filetransfer.httpclient5.win32
+requires.0.filter = (osgi.os=win32)
+requires.0.range = [1.1.0,2.0.0)


### PR DESCRIPTION
- Only import the bundles that are not required by any p2 bundle, i.e., the ones that provide the extensions to the underlying framework that are directly required by p2.