### PR TITLE
Requirements could not be serialised as LDAP filter strings, which blocked bridging p2 to the OSGi Repository Service.

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Exists.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Exists.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 Cloudsmith Inc. and others.
+ * Copyright (c) 2009, 2026 Cloudsmith Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -23,6 +23,11 @@ import org.eclipse.equinox.p2.metadata.expression.IEvaluationContext;
 final class Exists extends CollectionFilter {
 	Exists(Expression collection, LambdaExpression lambda) {
 		super(collection, lambda);
+	}
+
+	@Override
+	public void toLDAPString(StringBuilder buf) {
+		lambda.toLDAPString(buf);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/LambdaExpression.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/LambdaExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 Cloudsmith Inc. and others.
+ * Copyright (c) 2009, 2026 Cloudsmith Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -55,6 +55,11 @@ public class LambdaExpression extends Unary {
 	@Override
 	public int getExpressionType() {
 		return TYPE_LAMBDA;
+	}
+
+	@Override
+	public void toLDAPString(StringBuilder buf) {
+		operand.toLDAPString(buf);
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/MatchExpression.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/MatchExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2017 Cloudsmith Inc. and others.
+ * Copyright (c) 2009, 2026 Cloudsmith Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -97,7 +97,76 @@ public class MatchExpression<T> extends Unary implements IMatchExpression<T> {
 
 	@Override
 	public void toLDAPString(StringBuilder bld) {
-		operand.toLDAPString(bld);
+		if (parameters.length == 0) {
+			operand.toLDAPString(bld);
+		} else {
+			substituteParameters(operand).toLDAPString(bld);
+		}
+	}
+
+	/**
+	 * Returns a copy of the expression tree with every {@link Parameter} node
+	 * replaced by a {@link Literal} wrapping its bound value from
+	 * {@link #parameters}. Once substituted, the existing {@code toLDAPString}
+	 * implementations on {@link Equals} and {@link Compare} (which already handle
+	 * {@code Literal} rhs values) can serialise the tree without any further
+	 * changes.
+	 */
+	private Expression substituteParameters(Expression expr) {
+		if (expr instanceof Parameter p) {
+			return Literal.create(parameters[p.position]);
+		}
+		if (expr instanceof NAry nary) {
+			Expression[] ops = nary.operands;
+			Expression[] resolved = new Expression[ops.length];
+			boolean changed = false;
+			for (int i = 0; i < ops.length; i++) {
+				resolved[i] = substituteParameters(ops[i]);
+				if (resolved[i] != ops[i]) {
+					changed = true;
+				}
+			}
+			if (!changed) {
+				return expr;
+			}
+			if (expr instanceof And) {
+				return new And(resolved);
+			}
+			if (expr instanceof Or) {
+				return new Or(resolved);
+			}
+		}
+		if (expr instanceof Binary b) {
+			Expression resolvedLhs = substituteParameters(b.lhs);
+			Expression resolvedRhs = substituteParameters(b.rhs);
+			if (resolvedLhs == b.lhs && resolvedRhs == b.rhs) {
+				return expr;
+			}
+			if (expr instanceof Equals equals) {
+				return new Equals(resolvedLhs, resolvedRhs, equals.negate);
+			}
+			if (expr instanceof Compare compare) {
+				return new Compare(resolvedLhs, resolvedRhs, compare.compareLess, compare.equalOK);
+			}
+		}
+		if (expr instanceof CollectionFilter collectionFilter) {
+			Expression resolvedCollection = substituteParameters(collectionFilter.operand);
+			LambdaExpression resolvedLambda = (LambdaExpression) substituteParameters(collectionFilter.lambda);
+			if (resolvedCollection == collectionFilter.operand && resolvedLambda == collectionFilter.lambda) {
+				return expr;
+			}
+			if (expr instanceof Exists) {
+				return new Exists(resolvedCollection, resolvedLambda);
+			}
+		}
+		if (expr instanceof LambdaExpression lambda) {
+			Expression resolvedBody = substituteParameters(lambda.operand);
+			if (resolvedBody == lambda.operand) {
+				return expr;
+			}
+			return new LambdaExpression(lambda.each, resolvedBody);
+		}
+		return expr;
 	}
 
 	@Override

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/AllTests.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/AllTests.java
@@ -24,7 +24,8 @@ import org.junit.platform.suite.api.Suite;
 @SelectClasses({ ArtifactKeyParsingTest.class, FragmentMethodTest.class, FragmentTest.class,
 		InstallableUnitTest.class, InstallableUnitPatchTest.class, IUPersistenceTest.class, LatestIUTest.class,
 		LicenseTest.class, MultipleIUAndFragmentTest.class, PersistNegation.class, PersistFragment.class,
-		ProvidedCapabilityTest.class, RequirementToString.class, RequirementParsingTest.class })
+		ProvidedCapabilityTest.class, RequirementToString.class, RequirementParsingTest.class,
+		RequirementToLDAPFilterTest.class })
 public class AllTests {
 //test suite
 }

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/RequirementToLDAPFilterTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/RequirementToLDAPFilterTest.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.equinox.p2.tests.metadata;
+
+import static org.junit.Assert.assertThrows;
+
+import org.eclipse.equinox.internal.p2.metadata.RequiredCapability;
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+import org.eclipse.equinox.p2.metadata.VersionRange;
+import org.eclipse.equinox.p2.metadata.expression.ExpressionUtil;
+import org.eclipse.equinox.p2.metadata.expression.IMatchExpression;
+import org.junit.Test;
+
+/**
+ * Tests that {@link IMatchExpression#toLDAPString(StringBuilder)} works for all
+ * predefined {@link RequiredCapability} version-range templates. The expression-layer
+ * overrides on {@code MatchExpression}, {@code Exists}, and {@code LambdaExpression}
+ * are exercised by calling {@code toLDAPString()} directly; output syntax is validated
+ * by passing the result through the LDAP filter parser.
+ */
+public class RequirementToLDAPFilterTest {
+
+	private static final String NS = "org.eclipse.equinox.p2.iu"; //$NON-NLS-1$
+	private static final String NAME = "my.bundle"; //$NON-NLS-1$
+
+	/**
+	 * Calls {@code toLDAPString()} on the match expression for the given range and
+	 * validates that the output is syntactically valid RFC 4515 by parsing it.
+	 */
+	private static void assertValidLDAP(VersionRange range) throws Exception {
+		IMatchExpression<IInstallableUnit> expr =
+				RequiredCapability.createMatchExpressionFromRange(NS, NAME, range);
+		StringBuilder buf = new StringBuilder();
+		expr.toLDAPString(buf); // exercises MatchExpression -> Exists -> LambdaExpression
+		ExpressionUtil.parseLDAP(buf.toString()); // throws InvalidSyntaxException if invalid
+	}
+
+	@Test
+	public void testAll_nullRange() throws Exception {
+		assertValidLDAP(null);
+	}
+
+	@Test
+	public void testAll_emptyRange() throws Exception {
+		assertValidLDAP(VersionRange.emptyRange);
+	}
+
+	@Test
+	public void testStrict() throws Exception {
+		assertValidLDAP(VersionRange.create("[1.0.0,1.0.0]")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testOpenI() throws Exception {
+		assertValidLDAP(VersionRange.create("1.0.0")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testOpenN() throws Exception {
+		assertValidLDAP(VersionRange.create("(1.0.0,)")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testClosedII() throws Exception {
+		assertValidLDAP(VersionRange.create("[1.0.0,2.0.0]")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testClosedIN() throws Exception {
+		assertValidLDAP(VersionRange.create("[1.0.0,2.0.0)")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testClosedNI() throws Exception {
+		assertValidLDAP(VersionRange.create("(1.0.0,2.0.0]")); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testClosedNN() throws Exception {
+		assertValidLDAP(VersionRange.create("(1.0.0,2.0.0)")); //$NON-NLS-1$
+	}
+
+	// toLDAPString throws UnsupportedOperationException (pre-existing contract on
+	// Expression.toLDAPString) when a node has no LDAP equivalent, e.g. ~= (Matches).
+	@Test
+	public void testNonSerializableThrows() {
+		IMatchExpression<IInstallableUnit> custom = ExpressionUtil.getFactory()
+				.matchExpression(ExpressionUtil.parse("id ~= $0"), //$NON-NLS-1$
+						ExpressionUtil.getFactory().matchExpression(ExpressionUtil.parse("'some.id'"))); //$NON-NLS-1$
+		StringBuilder buf = new StringBuilder();
+		assertThrows(UnsupportedOperationException.class, () -> custom.toLDAPString(buf));
+	}
+}


### PR DESCRIPTION
Requirements could not be serialised as LDAP filter strings, which blocked bridging p2 to the OSGi Repository Service. The root cause was that RequiredCapability match expressions store bound values as Parameter placeholder nodes, which the existing Equals/Compare serialisers could not handle.

The fix adds toLDAPString overrides to MatchExpression, Exists, and LambdaExpression. MatchExpression substitutes each Parameter with a Literal before delegating to the existing serialisers; Exists and LambdaExpression simply drop their wrappers.

Fixes: https://github.com/eclipse-equinox/p2/issues/211