### PR TITLE
Default implement IRepositoryManager.loadRepository(URI, IProgressMonitor)

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/ArtifactRepositoryManager.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/ArtifactRepositoryManager.java
@@ -123,11 +123,6 @@ public class ArtifactRepositoryManager extends AbstractRepositoryManager<IArtifa
 	}
 
 	@Override
-	public IArtifactRepository loadRepository(URI location, IProgressMonitor monitor) throws ProvisionException {
-		return loadRepository(location, 0, monitor);
-	}
-
-	@Override
 	public IArtifactRepository loadRepository(URI location, int flags, IProgressMonitor monitor)
 			throws ProvisionException {
 		return (IArtifactRepository) loadRepository(location, monitor, null, flags);

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.metadata.repository;singleton:=true
-Bundle-Version: 1.5.600.qualifier
+Bundle-Version: 1.5.700.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.metadata.repository;

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/MetadataRepositoryManager.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/MetadataRepositoryManager.java
@@ -103,11 +103,6 @@ public class MetadataRepositoryManager extends AbstractRepositoryManager<IInstal
 	}
 
 	@Override
-	public IMetadataRepository loadRepository(URI location, IProgressMonitor monitor) throws ProvisionException {
-		return loadRepository(location, 0, monitor);
-	}
-
-	@Override
 	public IMetadataRepository loadRepository(URI location, int flags, IProgressMonitor monitor) throws ProvisionException {
 		return (IMetadataRepository) loadRepository(location, monitor, null, flags);
 	}

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/AbstractApplication.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/AbstractApplication.java
@@ -218,7 +218,7 @@ public abstract class AbstractApplication {
 		IRepository<T> source = null;
 		try {
 			if (toInit.getFormat() != null) {
-				source = mgr.loadRepository(toInit.getFormat(), 0, null);
+				source = mgr.loadRepository(toInit.getFormat(), null);
 			}
 		} catch (ProvisionException e) {
 			// Ignore.

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/CompositeRepositoryApplication.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/CompositeRepositoryApplication.java
@@ -148,7 +148,7 @@ public class CompositeRepositoryApplication extends AbstractApplication {
 		IRepository<T> source = null;
 		try {
 			if (toInit.getFormat() != null) {
-				source = mgr.loadRepository(toInit.getFormat(), 0, null);
+				source = mgr.loadRepository(toInit.getFormat(), null);
 			}
 		} catch (ProvisionException e) {
 			// Ignore

--- a/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.repository;singleton:=true
-Bundle-Version: 2.9.400.qualifier
+Bundle-Version: 2.9.500.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/IRepositoryManager.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/IRepositoryManager.java
@@ -306,7 +306,9 @@ public interface IRepositoryManager<T> extends IQueryable<T> {
 	 * </ul>
 	 * @since 2.8
 	 */
-	IRepository<T> loadRepository(URI location, IProgressMonitor monitor) throws ProvisionException;
+	default IRepository<T> loadRepository(URI location, IProgressMonitor monitor) throws ProvisionException {
+		return loadRepository(location, 0, monitor);
+	}
 
 	/**
 	 * Loads the repository at the given location. If a repository has

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/artifact/IArtifactRepositoryManager.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/artifact/IArtifactRepositoryManager.java
@@ -132,7 +132,9 @@ public interface IArtifactRepositoryManager extends IRepositoryManager<IArtifact
 	 * </ul>
 	 */
 	@Override
-	IArtifactRepository loadRepository(URI location, IProgressMonitor monitor) throws ProvisionException;
+	default IArtifactRepository loadRepository(URI location, IProgressMonitor monitor) throws ProvisionException {
+		return loadRepository(location, 0, monitor);
+	}
 
 	/**
 	 * Loads the repository at the given location. The location is expected to contain

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/IMetadataRepositoryManager.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/metadata/IMetadataRepositoryManager.java
@@ -96,8 +96,10 @@ public interface IMetadataRepositoryManager extends IRepositoryManager<IInstalla
 	 * </ul>
 	 */
 	@Override
-	IMetadataRepository loadRepository(URI location, IProgressMonitor monitor)
-			throws ProvisionException, OperationCanceledException;
+	default IMetadataRepository loadRepository(URI location, IProgressMonitor monitor)
+			throws ProvisionException, OperationCanceledException {
+		return loadRepository(location, 0, monitor);
+	}
 
 	/**
 	 * Loads the repository at the given location. If a repository has


### PR DESCRIPTION
This simplifies the implementations and makes it easier to discover what default value is used for 'flags'.