### PR TITLE
[Build] Set test timeout of 30min for o.e.equinox.p2.tests

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests/pom.xml
@@ -75,6 +75,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
 					<argLine>-Xmx512m -Dorg.eclipse.equinox.p2.reconciler.tests.platform.archive=${dropinsProduct} -Dorg.eclipse.equinox.p2.reconciler.tests.35.platform.archive=${platform.archive.name} -Dorg.eclipse.equinox.p2.repository -Dorg.eclipse.equinox.p2.transport.ecf.retry=5</argLine>
+					<forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
 					<appArgLine>-consoleLog -debug</appArgLine>
 					<explodedBundles>
 						<explodedBundle>org.apache.ant</explodedBundle>


### PR DESCRIPTION
This extends the general timeout, which could be too strict in this case and is introduced via
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3427