### PR TITLE
Honour eclipse.p2.checksums.disable as documented

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.artifact.repository;singleton:=true
-Bundle-Version: 1.5.900.qualifier
+Bundle-Version: 1.5.1000.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.artifact.repository.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactRepository.java
@@ -815,7 +815,7 @@ public class SimpleArtifactRepository extends AbstractArtifactRepository impleme
 	 * @see IArtifactDescriptor#ARTIFACT_CHECKSUM
 	 */
 	public static boolean isChecksumsEnabled(IProvisioningAgent agent) {
-		return !FALSE.equals(getAgentPropertyWithFallback(agent, PROPERTY_ECLIPSE_P2_CHECKSUMS_DISABLE));
+		return !Boolean.parseBoolean(getAgentPropertyWithFallback(agent, PROPERTY_ECLIPSE_P2_CHECKSUMS_DISABLE));
 	}
 
 	/**


### PR DESCRIPTION
Fixes #561.

`isChecksumsEnabled()` reads the negatively-named `eclipse.p2.checksums.disable`
property with the `!FALSE.equals(...)` idiom, which is only correct for
positively-named properties. As a result `=true` (the documented way to disable
checksum verification) was a no-op, and `=false` was the only value that
disabled it.

Parse the property as a boolean instead: verification stays on by default and
is disabled only when the flag is `true`. `Boolean.parseBoolean` also makes the
check null-safe and case-insensitive.
