### PR TITLE
Support plugin_customization.ini for p2 trust preferences

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.engine;singleton:=true
-Bundle-Version: 2.11.100.qualifier
+Bundle-Version: 2.11.200.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.engine.EngineActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
@@ -31,7 +31,8 @@ Export-Package: org.eclipse.equinox.internal.p2.engine;
  org.eclipse.equinox.p2.engine.spi;version="2.0.0";uses:="org.eclipse.core.runtime,org.eclipse.equinox.p2.engine"
 Require-Bundle: org.eclipse.equinox.common,
  org.eclipse.equinox.registry,
- org.eclipse.core.jobs;bundle-version="[3.4.0,4.0.0)"
+ org.eclipse.core.jobs;bundle-version="[3.4.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.34.0,4.0.0)"
 Eclipse-RegisterBuddy: org.eclipse.equinox.p2.metadata.repository
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/AuthorityChecker.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/AuthorityChecker.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.*;
 import org.eclipse.equinox.internal.p2.core.helpers.LogHelper;
 import org.eclipse.equinox.internal.p2.engine.EngineActivator;
 import org.eclipse.equinox.internal.p2.engine.Messages;
@@ -163,9 +163,10 @@ public class AuthorityChecker {
 	}
 
 	public boolean isTrustAlways() {
-		var preferences = getEnngineProfilePreferences();
-		if (preferences != null) {
-			return preferences.getBoolean(TRUST_ALL_AUTHORITIES, false);
+		if (profile != null) {
+			var profileScope = new ProfileScope(agent.getService(IAgentLocation.class), profile.getProfileId());
+			return Platform.getPreferencesService().getBoolean(EngineActivator.ID, TRUST_ALL_AUTHORITIES, false,
+					new IScopeContext[] { profileScope, DefaultScope.INSTANCE });
 		}
 		return false;
 	}

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/CertificateChecker.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/CertificateChecker.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.eclipse.core.runtime.*;
-import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.*;
 import org.eclipse.equinox.internal.p2.artifact.processors.pgp.PGPPublicKeyStore;
 import org.eclipse.equinox.internal.p2.artifact.processors.pgp.PGPSignatureVerifier;
 import org.eclipse.equinox.internal.p2.artifact.repository.simple.SimpleArtifactRepository;
@@ -544,7 +544,8 @@ public class CertificateChecker {
 		if (profile != null) {
 			ProfileScope profileScope = new ProfileScope(agent.getService(IAgentLocation.class),
 					profile.getProfileId());
-			return profileScope.getNode(EngineActivator.ID).getBoolean(TRUST_ALWAYS_PROPERTY, false);
+			return Platform.getPreferencesService().getBoolean(EngineActivator.ID, TRUST_ALWAYS_PROPERTY, false,
+					new IScopeContext[] { profileScope, DefaultScope.INSTANCE });
 		}
 		return false;
 	}

--- a/features/org.eclipse.equinox.p2.core.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.core.feature"
       label="%featureName"
-      version="1.7.1100.qualifier"
+      version="1.7.1200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.extras.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.extras.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.extras.feature"
       label="%featureName"
-      version="1.4.3200.qualifier"
+      version="1.4.3300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.rcp.feature/feature.xml
+++ b/features/org.eclipse.equinox.p2.rcp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.rcp.feature"
       label="%featureName"
-      version="1.4.3200.qualifier"
+      version="1.4.3300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.sdk/feature.xml
+++ b/features/org.eclipse.equinox.p2.sdk/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.sdk"
       label="%featureName"
-      version="3.11.3200.qualifier"
+      version="3.11.3300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.p2.user.ui/feature.xml
+++ b/features/org.eclipse.equinox.p2.user.ui/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.p2.user.ui"
       label="%featureName"
-      version="2.4.3200.qualifier"
+      version="2.4.3300.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/features/org.eclipse.equinox.server.p2/feature.xml
+++ b/features/org.eclipse.equinox.server.p2/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.p2"
       label="%featureName"
-      version="1.12.2100.qualifier"
+      version="1.12.2200.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
p2's "trust always" preferences (`trustAlways` for artifacts, `trustAllAuthorities` for authorities) were read with `IEclipsePreferences.getBoolean()` on a single `ProfileScope` node, which by contract never falls through to other scopes. Values seeded into `DefaultScope` via a product's `plugin_customization.ini` were therefore unreachable, even though `docs/Trust_Settings.md` documents that as the configuration path.

Both `isTrustAlways()` methods now read through `IPreferencesService` with `{ ProfileScope, DefaultScope.INSTANCE }`, so user-set profile values still win and `plugin_customization.ini` defaults are honored as a fallback. Writes still go to ProfileScope and are unchanged.

Mirrors the fix in eclipse-platform/eclipse.platform.ui#1795 for the e4 workbench renderer preferences.