### PR TITLE
Revert "Use CI Friendly versions for the P2 maven build"

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/pom.xml
+++ b/bundles/org.eclipse.equinox.p2.tests/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.eclipse.platform</groupId>
 		<artifactId>rt.equinox.p2</artifactId>
-		<version>${releaseVersion}${qualifier}</version>
+		<version>4.40.0-SNAPSHOT</version>
 		<relativePath>../../</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,15 +22,9 @@
   <groupId>org.eclipse.platform</groupId>
   <artifactId>rt.equinox.p2</artifactId>
   <packaging>pom</packaging>
-  <version>${releaseVersion}${qualifier}</version>
 
   <properties>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-equinox/p2.git</tycho.scmUrl>
-    <!-- Defines the default Qualifier if no format is given-->
-    <!-- can be overriden with -Dtycho.buildqualifier.format=yyyyMMddHHmm for a dynamic qualifier or -Dqualifier=abcd for a static value -->
-    <qualifier>.0-SNAPSHOT</qualifier>
-    <!-- disabled for now, should be enabled later! -->
-    <addMavenDescriptor>false</addMavenDescriptor>
     <failOnJavadocErrors>true</failOnJavadocErrors>
   </properties>
 


### PR DESCRIPTION
This reverts the changes
- https://github.com/eclipse-equinox/p2/pull/109
- https://github.com/eclipse-equinox/p2/pull/686

Together they break the the automated update of versions:
- https://github.com/eclipse-tycho/tycho/pull/5933#discussion_r3325625599

Reverting both unblocks the preparation of the next development cycle.
And now that only almost all p2 projects are pomless and the version update is automated, the benefit of it is small anyway.