### PR TITLE
Show the IU id column in the Available Software dialog

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUGroup.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUGroup.java
@@ -99,7 +99,8 @@ public class AvailableIUGroup extends StructuredIUGroup {
 		// increase primary column width because we might be nesting names under categories and require more space than a flat list
 		IUColumnConfig nameColumn = new IUColumnConfig(ProvUIMessages.ProvUI_NameColumnTitle, IUColumnConfig.COLUMN_NAME, ILayoutConstants.DEFAULT_PRIMARY_COLUMN_WIDTH + 15);
 		IUColumnConfig versionColumn = new IUColumnConfig(ProvUIMessages.ProvUI_VersionColumnTitle, IUColumnConfig.COLUMN_VERSION, ILayoutConstants.DEFAULT_COLUMN_WIDTH);
-		return new IUColumnConfig[] {nameColumn, versionColumn};
+		IUColumnConfig idColumn = new IUColumnConfig(ProvUIMessages.ProvUI_IdColumnTitle, IUColumnConfig.COLUMN_ID, ILayoutConstants.DEFAULT_PRIMARY_COLUMN_WIDTH);
+		return new IUColumnConfig[] {nameColumn, versionColumn, idColumn};
 	}
 
 	/**

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUsPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUsPage.java
@@ -51,6 +51,7 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 	private static final String FILTER_ON_ENV = "FilterOnEnv"; //$NON-NLS-1$
 	private static final String NAME_COLUMN_WIDTH = "AvailableNameColumnWidth"; //$NON-NLS-1$
 	private static final String VERSION_COLUMN_WIDTH = "AvailableVersionColumnWidth"; //$NON-NLS-1$
+	private static final String ID_COLUMN_WIDTH = "AvailableIdColumnWidth"; //$NON-NLS-1$
 	private static final String LIST_WEIGHT = "AvailableListSashWeight"; //$NON-NLS-1$
 	private static final String DETAILS_WEIGHT = "AvailableDetailsSashWeight"; //$NON-NLS-1$
 	private static final String LINKACTION = "linkAction"; //$NON-NLS-1$
@@ -68,6 +69,7 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 	SashForm sashForm;
 	IUColumnConfig nameColumn;
 	IUColumnConfig versionColumn;
+	IUColumnConfig idColumn;
 	StructuredViewerProvisioningListener profileListener;
 	Display display;
 	int batchCount = 0;
@@ -121,9 +123,10 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 		}
 		nameColumn = new IUColumnConfig(ProvUIMessages.ProvUI_NameColumnTitle, IUColumnConfig.COLUMN_NAME, ILayoutConstants.DEFAULT_PRIMARY_COLUMN_WIDTH + 15);
 		versionColumn = new IUColumnConfig(ProvUIMessages.ProvUI_VersionColumnTitle, IUColumnConfig.COLUMN_VERSION, ILayoutConstants.DEFAULT_COLUMN_WIDTH);
+		idColumn = new IUColumnConfig(ProvUIMessages.ProvUI_IdColumnTitle, IUColumnConfig.COLUMN_ID, ILayoutConstants.DEFAULT_PRIMARY_COLUMN_WIDTH);
 
 		getColumnWidthsFromSettings();
-		availableIUGroup = new AvailableIUGroup(getProvisioningUI(), aboveSash, JFaceResources.getDialogFont(), queryContext, new IUColumnConfig[] {nameColumn, versionColumn}, filterConstant);
+		availableIUGroup = new AvailableIUGroup(getProvisioningUI(), aboveSash, JFaceResources.getDialogFont(), queryContext, new IUColumnConfig[] {nameColumn, versionColumn, idColumn}, filterConstant);
 
 		// Selection listeners must be registered on both the normal selection
 		// events and the check mark events.  Must be done after buttons
@@ -566,6 +569,9 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 				if (section.get(VERSION_COLUMN_WIDTH) != null) {
 					versionColumn.setWidthInPixels(section.getInt(VERSION_COLUMN_WIDTH));
 				}
+				if (section.get(ID_COLUMN_WIDTH) != null) {
+					idColumn.setWidthInPixels(section.getInt(ID_COLUMN_WIDTH));
+				}
 			} catch (NumberFormatException e) {
 				// Ignore if there actually was a value that didn't parse.
 			}
@@ -614,6 +620,8 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 		section.put(NAME_COLUMN_WIDTH, col.getWidth());
 		col = availableIUGroup.getCheckboxTreeViewer().getTree().getColumn(1);
 		section.put(VERSION_COLUMN_WIDTH, col.getWidth());
+		col = availableIUGroup.getCheckboxTreeViewer().getTree().getColumn(2);
+		section.put(ID_COLUMN_WIDTH, col.getWidth());
 
 		int[] weights = sashForm.getWeights();
 		section.put(LIST_WEIGHT, weights[0]);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUDetailsLabelProvider.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUDetailsLabelProvider.java
@@ -86,8 +86,8 @@ public class IUDetailsLabelProvider extends ColumnLabelProvider implements ITabl
 		IInstallableUnit iu = ProvUI.getAdapter(element, IInstallableUnit.class);
 		if (iu == null) {
 			if (columnIndex == 0) {
-				if (element instanceof ProvElement) {
-					return ((ProvElement) element).getLabel(element);
+				if (element instanceof ProvElement provElement) {
+					return provElement.getLabel(element);
 				}
 				return element.toString();
 			}
@@ -96,6 +96,15 @@ public class IUDetailsLabelProvider extends ColumnLabelProvider implements ITabl
 
 		switch (columnContent) {
 			case IUColumnConfig.COLUMN_ID :
+				// If it's an element, determine if the id should be shown.
+				// Categories (groups) reuse the same rule as the version column.
+				if (element instanceof IIUElement iuElement) {
+					if (iuElement.shouldShowVersion()) {
+						return iu.getId();
+					}
+					return BLANK;
+				}
+				// It's a raw IU, return the id
 				return iu.getId();
 			case IUColumnConfig.COLUMN_NAME :
 				// Get the iu name in the current locale


### PR DESCRIPTION
The Available Software install dialog now shows an Id column after Version, so users can see the feature or plug-in id of each entry, not just its display name and version.
The id is hidden for category (group) rows, matching the existing behaviour of the Version column.
The filter field now also matches against the id, and IUs without a display name no longer duplicate their id in the Name column since it has its own column.