### PR TITLE
Use placeholder text for filter field in install/update in Preference page

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RepositoryManipulationPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RepositoryManipulationPage.java
@@ -217,7 +217,7 @@ public class RepositoryManipulationPage extends PreferencePage implements IWorkb
 		// Filter box
 		pattern = new Text(composite, SWT.SINGLE | SWT.BORDER | SWT.SEARCH | SWT.CANCEL);
 		pattern.getAccessible().addAccessibleListener(AccessibleListener.getNameAdapter(e -> e.result = DEFAULT_FILTER_TEXT));
-		pattern.setText(DEFAULT_FILTER_TEXT);
+		pattern.setMessage(DEFAULT_FILTER_TEXT);
 		pattern.selectAll();
 		pattern.addModifyListener(e -> applyFilter());
 


### PR DESCRIPTION
This PR uses `setMessage()` instead of `setText()` , to display the text as grey placeholder text. 

This now aligns with the standard UI convention used throughout Eclipse preference pages and dialogs. This also eliminates the need to manually empty the text before typing. This makes the field appear empty but still directs the user with proper guidance.

Before:

<img width="600" height="108" alt="image" src="https://github.com/user-attachments/assets/e7892096-cc32-42ec-ab8f-21537786ad41" />

After:

<img width="600" height="114" alt="image" src="https://github.com/user-attachments/assets/0be171ef-2c4d-4dba-b1ae-c178996e98a1" />

