### PR TITLE
Use SWT.ON_TOP flag for MessageDialog created in TrustCertificateDialog

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TrustCertificateDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TrustCertificateDialog.java
@@ -629,17 +629,11 @@ public class TrustCertificateDialog extends SelectionDialog {
 				// risk, and where the preference is stored if they wish to change it in the
 				// future. Also ensure that the default button is no so that they must
 				// explicitly click the yes button, not just hit enter.
-				MessageDialog messageDialog = new MessageDialog(getShell(),
-						ProvUIMessages.TrustCertificateDialog_AlwaysTrustConfirmationTitle, null,
-						ProvUIMessages.TrustCertificateDialog_AlwaysTrustConfirmationMessage, MessageDialog.QUESTION,
-						new String[] { ProvUIMessages.TrustCertificateDialog_AlwaysTrustYes,
-								ProvUIMessages.TrustCertificateDialog_AlwaysTrustNo },
-						1) {
-					@Override
-					public Image getImage() {
-						return getWarningImage();
-					}
-				};
+				MessageDialog messageDialog = new QuestionDialog(getShell(),
+						ProvUIMessages.TrustCertificateDialog_AlwaysTrustConfirmationTitle,
+						ProvUIMessages.TrustCertificateDialog_AlwaysTrustConfirmationMessage,
+						ProvUIMessages.TrustCertificateDialog_AlwaysTrustYes,
+						ProvUIMessages.TrustCertificateDialog_AlwaysTrustNo);
 				int result = messageDialog.open();
 				if (result != Window.OK) {
 					// Restore the checkbox state.
@@ -732,17 +726,11 @@ public class TrustCertificateDialog extends SelectionDialog {
 		if (!revocationMap.isEmpty()) {
 			// Prompt the user to ensure they really understand that they've chosen to
 			// install content signed with a revoked PGP key.
-			MessageDialog messageDialog = new MessageDialog(getShell(),
-					ProvUIMessages.TrustCertificateDialogQuestionTrustRevokedKeyTitle, null,
-					ProvUIMessages.TrustCertificateDialogQuestionTrustRevokedKeyQuestion, MessageDialog.QUESTION,
-					new String[] { ProvUIMessages.TrustCertificateDialogQuestionTrustRevokedKeyAccept,
-							ProvUIMessages.TrustCertificateDialogQuestionTrustRevokedKeyReject },
-					1) {
-				@Override
-				public Image getImage() {
-					return getWarningImage();
-				}
-			};
+			MessageDialog messageDialog = new QuestionDialog(getShell(),
+					ProvUIMessages.TrustCertificateDialogQuestionTrustRevokedKeyTitle,
+					ProvUIMessages.TrustCertificateDialogQuestionTrustRevokedKeyQuestion,
+					ProvUIMessages.TrustCertificateDialogQuestionTrustRevokedKeyAccept,
+					ProvUIMessages.TrustCertificateDialogQuestionTrustRevokedKeyReject);
 			if (messageDialog.open() != Window.OK) {
 				return;
 			}
@@ -859,5 +847,20 @@ public class TrustCertificateDialog extends SelectionDialog {
 			return null;
 		}
 		return PGPPublicKeyService.toHexFingerprint(key);
+	}
+
+	private static class QuestionDialog extends MessageDialog {
+
+		public QuestionDialog(Shell shell, String title, String message, String labelAccept, String labelReject) {
+			super(shell, title, null, message, MessageDialog.QUESTION, new String[] { labelAccept, labelReject }, 1);
+			// on GTK+ we require the 'SWT.ON_TOP' flag, so that this dialog is not hidden
+			// beneath the main dialog
+			this.setShellStyle(getShellStyle() | SWT.ON_TOP);
+		}
+
+		@Override
+		public Image getImage() {
+			return getWarningImage();
+		}
 	}
 }


### PR DESCRIPTION
When clicking on the "Always trust all authorities" checkbox, with Eclipse running on GTK+, the created MessageDialog is hidden by the "main" dialog of TrustCertificateDialog. After this, the "main" dialog cannot be interacted with using the mouse pointer, giving the impression that Eclipse is frozen and unusable.

This change adds the SWT.ON_TOP flag to MessageDialog dialogs created in TrustCertificateDialog, so that the question dialog appears above the TrustCertificateDialog dialog - that way the question dialog is seen by the user and can be interacted with normally.

Fixes: #570