### PR TITLE
Do not expose unstarted service, stop started service leak

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.core;singleton:=true
-Bundle-Version: 2.13.100.qualifier
+Bundle-Version: 2.13.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.core.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -63,7 +63,7 @@ Export-Package: org.eclipse.equinox.internal.p2.core;x-friends:="org.eclipse.equ
    org.eclipse.equinox.p2.updatesite,
    org.eclipse.equinox.p2.director.app,
    org.eclipse.equinox.p2.transport.ecf",
- org.eclipse.equinox.p2.core;version="2.13.100";uses:="org.eclipse.core.runtime",
+ org.eclipse.equinox.p2.core;version="2.13.200";uses:="org.eclipse.core.runtime",
  org.eclipse.equinox.p2.core.spi;version="2.2.0";uses:="org.eclipse.equinox.p2.core"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/ProvisioningAgent.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/ProvisioningAgent.java
@@ -95,9 +95,11 @@ public class ProvisioningAgent implements IProvisioningAgent, ServiceTrackerCust
 	@Override
 	public void registerService(String serviceName, Object service) {
 		checkRunning();
-		agentServices.put(serviceName, service);
 		if (service instanceof IAgentService) {
 			((IAgentService) service).start();
+		}
+		if (agentServices.put(serviceName, service) instanceof IAgentService prevService) {
+			prevService.stop();
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
@@ -130,7 +130,8 @@ Require-Bundle: org.eclipse.equinox.frameworkadmin,
  org.eclipse.equinox.p2.ui.sdk.scheduler,
  org.eclipse.equinox.p2.artifact.repository;bundle-version="[1.3.0,2.0.0)",
  org.mockito.mockito-core,
- net.bytebuddy.byte-buddy
+ net.bytebuddy.byte-buddy,
+ org.eclipse.equinox.p2.core
 Eclipse-RegisterBuddy: org.eclipse.equinox.p2.artifact.repository
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/core/ProvisioningAgentTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/core/ProvisioningAgentTest.java
@@ -19,6 +19,7 @@ import java.net.URISyntaxException;
 import org.eclipse.equinox.p2.core.IProvisioningAgent;
 import org.eclipse.equinox.p2.core.IProvisioningAgentProvider;
 import org.eclipse.equinox.p2.core.ProvisionException;
+import org.eclipse.equinox.p2.core.spi.IAgentService;
 import org.eclipse.equinox.p2.engine.IProfileRegistry;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.equinox.p2.tests.AbstractProvisioningTest;
@@ -59,5 +60,52 @@ public class ProvisioningAgentTest extends AbstractProvisioningTest {
 
 		TestActivator.context.ungetService(providerRef);
 
+	}
+
+	/**
+	 * Stop all registered services
+	 */
+	public void testStopServices() throws ProvisionException {
+		URI p2location = getTempFolder().toURI();
+
+		ServiceReference<IProvisioningAgentProvider> providerRef = TestActivator.context.getServiceReference(IProvisioningAgentProvider.class);
+		IProvisioningAgentProvider provider = TestActivator.context.getService(providerRef);
+
+		IProvisioningAgent firstAgent = provider.createAgent(p2location);
+
+
+		MockService mockService1 = new MockService();
+		MockService mockService2 = new MockService();
+
+		firstAgent.registerService(IMockService.class.getName(), mockService1);
+		assertTrue(mockService1.started);
+
+		firstAgent.registerService(IMockService.class.getName(), mockService2);
+		assertTrue(mockService2.started);
+		assertFalse(mockService1.started);
+
+		firstAgent.stop();
+
+		assertFalse(mockService1.started);
+		assertFalse(mockService2.started);
+
+	}
+
+	public static interface IMockService extends IAgentService {
+
+	}
+
+	private static class MockService implements IMockService {
+		boolean started = false;
+
+		@Override
+		public void start() {
+			started = true;
+		}
+
+		@Override
+		public void stop() {
+			started = false;
+		}
 	}
 }


### PR DESCRIPTION
There is a potential for client to see service before they are started.
Dynamically registered services may be never stopped causing resource leaks.