### PR TITLE
Potential fix for code scanning alert no. 7: Implicit narrowing conversion in compound assignment

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/MethodInfo.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/comparator/java/MethodInfo.java
@@ -70,9 +70,9 @@ public class MethodInfo extends ClassFileStruct {
 			}
 		}
 		int attributesIndex = 0;
-		int readOffset = 8;
+		long readOffset = 8;
 		for (int i = 0; i < this.attributesCount; i++) {
-			constantPoolEntry = constantPool.decodeEntry(u2At(classFileBytes, readOffset, offset));
+			constantPoolEntry = constantPool.decodeEntry(u2At(classFileBytes, (int)readOffset, offset));
 			if (constantPoolEntry.getKind() != ConstantPoolConstant.CONSTANT_Utf8) {
 				throw new ClassFormatException(ClassFormatException.INVALID_CONSTANT_POOL_ENTRY);
 			}
@@ -106,9 +106,9 @@ public class MethodInfo extends ClassFileStruct {
 			} else {
 				this.attributes[attributesIndex++] = new ClassFileAttribute(classFileBytes, constantPool, offset + readOffset);
 			}
-			readOffset += (6 + u4At(classFileBytes, readOffset + 2, offset));
+			readOffset += (6 + u4At(classFileBytes, (int)readOffset + 2, offset));
 		}
-		this.attributeBytes = readOffset;
+		this.attributeBytes = (int)readOffset;
 	}
 
 	/*


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-equinox/p2/security/code-scanning/7](https://github.com/eclipse-equinox/p2/security/code-scanning/7)

To resolve the issue, declare `readOffset` as a `long` so it matches the type returned by `u4At` and prevents implicit narrowing during incrementation. This change should be limited to the region where `readOffset` is used for offset calculations, i.e., within the constructor. Changing just the local variable `readOffset` from `int` to `long` is sufficient, as long as all related arithmetic respects the type. There is no need for additional imports or method changes, provided the remainder of the byte indexing logic elsewhere does not require `int` specifically; given `readOffset` is only used locally within this scope for offset computation, using a `long` is safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
