### PR TITLE
Skip AutomaticUpdateScheduler if automatic updates are globally disabled

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdateScheduler.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdateScheduler.java
@@ -64,6 +64,10 @@ public class AutomaticUpdateScheduler implements EventHandler {
 
 	@Override
 	public void handleEvent(Event event) {
+		if (!AutomaticUpdatePlugin.getDefault().getPreferenceStore()
+				.getBoolean(PreferenceConstants.PREF_AUTO_UPDATE_ENABLED)) {
+			return; // Do nothing if updates are generally disabled
+		}
 		AutomaticUpdatePlugin.getDefault().setScheduler(this);
 
 		Job updateJob = new Job("Update Job") { //$NON-NLS-1$


### PR DESCRIPTION
Originally requested, but missed in https://github.com/eclipse-equinox/p2/pull/400#issuecomment-2414669175 (quite some time ago).

FYI @iloveeclipse