### PR TITLE
Consider source repositories in p2.composite.repository ANT task

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository.tools/src_ant/org/eclipse/equinox/p2/internal/repository/tools/tasks/CompositeRepositoryTask.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src_ant/org/eclipse/equinox/p2/internal/repository/tools/tasks/CompositeRepositoryTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -34,6 +34,7 @@ public class CompositeRepositoryTask extends AbstractRepositoryTask<CompositeRep
 	@Override
 	public void execute() throws BuildException {
 		try {
+			prepareSourceRepos();
 			IStatus result = application.run(null);
 			if (result.matches(IStatus.ERROR)) {
 				throw new BuildException(TaskHelper.statusToString(result, IStatus.ERROR, null).toString());


### PR DESCRIPTION
Consider the source repositories defined in a 'p2.composite.repository' ANT task and (if the task's destination repository doesn't have a 'format' repository) copy the name, properties and existing children into the (local) destination repository, before the specified addition or removal of children is performed.
This allows to add or remove children from a remote composite repository and output the result locally. The updated files can then be transferred to the remote server by a ordinary copy. Consequently this enables de-facto 'local' modifications of remote composite repositories with only commonly available tools (like plain SSH files copies).

This allows us to extend the `addToComposite.xml` and [removeFromComposite.xml](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/1db87cd65f60049af79b516e9cd40b8e9c1bab74/cje-production/scripts/removeFromComposite.xml) ANT scripts we use for our RelEng:

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/1db87cd65f60049af79b516e9cd40b8e9c1bab74/cje-production/scripts/addToComposite.xml#L12-L19

by a simple `source` repository within the `p2.composite.repository` task (as explained in https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Fguide%2Fp2_repositorytasks.htm):
```
<source
    location="${sourceRepo}" />
```

We can then pass the current I-build composite repository as `sourceRepo` and a local path from the Jenkins workspace as `repodir` and just copy (via SSH) the resulting `compositeArtifacts/Content.jar` to the download server. Consequently we can get rid of many (if not all) of the remaining Eclipse executions at the download server.


