### PR TITLE
Fix Remedy leaks internal API

### DIFF
--- a/bundles/org.eclipse.equinox.p2.operations/.settings/.api_filters
+++ b/bundles/org.eclipse.equinox.p2.operations/.settings/.api_filters
@@ -19,18 +19,36 @@
         </filter>
     </resource>
     <resource path="src/org/eclipse/equinox/p2/operations/Remedy.java" type="org.eclipse.equinox.p2.operations.Remedy">
-        <filter comment="Workaround for bug 411257: .api_description files in Kepler release do not contain @noreference restrictions" id="643842064">
+        <filter comment="Marked as no reference and leaking API" id="305365105">
             <message_arguments>
-                <message_argument value="ProfileChangeRequest"/>
-                <message_argument value="Remedy"/>
-                <message_argument value="getRequest()"/>
+                <message_argument value="org.eclipse.equinox.p2.operations.Remedy"/>
+                <message_argument value="org.eclipse.equinox.p2.operations_2.8.0"/>
             </message_arguments>
         </filter>
-        <filter comment="Workaround for bug 411257: .api_description files in Kepler release do not contain @noreference restrictions" id="643846161">
+    </resource>
+    <resource path="src/org/eclipse/equinox/p2/operations/RemedyConfig.java" type="org.eclipse.equinox.p2.operations.RemedyConfig">
+        <filter id="388018290">
             <message_arguments>
-                <message_argument value="ProfileChangeRequest"/>
-                <message_argument value="Remedy"/>
-                <message_argument value="setRequest(ProfileChangeRequest)"/>
+                <message_argument value="org.eclipse.equinox.p2.operations.RemedyConfig"/>
+                <message_argument value="allowDifferentVersion"/>
+            </message_arguments>
+        </filter>
+        <filter id="388018290">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.operations.RemedyConfig"/>
+                <message_argument value="allowInstalledRemoval"/>
+            </message_arguments>
+        </filter>
+        <filter id="388018290">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.operations.RemedyConfig"/>
+                <message_argument value="allowInstalledUpdate"/>
+            </message_arguments>
+        </filter>
+        <filter id="388018290">
+            <message_arguments>
+                <message_argument value="org.eclipse.equinox.p2.operations.RemedyConfig"/>
+                <message_argument value="allowPartialInstall"/>
             </message_arguments>
         </filter>
     </resource>

--- a/bundles/org.eclipse.equinox.p2.operations/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.operations/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.operations;singleton:=true
-Bundle-Version: 2.7.700.qualifier
+Bundle-Version: 2.8.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.operations;x-friends:="org.eclipse.pde.ui,org.eclipse.equinox.p2.ui",
- org.eclipse.equinox.p2.operations;version="2.0.0"
+ org.eclipse.equinox.p2.operations;version="2.1.0"
 Require-Bundle: org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.core.jobs;bundle-version="3.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/IRemedy.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/IRemedy.java
@@ -1,0 +1,21 @@
+package org.eclipse.equinox.p2.operations;
+
+import java.util.List;
+import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
+
+/**
+ * @since 2.8
+ */
+public interface IRemedy {
+
+	RemedyConfig getConfig();
+
+	List<RemedyIUDetail> getIusDetails();
+
+	IProfileChangeRequest getRequest();
+
+	int getBeingInstalledRelaxedWeight();
+
+	int getInstallationRelaxedWeight();
+
+}

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/Remedy.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/Remedy.java
@@ -28,7 +28,7 @@ import org.eclipse.equinox.p2.planner.IProfileChangeRequest;
  * @since 2.3
  * @noreference
  */
-public class Remedy {
+class Remedy implements IRemedy {
 
 	private RemedyConfig config;
 	private ProfileChangeRequest request;
@@ -37,6 +37,7 @@ public class Remedy {
 	private final IProfileChangeRequest originalRequest;
 	private final List<RemedyIUDetail> iusDetails;
 
+	@Override
 	public List<RemedyIUDetail> getIusDetails() {
 		return iusDetails;
 	}
@@ -51,6 +52,7 @@ public class Remedy {
 		this.iusDetails = new ArrayList<>();
 	}
 
+	@Override
 	public RemedyConfig getConfig() {
 		return config;
 	}
@@ -59,6 +61,7 @@ public class Remedy {
 		this.config = config;
 	}
 
+	@Override
 	public ProfileChangeRequest getRequest() {
 		return request;
 	}
@@ -67,6 +70,7 @@ public class Remedy {
 		this.request = request;
 	}
 
+	@Override
 	public int getBeingInstalledRelaxedWeight() {
 		return beingInstalledRelaxedWeight;
 	}
@@ -75,6 +79,7 @@ public class Remedy {
 		this.beingInstalledRelaxedWeight = beingInstalledRelaxedWeight;
 	}
 
+	@Override
 	public int getInstallationRelaxedWeight() {
 		return installationRelaxedWeight;
 	}

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RemedyConfig.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RemedyConfig.java
@@ -17,37 +17,37 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 /**
- * <p>
- * <strong>EXPERIMENTAL</strong>. This class or interface has been added as
- * part of a work in progress. There is no guarantee that this API will
- * work or that it will remain the same. Please do not use this API without
- * consulting with the p2 team.
- * </p>
- * @since 2.3
- * @noreference
+ * @since 2.8
  */
 public class RemedyConfig {
 
-	public boolean allowInstalledUpdate = false;
-	public boolean allowInstalledRemoval = false;
-	public boolean allowDifferentVersion = false;
-	public boolean allowPartialInstall = false;
+	boolean allowInstalledUpdate = false;
+	boolean allowInstalledRemoval = false;
+	boolean allowDifferentVersion = false;
+	boolean allowPartialInstall = false;
 
-	public RemedyConfig() {
+	RemedyConfig() {
 
 	}
 
-	private RemedyConfig(boolean allowPartialInstall, boolean allowDifferentVersion, boolean allowInstalledUpdate, boolean allowInstalledRemoval) {
+	RemedyConfig(boolean allowPartialInstall, boolean allowDifferentVersion, boolean allowInstalledUpdate,
+			boolean allowInstalledRemoval) {
 		this.allowDifferentVersion = allowDifferentVersion;
 		this.allowInstalledRemoval = allowInstalledRemoval;
 		this.allowInstalledUpdate = allowInstalledUpdate;
 		this.allowPartialInstall = allowPartialInstall;
 	}
 
+	/**
+	 * @since 2.8
+	 */
 	public static RemedyConfig[] getCheckForUpdateRemedyConfigs() {
 		return new RemedyConfig[] {new RemedyConfig(false, true, true, false)};
 	}
 
+	/**
+	 * @since 2.8
+	 */
 	public static RemedyConfig[] getAllRemedyConfigs() {
 		Collection<RemedyConfig> remedyConfigs = new ArrayList<>();
 		int allMasks = (1 << 4);
@@ -76,5 +76,33 @@ public class RemedyConfig {
 		}
 		RemedyConfig[] test = remedyConfigs.toArray(new RemedyConfig[remedyConfigs.size()]);
 		return test;
+	}
+
+	/**
+	 * @since 2.8
+	 */
+	public boolean isAllowDifferentVersion() {
+		return allowDifferentVersion;
+	}
+
+	/**
+	 * @since 2.8
+	 */
+	public boolean isAllowInstalledRemoval() {
+		return allowInstalledRemoval;
+	}
+
+	/**
+	 * @since 2.8
+	 */
+	public boolean isAllowInstalledUpdate() {
+		return allowInstalledUpdate;
+	}
+
+	/**
+	 * @since 2.8
+	 */
+	public boolean isAllowPartialInstall() {
+		return allowPartialInstall;
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RemedyIUDetail.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RemedyIUDetail.java
@@ -14,17 +14,10 @@
 package org.eclipse.equinox.p2.operations;
 
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
-
 import org.eclipse.equinox.p2.metadata.Version;
+
 /**
- * <p>
- * <strong>EXPERIMENTAL</strong>. This class or interface has been added as
- * part of a work in progress. There is no guarantee that this API will
- * work or that it will remain the same. Please do not use this API without
- * consulting with the p2 team.
- * </p>
- * @since 2.3
- * @noreference
+ * @since 2.8
  */
 public class RemedyIUDetail {
 
@@ -39,42 +32,72 @@ public class RemedyIUDetail {
 	private Version beingInstalledVersion;
 	private final IInstallableUnit iu;
 
+	/**
+	 * @since 2.8
+	 */
 	public RemedyIUDetail(IInstallableUnit iu) {
 		this.iu = iu;
 	}
 
+	/**
+	 * @since 2.8
+	 */
 	public void setStatus(int status) {
 		this.status = status;
 	}
 
+	/**
+	 * @since 2.8
+	 */
 	public int getStatus() {
 		return status;
 	}
 
+	/**
+	 * @since 2.8
+	 */
 	public Version getRequestedVersion() {
 		return requestedVersion;
 	}
 
+	/**
+	 * @since 2.8
+	 */
 	public void setRequestedVersion(Version requestedVersion) {
 		this.requestedVersion = requestedVersion;
 	}
 
+	/**
+	 * @since 2.8
+	 */
 	public Version getBeingInstalledVersion() {
 		return beingInstalledVersion;
 	}
 
+	/**
+	 * @since 2.8
+	 */
 	public void setBeingInstalledVersion(Version beingInstalledVersion) {
 		this.beingInstalledVersion = beingInstalledVersion;
 	}
 
+	/**
+	 * @since 2.8
+	 */
 	public IInstallableUnit getIu() {
 		return iu;
 	}
 
+	/**
+	 * @since 2.8
+	 */
 	public Version getInstalledVersion() {
 		return installedVersion;
 	}
 
+	/**
+	 * @since 2.8
+	 */
 	public void setInstalledVersion(Version installedVersion) {
 		this.installedVersion = installedVersion;
 	}

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/ElementUtils.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/ElementUtils.java
@@ -20,7 +20,7 @@ import java.util.*;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.equinox.internal.p2.ui.*;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
-import org.eclipse.equinox.p2.operations.Remedy;
+import org.eclipse.equinox.p2.operations.IRemedy;
 import org.eclipse.equinox.p2.operations.RemedyIUDetail;
 import org.eclipse.equinox.p2.repository.IRepository;
 import org.eclipse.equinox.p2.repository.IRepositoryManager;
@@ -140,7 +140,7 @@ public class ElementUtils {
 		return false;
 	}
 
-	public static AvailableIUElement[] requestToElement(Remedy remedy, boolean installMode) {
+	public static AvailableIUElement[] requestToElement(IRemedy remedy, boolean installMode) {
 		if (remedy == null) {
 			return new AvailableIUElement[0];
 		}
@@ -164,7 +164,7 @@ public class ElementUtils {
 		return temp.toArray(new AvailableIUElement[temp.size()]);
 	}
 
-	public static RemedyElementCategory[] requestToRemedyElementsCategories(Remedy remedy) {
+	public static RemedyElementCategory[] requestToRemedyElementsCategories(IRemedy remedy) {
 		List<RemedyElementCategory> categories = new ArrayList<>();
 		RemedyElementCategory categoryAdded = new RemedyElementCategory(ProvUIMessages.RemedyCategoryAdded);
 		RemedyElementCategory cateogyRemoved = new RemedyElementCategory(ProvUIMessages.RemedyCategoryRemoved);


### PR DESCRIPTION
Currently the Remedy class leaks internal API through getRequest, this problem was previously suppressed.

This now introduces a new interface IRemedy that only returns public API types and make those non experimental as its unlikely we will evolve this API any time soon. This then also reduces warning in the places where this API is actually used.

the other leaking type is `RemediationOperation` but it seems better to handle this separately.