### PR TITLE
Plugin section via file import does not work as expected

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui.importexport/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.importexport;singleton:=true
-Bundle-Version: 1.5.100.qualifier
+Bundle-Version: 1.5.200.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime;bundle-version="[3.34.200,4.0.0)",

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/AbstractImportPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/AbstractImportPage.java
@@ -111,7 +111,7 @@ public abstract class AbstractImportPage extends AbstractPage {
 					IInstallableUnit iu = ProvUI.getAdapter(element, IInstallableUnit.class);
 					IQueryResult<IInstallableUnit> collector = profile.query(QueryUtil.createIUQuery(iu.getId(), new VersionRange(iu.getVersion(), true, null, false)), new NullProgressMonitor());
 					if (collector.isEmpty()) {
-						return true;
+						return false;
 					}
 				}
 				return false;

--- a/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/AbstractPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui.importexport/src/org/eclipse/equinox/internal/p2/importexport/internal/wizard/AbstractPage.java
@@ -485,6 +485,7 @@ public abstract class AbstractPage extends WizardPage implements Listener {
 		Button deselectAll = new Button(buttons, SWT.PUSH);
 		deselectAll.setText(Messages.AbstractPage_ButtonDeselectAll);
 		deselectAll.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+			viewer.setCheckStateProvider(null);
 			for (TreeItem item : viewer.getTree().getItems()) {
 				viewer.setSubtreeChecked(item.getData(), false);
 			}


### PR DESCRIPTION

<img width="2120" height="1302" alt="image" src="https://github.com/user-attachments/assets/701e2940-b16e-4a0d-a7a1-b6e2870f65c4" />


Changes the behavior so that no plugins are selected by default when importing from a p2f file. This allows users to explicitly select only the plugins they want to install.

Fix: https://github.com/eclipse-equinox/p2/issues/1003