### PR TITLE
Remove source features and source bundles from o.e.equinox.p2.sdk

### DIFF
--- a/features/org.eclipse.equinox.p2.sdk/feature.properties
+++ b/features/org.eclipse.equinox.p2.sdk/feature.properties
@@ -27,8 +27,8 @@ providerName=Eclipse.org - Equinox
 updateSiteName=The Equinox Project Repository
 
 # "description" property - description of the feature
-description=All of the bundles and source that comprise the Equinox p2 provisioning platform. \n\
-This feature includes the corresponding source and is intended \
+description=All of the bundles that comprise the Equinox p2 provisioning platform. \n\
+This feature is intended \
 to be added to target platforms at development time rather than \
 deployed with end-user systems.
 

--- a/features/org.eclipse.equinox.p2.sdk/feature.xml
+++ b/features/org.eclipse.equinox.p2.sdk/feature.xml
@@ -28,23 +28,11 @@
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.equinox.p2.core.feature.source"
-         version="0.0.0"/>
-
-   <includes
          id="org.eclipse.equinox.p2.user.ui"
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.equinox.p2.user.ui.source"
-         version="0.0.0"/>
-
-   <includes
          id="org.eclipse.equinox.server.p2"
-         version="0.0.0"/>
-
-   <includes
-         id="org.eclipse.equinox.server.p2.source"
          version="0.0.0"/>
 
    <plugin
@@ -52,15 +40,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.p2.installer.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.p2.ui.admin.rcp"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.ui.admin.rcp.source"
          version="0.0.0"/>
 
    <plugin
@@ -68,27 +48,7 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.equinox.p2.ui.admin.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.equinox.simpleconfigurator"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.simpleconfigurator.source"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.discovery.source"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.discovery.compatibility.source"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.equinox.p2.ui.discovery.source"
          version="0.0.0"/>
 
 </feature>


### PR DESCRIPTION
- The repositories and products that use this SDK feature using includeAllSources to ensure that sources are available.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3206