### PR TITLE
Bump o.e.equinox.p2.tests version for 4.38 stream

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.tests;singleton:=true
-Bundle-Version: 1.9.900.qualifier
+Bundle-Version: 1.9.1000.qualifier
 Bundle-Activator: org.eclipse.equinox.p2.tests.TestActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.equinox.p2.tests</artifactId>
-	<version>1.9.900-SNAPSHOT</version>
+	<version>1.9.1000-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<properties>


### PR DESCRIPTION
Reported at
https://download.eclipse.org/eclipse/downloads/drops4/I20251112-1800/buildlogs/reporeports/reports/versionChecks.html