### PR TITLE
Don't call pack() on not yet visible table on Linux

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui.sdk/src/org/eclipse/equinox/internal/p2/ui/sdk/TrustPreferencePage.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk/src/org/eclipse/equinox/internal/p2/ui/sdk/TrustPreferencePage.java
@@ -42,6 +42,7 @@ import org.eclipse.jface.layout.TableColumnLayout;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.Policy;
+import org.eclipse.jface.util.Util;
 import org.eclipse.jface.viewers.*;
 import org.eclipse.jface.widgets.WidgetFactory;
 import org.eclipse.jface.window.Window;
@@ -417,7 +418,17 @@ public class TrustPreferencePage extends PreferencePage implements IWorkbenchPre
 
 		certificateViewer.addDoubleClickListener(e -> details.run());
 
-		typeColumn.getColumn().pack();
+		if (Util.isLinux()) {
+			// pack() produces stack overflow on not yet visible table
+			Control control = certificateViewer.getControl();
+			control.getDisplay().asyncExec(() -> {
+				if (!control.isDisposed()) {
+					typeColumn.getColumn().pack();
+				}
+			});
+		} else {
+			typeColumn.getColumn().pack();
+		}
 
 		var menu = new Menu(table);
 		table.setMenu(menu);


### PR DESCRIPTION
Something goes wrong on SWT Column/Table GTK code if column is being packed on not yet shown table. So let pack() the column on a next call on Linux.

Fixes https://github.com/eclipse-equinox/p2/issues/946