### PR TITLE
Enable Manifest cleanups for P2 repository

### DIFF
--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -14,5 +14,6 @@ jobs:
       author: Eclipse Equinox Bot <equinox-bot@eclipse.org>
       do-quickfix: false
       do-cleanups: true
+      do-manifest: true
     secrets:
       token: ${{ secrets.EQUINOX_BOT_PAT }}


### PR DESCRIPTION
As it worked for Equinox since a while now and P2 also offers a lot of API it seems good to have it enabled here as well.