### PR TITLE
Improve Bug351944 test stability

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/Bug351944.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/Bug351944.java
@@ -81,18 +81,19 @@ public class Bug351944 extends AbstractProvisioningTest {
 
 			long start = System.currentTimeMillis();
 			Collection<IArtifactRequest> toBeRequests = getRequestsForRepository(repo,
-					requests.toArray(new IArtifactRequest[requests.size()]));
+					requests.toArray(IArtifactRequest[]::new));
 			long end = System.currentTimeMillis();
 			long queryArtifactOneByOne = end - start;
 
 			start = System.currentTimeMillis();
 			Collection<IArtifactRequest> toBeRequests2 = getRequestsForRepository2(repo,
-					requests.toArray(new IArtifactRequest[requests.size()]));
+					requests.toArray(IArtifactRequest[]::new));
 			end = System.currentTimeMillis();
 			long queryAllArtifacts = end - start;
 
 			assertEquals("Test case has problem, not find same requests.", toBeRequests.size(), toBeRequests2.size());
-			assertEquals("Querying artifact key from simple repository has performance issue.", queryAllArtifacts, queryArtifactOneByOne, 10);
+			assertEquals("Querying artifact key from simple repository has performance issue.", queryAllArtifacts,
+					queryArtifactOneByOne, 20);
 		}
 	}
 


### PR DESCRIPTION
This test failed again today  (see
https://download.eclipse.org/eclipse/downloads/drops4/I20260709-2300/testresults/html/org.eclipse.equinox.p2.tests_ep441I-unit-linux-x86_64-java21_linux.gtk.x86_64_21.html ). Increase the acceptable delta to count for CI jitter.