### PR TITLE
Fix #990: Grouping Items in Install dialog gives different results than without grouping

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/query/QueryProviderTests.java
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/query/QueryProviderTests.java
@@ -16,8 +16,8 @@ package org.eclipse.equinox.p2.tests.ui.query;
 import java.util.ArrayList;
 import java.util.HashMap;
 import org.eclipse.equinox.internal.p2.ui.model.*;
-import org.eclipse.equinox.p2.metadata.IInstallableUnit;
-import org.eclipse.equinox.p2.metadata.Version;
+import org.eclipse.equinox.internal.p2.ui.query.IUViewQueryContext;
+import org.eclipse.equinox.p2.metadata.*;
 import org.eclipse.equinox.p2.operations.InstallOperation;
 import org.eclipse.equinox.p2.query.IQueryable;
 import org.eclipse.equinox.p2.repository.metadata.IMetadataRepository;
@@ -25,12 +25,15 @@ import org.eclipse.equinox.p2.tests.ui.AbstractProvisioningUITest;
 
 public class QueryProviderTests extends AbstractProvisioningUITest {
 	IInstallableUnit nestedCategory;
-	IInstallableUnit a, b, c;
+	IInstallableUnit a, b, c, nonGroup;
 	static final String CAT = "Category";
 	static final String NESTED = "NestedCategory";
 	static final String A = "A";
 	static final String B = "B";
 	static final String C = "C";
+	static final String D = "D";
+	static final String E = "E";
+	static final String NON_GROUP = "NonGroup"; // non-group, non-category, direct member of NESTED
 	IMetadataRepository testRepo;
 
 	@Override
@@ -42,14 +45,17 @@ public class QueryProviderTests extends AbstractProvisioningUITest {
 		groupProperties.put("org.eclipse.equinox.p2.type.group", "true");
 		IInstallableUnit cat = createIU(CAT, Version.create("1.0.0"),
 				createRequiredCapabilities(IInstallableUnit.NAMESPACE_IU_ID, NESTED), categoryProperties, true);
-		nestedCategory = createIU(NESTED, Version.create("1.0.0"),
-				createRequiredCapabilities(IInstallableUnit.NAMESPACE_IU_ID, A), categoryProperties, true);
+		IRequirement[] nestedReqs = new IRequirement[] {
+				MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, A, VersionRange.emptyRange, null, false, false),
+				MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, NON_GROUP, VersionRange.emptyRange, null, false, false) };
+		nestedCategory = createIU(NESTED, Version.create("1.0.0"), nestedReqs, categoryProperties, true);
 		a = createIU(A, Version.create("1.0.0"), createRequiredCapabilities(IInstallableUnit.NAMESPACE_IU_ID, B),
 				groupProperties, true);
 		b = createIU(B, Version.create("1.0.0"), createRequiredCapabilities(IInstallableUnit.NAMESPACE_IU_ID, C),
 				groupProperties, true);
 		c = createIU(C, Version.create("1.0.0"), NO_REQUIRES, NO_PROPERTIES, true);
-		testRepo = createTestMetdataRepository(cat, nestedCategory, a, b, c);
+		nonGroup = createIU(NON_GROUP, Version.create("1.0.0"), NO_REQUIRES, NO_PROPERTIES, true);
+		testRepo = createTestMetdataRepository(cat, nestedCategory, a, b, c, nonGroup);
 	}
 
 	public void testNestedCategories() {
@@ -85,6 +91,67 @@ public class QueryProviderTests extends AbstractProvisioningUITest {
 		element.setQueryable(queryable);
 		Object[] children = element.getChildren(element);
 		assertEquals("1.1", 1, children.length);
+	}
+
+	public void testFlatViewShowsCategoryMembers() {
+		getPolicy().setGroupByCategory(false);
+		MetadataRepositoryElement element = new MetadataRepositoryElement(null, testRepo.getLocation(), true);
+		IUViewQueryContext ctx = new IUViewQueryContext(IUViewQueryContext.AVAILABLE_VIEW_FLAT);
+		ctx.setUseCategories(false);
+		element.setQueryContext(ctx);
+
+		Object[] children = element.getChildren(element);
+
+		java.util.Set<String> ids = new java.util.HashSet<>();
+		for (Object child : children) {
+			IInstallableUnit iu = org.eclipse.equinox.internal.p2.ui.ProvUI.getAdapter(child, IInstallableUnit.class);
+			if (iu != null) {
+				ids.add(iu.getId());
+			}
+		}
+
+		assertTrue(ids.contains(A));        // group, direct member of NESTED — must appear
+		assertTrue(ids.contains(B));        // group — must appear
+		assertTrue(ids.contains(NON_GROUP)); // non-group, direct member of NESTED — must appear
+		assertFalse(ids.contains(CAT));     // top-level category itself — must not appear
+		assertFalse(ids.contains(NESTED));  // nested category itself — must not appear
+		assertFalse(ids.contains(C));       // not a group, not a direct category member — must not appear
+	}
+
+	public void testFlatViewShowsMembersFromAllCategoryVersions() {
+		getPolicy().setGroupByCategory(false);
+
+		HashMap<String, String> categoryProperties = new HashMap<>();
+		categoryProperties.put("org.eclipse.equinox.p2.type.category", "true");
+
+		// Two versions of the SAME category id, each requiring a different, otherwise
+		// unreachable member. A fix that keys categories by id alone will drop one
+		// version's requirements when the other overwrites it in the map.
+		IInstallableUnit catV1 = createIU(CAT, Version.create("1.0.0"),
+				createRequiredCapabilities(IInstallableUnit.NAMESPACE_IU_ID, D), categoryProperties, true);
+		IInstallableUnit catV2 = createIU(CAT, Version.create("2.0.0"),
+				createRequiredCapabilities(IInstallableUnit.NAMESPACE_IU_ID, E), categoryProperties, true);
+		IInstallableUnit d = createIU(D, Version.create("1.0.0"), NO_REQUIRES, NO_PROPERTIES, true);
+		IInstallableUnit e = createIU(E, Version.create("1.0.0"), NO_REQUIRES, NO_PROPERTIES, true);
+
+		IMetadataRepository multiVersionRepo = createTestMetdataRepository(catV1, catV2, d, e);
+		MetadataRepositoryElement element = new MetadataRepositoryElement(null, multiVersionRepo.getLocation(), true);
+		IUViewQueryContext ctx = new IUViewQueryContext(IUViewQueryContext.AVAILABLE_VIEW_FLAT);
+		ctx.setUseCategories(false);
+		element.setQueryContext(ctx);
+
+		Object[] children = element.getChildren(element);
+
+		java.util.Set<String> ids = new java.util.HashSet<>();
+		for (Object child : children) {
+			IInstallableUnit iu = org.eclipse.equinox.internal.p2.ui.ProvUI.getAdapter(child, IInstallableUnit.class);
+			if (iu != null) {
+				ids.add(iu.getId());
+			}
+		}
+
+		assertTrue("member reachable only via category v1.0.0 is missing", ids.contains(D));
+		assertTrue("member reachable only via category v2.0.0 is missing", ids.contains(E));
 	}
 
 }

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/QueryProvider.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/QueryProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2010 IBM Corporation and others.
+ * Copyright (c) 2008, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -129,13 +129,18 @@ public class QueryProvider {
 				if (element instanceof MetadataRepositories || element instanceof MetadataRepositoryElement) {
 					if (context.getViewType() == IUViewQueryContext.AVAILABLE_VIEW_FLAT || !context.getUseCategories()) {
 						AvailableIUWrapper wrapper = new AvailableIUWrapper(queryable, element, false, context.getShowAvailableChildren());
-						if (showLatest) {
-							topLevelQuery = QueryUtil.createLatestQuery(topLevelQuery);
-						}
 						if (targetProfile != null) {
 							wrapper.markInstalledIUs(targetProfile, hideInstalled);
 						}
-						return new ElementQueryDescriptor(queryable, topLevelQuery, new Collector<>(), wrapper);
+						// Include category members in flat view to avoid missing items.
+						Collector<IInstallableUnit> collector = new Collector<>();
+						@SuppressWarnings("unchecked")
+						IQueryable<IInstallableUnit> iuQueryable = (IQueryable<IInstallableUnit>) queryable;
+						Collection<IInstallableUnit> allCategoryMembers = collectAllCategoryMembers(iuQueryable);
+						collector.addAll(new CollectionResult<>(allCategoryMembers));
+
+						IQuery<IInstallableUnit> flatQuery = showLatest ? QueryUtil.createLatestQuery(topLevelQuery) : topLevelQuery;
+						return new ElementQueryDescriptor(queryable, flatQuery, collector, wrapper);
 					}
 					// Installed content not a concern for collecting categories
 					return new ElementQueryDescriptor(queryable, categoryQuery, new Collector<>(), new CategoryElementWrapper(queryable, element));
@@ -247,5 +252,33 @@ public class QueryProvider {
 			default :
 				return null;
 		}
+	}
+
+	/**
+	 * Collects all IUs reachable through categories, including nested ones,
+	 * so that flat view shows same content as category view.
+	 */
+	private static Collection<IInstallableUnit> collectAllCategoryMembers(IQueryable<IInstallableUnit> queryable) {
+		Collection<IInstallableUnit> allCategories = queryable.query(QueryUtil.createIUCategoryQuery(), null)
+				.toUnmodifiableSet();
+
+		Set<IInstallableUnit> visitedCategories = new HashSet<>();
+		Set<IInstallableUnit> members = new LinkedHashSet<>(); // set: an IU can belong to more than one category
+		Deque<IInstallableUnit> toProcess = new ArrayDeque<>(allCategories);
+
+		while (!toProcess.isEmpty()) {
+			IInstallableUnit category = toProcess.pop();
+			if (!visitedCategories.add(category)) {
+				continue; // already processed, avoid infinite loops
+			}
+			for (IInstallableUnit member : queryable.query(QueryUtil.createIUCategoryMemberQuery(category), null)) {
+				if (QueryUtil.isCategory(member)) {
+					toProcess.push(member); // nested category — walk its members too
+				} else {
+					members.add(member);
+				}
+			}
+		}
+		return members;
 	}
 }


### PR DESCRIPTION
The flat view (grouping disabled) used createIUGroupQuery() which only matched IUs with type.group=true, while the category view surfaced everything reachable through category requirements, causing the two modes to show different content.

Fixed in QueryProvider by collecting all category requirements recursively and OR-ing them with the group query, so the flat view includes the same installable content as the category view.

Fix: https://github.com/eclipse-equinox/p2/issues/990