### PR TITLE
Validate repository URL reachability before saving

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AddRepositoryDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AddRepositoryDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2007, 2019 IBM Corporation and others.
+ *  Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -132,7 +132,7 @@ public abstract class AddRepositoryDialog extends RepositoryNameAndLocationDialo
 	}
 
 	protected IStatus addRepository() {
-		IStatus status = validateRepositoryURL(false);
+		IStatus status = validateRepositoryURL(true);
 		if (status.isOK()) {
 			addedLocation = getUserLocation();
 			String nick = nickname.getText().trim();

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUGroup.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUGroup.java
@@ -99,7 +99,8 @@ public class AvailableIUGroup extends StructuredIUGroup {
 		// increase primary column width because we might be nesting names under categories and require more space than a flat list
 		IUColumnConfig nameColumn = new IUColumnConfig(ProvUIMessages.ProvUI_NameColumnTitle, IUColumnConfig.COLUMN_NAME, ILayoutConstants.DEFAULT_PRIMARY_COLUMN_WIDTH + 15);
 		IUColumnConfig versionColumn = new IUColumnConfig(ProvUIMessages.ProvUI_VersionColumnTitle, IUColumnConfig.COLUMN_VERSION, ILayoutConstants.DEFAULT_COLUMN_WIDTH);
-		return new IUColumnConfig[] {nameColumn, versionColumn};
+		IUColumnConfig idColumn = new IUColumnConfig(ProvUIMessages.ProvUI_IdColumnTitle, IUColumnConfig.COLUMN_ID, ILayoutConstants.DEFAULT_PRIMARY_COLUMN_WIDTH);
+		return new IUColumnConfig[] {nameColumn, versionColumn, idColumn};
 	}
 
 	/**

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUsPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUsPage.java
@@ -51,6 +51,7 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 	private static final String FILTER_ON_ENV = "FilterOnEnv"; //$NON-NLS-1$
 	private static final String NAME_COLUMN_WIDTH = "AvailableNameColumnWidth"; //$NON-NLS-1$
 	private static final String VERSION_COLUMN_WIDTH = "AvailableVersionColumnWidth"; //$NON-NLS-1$
+	private static final String ID_COLUMN_WIDTH = "AvailableIdColumnWidth"; //$NON-NLS-1$
 	private static final String LIST_WEIGHT = "AvailableListSashWeight"; //$NON-NLS-1$
 	private static final String DETAILS_WEIGHT = "AvailableDetailsSashWeight"; //$NON-NLS-1$
 	private static final String LINKACTION = "linkAction"; //$NON-NLS-1$
@@ -68,6 +69,7 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 	SashForm sashForm;
 	IUColumnConfig nameColumn;
 	IUColumnConfig versionColumn;
+	IUColumnConfig idColumn;
 	StructuredViewerProvisioningListener profileListener;
 	Display display;
 	int batchCount = 0;
@@ -121,9 +123,10 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 		}
 		nameColumn = new IUColumnConfig(ProvUIMessages.ProvUI_NameColumnTitle, IUColumnConfig.COLUMN_NAME, ILayoutConstants.DEFAULT_PRIMARY_COLUMN_WIDTH + 15);
 		versionColumn = new IUColumnConfig(ProvUIMessages.ProvUI_VersionColumnTitle, IUColumnConfig.COLUMN_VERSION, ILayoutConstants.DEFAULT_COLUMN_WIDTH);
+		idColumn = new IUColumnConfig(ProvUIMessages.ProvUI_IdColumnTitle, IUColumnConfig.COLUMN_ID, ILayoutConstants.DEFAULT_PRIMARY_COLUMN_WIDTH);
 
 		getColumnWidthsFromSettings();
-		availableIUGroup = new AvailableIUGroup(getProvisioningUI(), aboveSash, JFaceResources.getDialogFont(), queryContext, new IUColumnConfig[] {nameColumn, versionColumn}, filterConstant);
+		availableIUGroup = new AvailableIUGroup(getProvisioningUI(), aboveSash, JFaceResources.getDialogFont(), queryContext, new IUColumnConfig[] {nameColumn, versionColumn, idColumn}, filterConstant);
 
 		// Selection listeners must be registered on both the normal selection
 		// events and the check mark events.  Must be done after buttons
@@ -566,6 +569,9 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 				if (section.get(VERSION_COLUMN_WIDTH) != null) {
 					versionColumn.setWidthInPixels(section.getInt(VERSION_COLUMN_WIDTH));
 				}
+				if (section.get(ID_COLUMN_WIDTH) != null) {
+					idColumn.setWidthInPixels(section.getInt(ID_COLUMN_WIDTH));
+				}
 			} catch (NumberFormatException e) {
 				// Ignore if there actually was a value that didn't parse.
 			}
@@ -614,6 +620,8 @@ public class AvailableIUsPage extends ProvisioningWizardPage implements ISelecta
 		section.put(NAME_COLUMN_WIDTH, col.getWidth());
 		col = availableIUGroup.getCheckboxTreeViewer().getTree().getColumn(1);
 		section.put(VERSION_COLUMN_WIDTH, col.getWidth());
+		col = availableIUGroup.getCheckboxTreeViewer().getTree().getColumn(2);
+		section.put(ID_COLUMN_WIDTH, col.getWidth());
 
 		int[] weights = sashForm.getWeights();
 		section.put(LIST_WEIGHT, weights[0]);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/RepositoryNameAndLocationDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/RepositoryNameAndLocationDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2018 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,7 +18,9 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.equinox.internal.p2.ui.ProvUIActivator;
 import org.eclipse.equinox.internal.p2.ui.ProvUIMessages;
+import org.eclipse.equinox.p2.core.ProvisionException;
 import org.eclipse.equinox.p2.operations.RepositoryTracker;
+import org.eclipse.equinox.p2.repository.metadata.IMetadataRepositoryManager;
 import org.eclipse.equinox.p2.ui.ProvisioningUI;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
@@ -153,7 +155,15 @@ public class RepositoryNameAndLocationDialog extends StatusDialog {
 				// the location is reverted to the original one that has not been saved
 				status[0] = Status.OK_STATUS;
 			} else {
-				BusyIndicator.showWhile(getShell().getDisplay(), () -> status[0] = getRepositoryTracker().validateRepositoryLocation(ui.getSession(), userLocation, contactRepositories, null));
+				BusyIndicator.showWhile(getShell().getDisplay(), () -> {
+					status[0] = getRepositoryTracker().validateRepositoryLocation(ui.getSession(), userLocation, false,
+							null);
+					// If contactRepositories is true, actually try to load the repository to verify
+					// it's reachable
+					if (contactRepositories && status[0].isOK()) {
+						status[0] = validateRepositoryReachability(userLocation);
+					}
+				});
 			}
 		}
 		// At this point the subclasses may have decided to opt out of
@@ -166,6 +176,25 @@ public class RepositoryNameAndLocationDialog extends StatusDialog {
 		updateStatus(status[0]);
 		return status[0];
 
+	}
+
+	/**
+	 * Validate that the repository at the given location is reachable by attempting
+	 * to load it.
+	 *
+	 * @param uri the repository location to validate
+	 * @return a status indicating whether the repository is reachable
+	 */
+	protected IStatus validateRepositoryReachability(URI uri) {
+		try {
+			IMetadataRepositoryManager manager = org.eclipse.equinox.internal.p2.ui.ProvUI
+					.getMetadataRepositoryManager(ui.getSession());
+			manager.loadRepository(uri, null);
+			return Status.OK_STATUS;
+		} catch (ProvisionException e) {
+			return new Status(IStatus.ERROR, ProvUIActivator.PLUGIN_ID,
+					RepositoryTracker.STATUS_INVALID_REPOSITORY_LOCATION, e.getMessage(), e);
+		}
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUDetailsLabelProvider.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUDetailsLabelProvider.java
@@ -96,6 +96,15 @@ public class IUDetailsLabelProvider extends ColumnLabelProvider implements ITabl
 
 		switch (columnContent) {
 			case IUColumnConfig.COLUMN_ID :
+				// If it's an element, determine if the id should be shown.
+				// Categories (groups) reuse the same rule as the version column.
+				if (element instanceof IIUElement) {
+					if (((IIUElement) element).shouldShowVersion()) {
+						return iu.getId();
+					}
+					return BLANK;
+				}
+				// It's a raw IU, return the id
 				return iu.getId();
 			case IUColumnConfig.COLUMN_NAME :
 				// Get the iu name in the current locale


### PR DESCRIPTION

<img width="591" height="196" alt="image" src="https://github.com/user-attachments/assets/02c5fc56-f18b-4900-ba3a-503846ab2afc" />

Repository URLs are now validated for reachability before being added or updated, preventing unreachable URLs from being saved to the system.

Fix: https://github.com/eclipse-equinox/p2/issues/1081

💀💀💀 Do not merge. Testing in progress 💀💀💀