### PR TITLE
Remove dead commented-out code in DiscoveryInstallOperation

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui.discovery/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.p2.ui.discovery;singleton:=true
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/operations/DiscoveryInstallOperation.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/operations/DiscoveryInstallOperation.java
@@ -121,33 +121,6 @@ public class DiscoveryInstallOperation implements IRunnableWithProgress {
 			checkForUnavailable(installableUnits);
 			return installableUnits.toArray(new IInstallableUnit[installableUnits.size()]);
 
-			// MultiStatus status = new MultiStatus(DiscoveryUi.ID_PLUGIN, 0,
-			// Messages.PrepareInstallProfileJob_ok, null);
-			// ius = installableUnits.toArray(new
-			// IInstallableUnit[installableUnits.size()]);
-			// ProfileChangeRequest profileChangeRequest =
-			// InstallAction.computeProfileChangeRequest(ius, profileId,
-			// status, new SubProgressMonitor(monitor, installableConnectors.size()));
-			// if (status.getSeverity() > IStatus.WARNING) {
-			// throw new CoreException(status);
-			// }
-			// if (profileChangeRequest == null) {
-			// // failed but no indication as to why
-			// throw new CoreException(new Status(IStatus.ERROR, DiscoveryUi.ID_PLUGIN,
-			// Messages.PrepareInstallProfileJob_computeProfileChangeRequestFailed, null));
-			// }
-			// PlannerResolutionOperation operation = new PlannerResolutionOperation(
-			// Messages.PrepareInstallProfileJob_calculatingRequirements, profileId,
-			// profileChangeRequest, null,
-			// status, true);
-			// IStatus operationStatus = operation.execute(new SubProgressMonitor(monitor,
-			// installableConnectors.size()));
-			// if (operationStatus.getSeverity() > IStatus.WARNING) {
-			// throw new CoreException(operationStatus);
-			// }
-			//
-			// plannerResolutionOperation = operation;
-
 		} catch (URISyntaxException e) {
 			// should never happen, since we already validated URLs.
 			throw new CoreException(new Status(IStatus.ERROR, DiscoveryUi.ID_PLUGIN,
@@ -282,9 +255,6 @@ public class DiscoveryInstallOperation implements IRunnableWithProgress {
 			if (repositoryLocations.add(uri)) {
 				checkCancelled(monitor);
 				repositoryTracker.addRepository(uri, null, session);
-				// ProvisioningUtil.addMetaDataRepository(url.toURI(), true);
-				// ProvisioningUtil.addArtifactRepository(url.toURI(), true);
-				// ProvisioningUtil.setColocatedRepositoryEnablement(url.toURI(), true);
 			}
 			monitor.worked(1);
 		}

--- a/features/org.eclipse.equinox.p2.discovery.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.discovery.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.discovery.feature"
       label="%featureName"
-      version="1.3.1100.qualifier"
+      version="1.3.1200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.sdk/feature.xml
+++ b/features/org.eclipse.equinox.p2.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.sdk"
       label="%featureName"
-      version="3.11.3200.qualifier"
+      version="3.11.3300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Two blocks of commented-out code in `DiscoveryInstallOperation` have been dead since July 2019 (commit 1139fc569, "Convert to the generic IProvisioningAgent.getService()"). One block sits after a `return` statement and can never execute; the other is an old `ProvisioningUtil` call that was superseded by `RepositoryTracker`. Both are pure clutter with no chance of being re-enabled as-is.