### PR TITLE
Auto-trigger updates on software site changes

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui;singleton:=true
-Bundle-Version: 2.9.100.qualifier
+Bundle-Version: 2.9.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.ui.ProvUIActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/MessageDialogWithLink.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/MessageDialogWithLink.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2015 Red Hat Inc.
+ *  Copyright (c) 2015, 2026 Red Hat Inc and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.*;
@@ -47,9 +48,25 @@ public class MessageDialogWithLink extends MessageDialog {
 			this.link = new Link(composite, getMessageLabelStyle());
 			this.link.setText(this.linkMessage);
 			GridDataFactory.fillDefaults().align(SWT.FILL, SWT.BEGINNING).grab(true, false).hint(convertHorizontalDLUsToPixels(IDialogConstants.MINIMUM_MESSAGE_AREA_WIDTH), SWT.DEFAULT).applyTo(this.link);
-			for (SelectionListener linkListener : this.linkListeners) {
-				this.link.addSelectionListener(linkListener);
-			}
+			this.link.addSelectionListener(new SelectionListener() {
+				@Override
+				public void widgetSelected(SelectionEvent e) {
+					// First notify existing listeners
+					for (SelectionListener listener : linkListeners) {
+						listener.widgetSelected(e);
+					}
+
+					Shell shell = getShell();
+					if (shell != null && !shell.isDisposed()) {
+						shell.close();
+					}
+				}
+
+				@Override
+				public void widgetDefaultSelected(SelectionEvent e) {
+					widgetSelected(e);
+				}
+			});
 		}
 		return composite;
 	}

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RepositoryManipulationPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RepositoryManipulationPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2007, 2018 IBM Corporation and others.
+ *  Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -47,6 +47,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.*;
 import org.eclipse.ui.*;
 import org.eclipse.ui.dialogs.PatternFilter;
+import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.statushandlers.StatusManager;
 
 /**
@@ -91,6 +92,7 @@ import org.eclipse.ui.statushandlers.StatusManager;
 public class RepositoryManipulationPage extends PreferencePage implements IWorkbenchPreferencePage, ICopyable {
 	final static String DEFAULT_FILTER_TEXT = ProvUIMessages.RepositoryManipulationPage_DefaultFilterString;
 	private final static int FILTER_DELAY = 200;
+	private static final String UPDATE = "org.eclipse.equinox.p2.ui.sdk.update"; //$NON-NLS-1$
 
 	StructuredViewerProvisioningListener listener;
 	CheckboxTableViewer repositoryViewer;
@@ -99,6 +101,7 @@ public class RepositoryManipulationPage extends PreferencePage implements IWorkb
 	Policy policy;
 	Display display;
 	boolean changed = false;
+	boolean repoAddedOrEdited;
 	MetadataRepositoryElementComparator comparator;
 	RepositoryDetailsLabelProvider labelProvider;
 	RepositoryTracker tracker;
@@ -504,6 +507,16 @@ public class RepositoryManipulationPage extends PreferencePage implements IWorkb
 		}
 		originalNameCache.clear();
 		originalURICache.clear();
+		
+		if (repoAddedOrEdited) {
+			Display.getDefault().asyncExec(() -> {
+				try {
+					PlatformUI.getWorkbench().getService(IHandlerService.class).executeCommand(UPDATE, null);
+				} catch (Exception e) {
+					// nothing to report
+				}
+			});
+		}
 		return super.performOk();
 	}
 
@@ -682,6 +695,9 @@ public class RepositoryManipulationPage extends PreferencePage implements IWorkb
 				repositoryViewer.update(element, null);
 			}
 		}
+		if (updated.length > 0) {
+			repoAddedOrEdited = true;
+		}
 		changed = true;
 	}
 
@@ -762,6 +778,7 @@ public class RepositoryManipulationPage extends PreferencePage implements IWorkb
 			}
 			if (originalURICache.size() > 0 || originalNameCache.size() > 0) {
 				changed = true;
+				repoAddedOrEdited = true;
 			} else {
 				changed = false;
 			}
@@ -885,6 +902,7 @@ public class RepositoryManipulationPage extends PreferencePage implements IWorkb
 						element.setNickname(nickname);
 					}
 					changed = true;
+					repoAddedOrEdited = true;
 					safeRefresh(element);
 				}
 


### PR DESCRIPTION
This PR reworks the update flow to improve the overall user experience.

An automatic update is now triggered when the user makes changes (add/edit/enable) to the available software sites and saves them. This removes the need for users to manually initiate an update after modifying repositories.

How to test the feature
----------------------
1. Install a plugin from the software site(this is not required if there is any plugin)
2.Then modify the software sites(add/edit or enable) the software site and "Apply and save"
3. This will trigger an auto update.

Fix: https://github.com/eclipse-equinox/p2/issues/1062