### PR TITLE
Make AbstractRepositoryTask.application mutable again

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository.tools/src_ant/org/eclipse/equinox/p2/internal/repository/tools/tasks/AbstractRepositoryTask.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src_ant/org/eclipse/equinox/p2/internal/repository/tools/tasks/AbstractRepositoryTask.java
@@ -33,7 +33,7 @@ import org.eclipse.osgi.util.NLS;
 
 public abstract class AbstractRepositoryTask<A extends AbstractApplication> extends Task {
 	protected static final String ANT_PREFIX = "${"; //$NON-NLS-1$
-	protected final A application;
+	protected A application;
 	protected final List<IUDescription> iuTasks = new ArrayList<>();
 	private final List<RepositoryFileSet> sourceRepos = new ArrayList<>();
 	protected final List<DestinationRepository> destinations = new ArrayList<>();


### PR DESCRIPTION
That field is assigned by PDE's `org.eclipse.pde.internal.build.publisher.BrandP2Task` ANT task.

Fixes https://github.com/eclipse-equinox/p2/issues/878