### PR TITLE
Remove Available Version column from uninstall dialog

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ResolutionResultsWizardPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ResolutionResultsWizardPage.java
@@ -17,8 +17,7 @@
 package org.eclipse.equinox.internal.p2.ui.dialogs;
 
 import java.util.Collection;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.*;
 import org.eclipse.equinox.internal.p2.ui.*;
 import org.eclipse.equinox.internal.p2.ui.model.*;
 import org.eclipse.equinox.internal.p2.ui.viewers.*;
@@ -127,7 +126,7 @@ public abstract class ResolutionResultsWizardPage extends ResolutionStatusPage {
 		});
 		final int DEFAULT_COLUMN_WIDTH = 200;
 		// check the operation is for update or installation
-		boolean isUpdate = (resolvedOperation instanceof UpdateOperation);
+		boolean isUpdate = shouldShowAvailableVersionColumn() && resolvedOperation instanceof UpdateOperation;
 		if (isUpdate) {
 			TreeViewerColumn versionColumnOld = new TreeViewerColumn(treeViewer, SWT.LEFT);
 			versionColumnOld.getColumn().setText(ProvUIMessages.ProvUI_VersionColumnTitle_Old);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ResolutionStatusPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ResolutionStatusPage.java
@@ -22,6 +22,7 @@ import org.eclipse.equinox.internal.p2.ui.model.*;
 import org.eclipse.equinox.internal.p2.ui.viewers.IUColumnConfig;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.operations.ProfileChangeOperation;
+import org.eclipse.equinox.p2.operations.UninstallOperation;
 import org.eclipse.equinox.p2.ui.ProvisioningUI;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.IMessageProvider;
@@ -318,14 +319,18 @@ public abstract class ResolutionStatusPage extends ProvisioningWizardPage {
 		// resolution errors are reported by ID.
 		nameColumn = new IUColumnConfig(ProvUIMessages.ProvUI_NameColumnTitle, IUColumnConfig.COLUMN_NAME,
 				ILayoutConstants.DEFAULT_PRIMARY_COLUMN_WIDTH);
-		versionColumnOld = new IUColumnConfig(ProvUIMessages.ProvUI_VersionColumnTitle_Old,
-				IUColumnConfig.OLD_COLUMN_VERSION, ILayoutConstants.DEFAULT_SMALL_COLUMN_WIDTH);
+		if (shouldShowAvailableVersionColumn()) {
+			versionColumnOld = new IUColumnConfig(ProvUIMessages.ProvUI_VersionColumnTitle_Old,
+					IUColumnConfig.OLD_COLUMN_VERSION, ILayoutConstants.DEFAULT_SMALL_COLUMN_WIDTH);
+		}
 		versionColumn = new IUColumnConfig(ProvUIMessages.ProvUI_VersionColumnTitle_New, IUColumnConfig.COLUMN_VERSION,
 				ILayoutConstants.DEFAULT_SMALL_COLUMN_WIDTH);
 		idColumn = new IUColumnConfig(ProvUIMessages.ProvUI_IdColumnTitle, IUColumnConfig.COLUMN_ID,
 				ILayoutConstants.DEFAULT_COLUMN_WIDTH);
 		getColumnWidthsFromSettings();
-		return new IUColumnConfig[] { nameColumn, versionColumnOld, versionColumn, idColumn };
+		return shouldShowAvailableVersionColumn()
+				? new IUColumnConfig[] { nameColumn, versionColumnOld, versionColumn, idColumn }
+				: new IUColumnConfig[] { nameColumn, versionColumn, idColumn };
 	}
 
 	private boolean isLocked(AvailableIUElement elementToBeUpdated) {
@@ -333,5 +338,13 @@ public abstract class ResolutionStatusPage extends ProvisioningWizardPage {
 			return updateElement.isLockedForUpdate();
 		}
 		return false;
+	}
+
+	protected boolean shouldShowAvailableVersionColumn() {
+		ProvisioningOperationWizard profWizard = getProvisioningWizard();
+		Integer severity = profWizard.getCurrentStatus().getSeverity();
+		// If the original request has been modified, then the ProvisioningOperation
+		// severity Status will be IStatus.ERROR
+		return !(profWizard.operation instanceof UninstallOperation || severity.equals(IStatus.ERROR));
 	}
 }


### PR DESCRIPTION
<img width="879" height="512" alt="image" src="https://github.com/user-attachments/assets/d15e8285-7f02-42f2-8d64-3bbe8055e1f8" />

<img width="1268" height="755" alt="image" src="https://github.com/user-attachments/assets/af081698-a43f-41c8-93d3-1908e44c5537" />

The uninstall dialog currently shows an "Available Version" column, which is not meaningful during uninstallation. This change removes that column and displays the plugin version under "Installed Version" instead.
The same behavior has been applied to the update page when the original request is modified.

Fix: https://github.com/eclipse-equinox/p2/issues/1083