### PR TITLE
Fix, status is OK when one of multiple retrieveing artifacts fail

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
@@ -995,7 +995,7 @@ public class SimpleArtifactRepository extends AbstractArtifactRepository impleme
 				} catch (InterruptedException e) {
 					// ignore
 				}
-				overallStatus.addAll(overallStatus);
+				overallStatus.addAll(jobStatus);
 			} finally {
 				monitor.done();
 			}


### PR DESCRIPTION
I recently found this bug in the tests for our private projects. Looking at the implementation of `SimpleArtifactRepository` it really seams that the the multi status is not being updated from the jobs in the end.