### PR TITLE
NextButton not disabled toggling "Hide items that are already installed"

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUsPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUsPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2018 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -277,6 +277,14 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 		updateSelection();
 	}
 
+	private void updatePageCompleteAsync() {
+		Display displayPage = availableIUGroup.getCheckboxTreeViewer().getControl().getDisplay();
+		displayPage.asyncExec(() -> {
+			Object[] checked = availableIUGroup.getCheckboxTreeViewer().getCheckedElements();
+			setPageComplete(checked.length > 0);
+		});
+	}
+
 	private void createViewControlsArea(Composite parent) {
 		showLatestVersionsCheckbox = new Button(parent, SWT.CHECK);
 		showLatestVersionsCheckbox.setText(ProvUIMessages.AvailableIUsPage_ShowLatestVersions);
@@ -285,12 +293,14 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 			public void widgetDefaultSelected(SelectionEvent e) {
 				updateQueryContext();
 				availableIUGroup.updateAvailableViewState();
+				updatePageCompleteAsync();
 			}
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				updateQueryContext();
 				availableIUGroup.updateAvailableViewState();
+				updatePageCompleteAsync();
 			}
 		});
 
@@ -301,12 +311,14 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 			public void widgetDefaultSelected(SelectionEvent e) {
 				updateQueryContext();
 				availableIUGroup.updateAvailableViewState();
+				updatePageCompleteAsync();
 			}
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				updateQueryContext();
 				availableIUGroup.updateAvailableViewState();
+				updatePageCompleteAsync();
 			}
 		});
 
@@ -317,12 +329,14 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 			public void widgetDefaultSelected(SelectionEvent e) {
 				updateQueryContext();
 				availableIUGroup.updateAvailableViewState();
+				updatePageCompleteAsync();
 			}
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				updateQueryContext();
 				availableIUGroup.updateAvailableViewState();
+				updatePageCompleteAsync();
 			}
 		});
 
@@ -343,12 +357,14 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 			public void widgetDefaultSelected(SelectionEvent e) {
 				updateQueryContext();
 				availableIUGroup.updateAvailableViewState();
+				updatePageCompleteAsync();
 			}
 
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				updateQueryContext();
 				availableIUGroup.updateAvailableViewState();
+				updatePageCompleteAsync();
 			}
 		});
 


### PR DESCRIPTION
Toggling "Hide items that are already installed" refreshes the available software view, but the wizard does not update the Next button state. This change ensures the Next button is disabled when no installable units are selected.

fix: https://github.com/eclipse-equinox/p2/issues/1036