### PR TITLE
Fix duplicate error dialog when an unreachable update site is added

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/MetadataRepositoryElement.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/MetadataRepositoryElement.java
@@ -139,7 +139,10 @@ public class MetadataRepositoryElement extends RootElement implements IRepositor
 
 	private IMetadataRepository getMetadataRepository(IProgressMonitor monitor) throws ProvisionException {
 		if (queryable == null) {
-			queryable = getProvisioningUI().loadMetadataRepository(location, false, monitor);
+			// Use manager directly so ProvisionException propagates to fetchChildren's catch,
+			// preventing a second load via getQueryable() and a duplicate error dialog.
+			queryable = ProvUI.getMetadataRepositoryManager(getProvisioningUI().getSession()).loadRepository(location,
+					monitor);
 		}
 		return (IMetadataRepository) queryable;
 


### PR DESCRIPTION
When an unreachable update site URL was added, the error dialog appeared twice because the repository was being loaded twice via two different code paths in MetadataRepositoryElement. Fixed by loading through the metadata repository manager directly so the ProvisionException propagates to the single correct catch block in fetchChildren().


https://github.com/user-attachments/assets/13b6ca4f-9f8d-4ec0-a317-ba140e41833f



Fix: https://github.com/eclipse-equinox/p2/issues/1093