### PR TITLE
Trigger auto-update after importing sites from bookmark file

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RepositoryManipulationPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RepositoryManipulationPage.java
@@ -706,6 +706,7 @@ public class RepositoryManipulationPage extends PreferencePage implements IWorkb
 			MetadataRepositoryElement[] imported = UpdateManagerCompatibility.importSites(getShell());
 			if (imported.length > 0) {
 				changed = true;
+				repoAddedOrEdited = true;
 				for (MetadataRepositoryElement element : imported) {
 					getInput().put(element);
 				}


### PR DESCRIPTION
Importing update sites via a bookmarks.xml file did not trigger the auto-update check after clicking Apply and Close, unlike the Add and Edit actions. Set repoAddedOrEdited = true in importRepositories() to fix this inconsistency.



OLD Implementation
-----------------------

https://github.com/user-attachments/assets/4892d8be-085b-4a61-968e-8a4d8a410bfa 


New implementation
--------------------

https://github.com/user-attachments/assets/5506ac4d-8deb-459d-9304-948f8906e183




Parent issue: https://github.com/eclipse-equinox/p2/issues/1062
NB: This was missed in #1066 
