### PR TITLE
Don't serialize ITouchpointType.NONE

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/io/MetadataParser.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/io/MetadataParser.java
@@ -338,8 +338,6 @@ public abstract class MetadataParser extends XMLParser implements XMLConstants {
 				currentUnit.setArtifacts(artifacts);
 				if (touchpointTypeHandler != null) {
 					currentUnit.setTouchpointType(touchpointTypeHandler.getTouchpointType());
-				} else {
-					// TODO: create an error
 				}
 				ITouchpointData[] touchpointData = (touchpointDataHandler == null ? new ITouchpointData[0] : touchpointDataHandler.getTouchpointData());
 				for (ITouchpointData touchpointData1 : touchpointData) {

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/io/MetadataWriter.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/io/MetadataWriter.java
@@ -89,7 +89,10 @@ public class MetadataWriter extends XMLWriter implements XMLConstants {
 		writeTrimmedCdata(IU_FILTER_ELEMENT, iu.getFilter() == null ? null : iu.getFilter().getParameters()[0].toString());
 
 		writeArtifactKeys(iu.getArtifacts());
-		writeTouchpointType(iu.getTouchpointType());
+		ITouchpointType touchpointType = iu.getTouchpointType();
+		if (touchpointType != ITouchpointType.NONE) {
+			writeTouchpointType(touchpointType);
+		}
 		writeTouchpointData(iu.getTouchpointData());
 		writeLicenses(iu.getLicenses());
 		writeCopyright(iu.getCopyright());

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TrustAuthorityDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TrustAuthorityDialog.java
@@ -34,6 +34,7 @@ import org.eclipse.equinox.internal.p2.ui.*;
 import org.eclipse.equinox.internal.p2.ui.dialogs.TrustCertificateDialog.QuestionDialog;
 import org.eclipse.equinox.internal.p2.ui.viewers.CertificateLabelProvider;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.ITouchpointType;
 import org.eclipse.jface.dialogs.*;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.layout.TableColumnLayout;
@@ -937,8 +938,9 @@ public class TrustAuthorityDialog extends SelectionDialog {
 
 					writeMetaRequirements(iu.getMetaRequirements());
 					writeArtifactKeys(iu.getArtifacts());
-					if (iu.getTouchpointType() != null) {
-						writeTouchpointType(iu.getTouchpointType());
+					ITouchpointType touchpointType = iu.getTouchpointType();
+					if (touchpointType != ITouchpointType.NONE) {
+						writeTouchpointType(touchpointType);
 					}
 					writeTouchpointData(iu.getTouchpointData());
 					end(INSTALLABLE_UNIT_ELEMENT);


### PR DESCRIPTION
- The implementation of InstallableUnit.getTouchpointType() always returns a non-null result returning ITouchpointType.NONE when the underlying field InstallableUnit.touchpointType is null so there is no need to serialize this.
- Also MetadataFactory.createTouchpointType(String, Version) has specialized handling for deserliazing ITouchpointType.NONE such that it makes no difference to deserialize the value versus there being no value specified.