### PR TITLE
Disable Back button on the initial uninstall selection page

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ProvisioningOperationWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ProvisioningOperationWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2008, 2018 IBM Corporation and others.
+ *  Copyright (c) 2008, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -117,7 +117,7 @@ public abstract class ProvisioningOperationWizard extends Wizard {
 
 	@Override
 	public IWizardPage getPreviousPage(IWizardPage page) {
-		if (page == errorPage) {
+		if (page == errorPage && page != mainPage) {
 			return mainPage;
 		}
 		return super.getPreviousPage(page);


### PR DESCRIPTION

<img width="1354" height="1008" alt="image" src="https://github.com/user-attachments/assets/223e0d82-0767-4214-9047-7834a489dc35" />

Depending on the provisioning status, the uninstall wizard may start on the selection page ("Check the items that you wish to uninstall."). In this scenario, the selection page is the first page presented to the user, but the Back button remains enabled even though there is no previous page available for navigation. Clicking the button has no effect. This change disables the Back button when the uninstall selection page is displayed as the initial page of the workflow, preventing a non-functional navigation option while preserving existing Back button behavior in workflows where a previous page is available.

Fix: https://github.com/eclipse-equinox/p2/issues/1080