### PR TITLE
Hide selection count during available software filter changes

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUsPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUsPage.java
@@ -282,6 +282,7 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 		displayPage.asyncExec(() -> {
 			Object[] checked = availableIUGroup.getCheckboxTreeViewer().getCheckedElements();
 			setPageComplete(checked.length > 0);
+			availableIUGroup.setChecked(new Object[0]);
 		});
 	}
 


### PR DESCRIPTION
<img width="2156" height="1460" alt="image" src="https://github.com/user-attachments/assets/7d5ade93-08db-49cc-8ad4-1ece0bec3e07" />

Hide the plugin selection count message when the available software view is refreshed through filter options such as “Show only the latest versions of available software”, “Group items by category”, “Show only software applicable to target environment”, and “Hide items that are already installed”.

This improves the UI behaviour by preventing stale or misleading selection count messages from being shown while the filtered content is being updated.

Fix: https://github.com/eclipse-equinox/p2/issues/1068