### PR TITLE
Delete deprecated and unused internal helper ChecksumProducer's computeMD5(File)

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.repository;singleton:=true
-Bundle-Version: 2.9.600.qualifier
+Bundle-Version: 2.9.700.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/ChecksumProducer.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/ChecksumProducer.java
@@ -61,20 +61,6 @@ public class ChecksumProducer {
 	}
 
 	/**
-	 * @param file should not be <code>null</code>
-	 * @return MD5 checksum of the file or <code>null</code> in case of NoSuchAlgorithmException
-	 */
-	@Deprecated
-	// bug #509401 - still here to not break x-friends like in bug #507193
-	public static String computeMD5(File file) throws IOException {
-		try {
-			return produce(file, "MD5", null); //$NON-NLS-1$
-		} catch (NoSuchAlgorithmException | NoSuchProviderException e) {
-			return null;
-		}
-	}
-
-	/**
 	 * @param file         should not be <code>null</code>
 	 * @param algorithm    {@link java.security.MessageDigest#getInstance(String)}
 	 * @param providerName {@link Provider#getName()}


### PR DESCRIPTION
PDE's tests do not use ChecksumProducer.computeMD5(File) since Apr'2022 [1], it was the only reason for ChecksumProducer to keep the method.

[1] https://github.com/eclipse-pde/eclipse.pde/commit/84af4cf63636732980e8486923af86608590f755