### PR TITLE
Fix: DownloadStatus should carry information about its URI

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/DownloadStatus.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/DownloadStatus.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.equinox.internal.p2.repository;
 
+import java.net.URI;
 import org.eclipse.core.runtime.Status;
 
 /**
@@ -26,6 +27,7 @@ public class DownloadStatus extends Status {
 	private long speed = UNKNOWN_RATE;
 	private long fileSize = UNKNOWN_SIZE;
 	private long lastModified = 0;
+	private URI uri;
 
 	/**
 	 * Constructs a new DownloadStatus with the given attributes.
@@ -79,9 +81,30 @@ public class DownloadStatus extends Status {
 		return lastModified;
 	}
 
+	/**
+	 * Sets the URI this download status applies to.
+	 *
+	 * @param uri the URI that was downloaded, or {@code null} if not known
+	 */
+	public void setUri(URI uri) {
+		this.uri = uri;
+	}
+
+	/**
+	 * Returns the URI this download status applies to.
+	 *
+	 * @return the downloaded URI, or {@code null} if not known
+	 */
+	public URI getUri() {
+		return uri;
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder(super.toString());
+		sb.append(' ');
+		sb.append("URI="); //$NON-NLS-1$
+		sb.append(getUri() == null ? "Unknown uri" : getUri()); //$NON-NLS-1$
 		sb.append(' ');
 		sb.append("LastModified="); //$NON-NLS-1$
 		sb.append(getLastModified());

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/repository/AllTests.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/repository/AllTests.java
@@ -21,7 +21,7 @@ import org.junit.platform.suite.api.Suite;
  */
 @Suite
 @SelectClasses({ CacheManagerTest.class, RepositoryHelperTest.class, RepositoryExtensionPointTest.class,
-		FileReaderTest2.class, ChecksumHelperTest.class })
+		FileReaderTest2.class, ChecksumHelperTest.class, DownloadStatusTest.class })
 public class AllTests {
 	// test suite
 }

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/repository/DownloadStatusTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/repository/DownloadStatusTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.p2.tests.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.net.ConnectException;
+import java.net.URI;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.equinox.internal.p2.repository.DownloadStatus;
+import org.eclipse.equinox.internal.p2.transport.ecf.RepositoryStatus;
+import org.eclipse.equinox.internal.p2.transport.ecf.RepositoryTransport;
+import org.junit.Test;
+
+/**
+ * Tests that {@link DownloadStatus} correctly carries URI information, and that
+ * the factory methods in {@link RepositoryTransport} and {@link RepositoryStatus}
+ * attach the URI to every status they produce.
+ */
+public class DownloadStatusTest {
+
+	private static final URI TEST_URI = URI.create("https://example.org/repository/artifact.jar"); //$NON-NLS-1$
+
+	@Test
+	public void testUriIsNullByDefault() {
+		DownloadStatus status = new DownloadStatus(IStatus.OK, "test.plugin", "ok"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNull("URI should be null when not set", status.getUri()); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testSetAndGetUri() {
+		DownloadStatus status = new DownloadStatus(IStatus.OK, "test.plugin", "ok"); //$NON-NLS-1$ //$NON-NLS-2$
+		status.setUri(TEST_URI);
+		assertEquals("URI should round-trip through getter", TEST_URI, status.getUri()); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testSetUriToNull() {
+		DownloadStatus status = new DownloadStatus(IStatus.OK, "test.plugin", "ok"); //$NON-NLS-1$ //$NON-NLS-2$
+		status.setUri(TEST_URI);
+		status.setUri(null);
+		assertNull("URI should be null after being set to null", status.getUri()); //$NON-NLS-1$
+	}
+
+	// toString tests
+	@Test
+	public void testToStringContainsUriWhenSet() {
+		DownloadStatus status = new DownloadStatus(IStatus.OK, "test.plugin", "ok"); //$NON-NLS-1$ //$NON-NLS-2$
+		status.setUri(TEST_URI);
+		assertTrue("toString should contain the URI value", //$NON-NLS-1$
+				status.toString().contains(TEST_URI.toString()));
+	}
+
+	@Test
+	public void testToStringShowsUnknownWhenUriIsNull() {
+		DownloadStatus status = new DownloadStatus(IStatus.OK, "test.plugin", "ok"); //$NON-NLS-1$ //$NON-NLS-2$
+		assertTrue("toString should show 'Unknown' when URI is null", //$NON-NLS-1$
+				status.toString().contains("URI=Unknown uri")); //$NON-NLS-1$
+	}
+
+	// RepositoryTransport factory method tests
+	@Test
+	public void testRepositoryTransportForExceptionSetsUri() {
+		DownloadStatus status = RepositoryTransport.forException(new FileNotFoundException(), TEST_URI);
+		assertEquals("forException should attach the URI to the returned status", //$NON-NLS-1$
+				TEST_URI, status.getUri());
+	}
+
+	@Test
+	public void testRepositoryTransportForExceptionConnectExceptionSetsUri() {
+		DownloadStatus status = RepositoryTransport.forException(new ConnectException(), TEST_URI);
+		assertEquals("forException (ConnectException) should attach the URI to the returned status", //$NON-NLS-1$
+				TEST_URI, status.getUri());
+	}
+
+	@Test
+	public void testRepositoryTransportForStatusSetsUri() {
+		IStatus original = new Status(IStatus.ERROR, "test.plugin", 0, "fail", new ConnectException()); //$NON-NLS-1$ //$NON-NLS-2$
+		DownloadStatus status = RepositoryTransport.forStatus(original, TEST_URI);
+		assertEquals("forStatus should attach the URI to the returned status", //$NON-NLS-1$
+				TEST_URI, status.getUri());
+	}
+
+	// RepositoryStatus factory method tests
+	@Test
+	public void testRepositoryStatusForExceptionSetsUri() {
+		DownloadStatus status = RepositoryStatus.forException(new FileNotFoundException(), TEST_URI);
+		assertEquals("RepositoryStatus.forException should attach the URI to the returned status", //$NON-NLS-1$
+				TEST_URI, status.getUri());
+	}
+
+	@Test
+	public void testRepositoryStatusForStatusSetsUri() {
+		IStatus original = new Status(IStatus.ERROR, "test.plugin", 0, "fail", new ConnectException()); //$NON-NLS-1$ //$NON-NLS-2$
+		DownloadStatus status = RepositoryStatus.forStatus(original, TEST_URI);
+		assertEquals("RepositoryStatus.forStatus should attach the URI to the returned status", //$NON-NLS-1$
+				TEST_URI, status.getUri());
+	}
+}

--- a/bundles/org.eclipse.equinox.p2.transport.ecf/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.transport.ecf
-Bundle-Version: 1.4.700.qualifier
+Bundle-Version: 1.4.800.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.ecf;bundle-version="3.1.0",
  org.eclipse.ecf.filetransfer;bundle-version="4.0.0",

--- a/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryStatus.java
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2010 Cloudsmith Inc. and others.
+ * Copyright (c) 2009, 2026 Cloudsmith Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -112,11 +112,23 @@ public class RepositoryStatus {
 	}
 
 	public static DownloadStatus forStatus(IStatus original, URI toDownload) {
+		DownloadStatus status = forStatus0(original, toDownload);
+		status.setUri(toDownload);
+		return status;
+	}
+
+	private static DownloadStatus forStatus0(IStatus original, URI toDownload) {
 		Throwable t = original.getException();
-		return forException(t, toDownload);
+		return forException0(t, toDownload);
 	}
 
 	public static DownloadStatus forException(Throwable t, URI toDownload) {
+		DownloadStatus status = forException0(t, toDownload);
+		status.setUri(toDownload);
+		return status;
+	}
+
+	private static DownloadStatus forException0(Throwable t, URI toDownload) {
 		if (t instanceof FileNotFoundException || (t instanceof IncomingFileTransferException && ((IncomingFileTransferException) t).getErrorCode() == 404)) {
 			return new DownloadStatus(IStatus.ERROR, Activator.ID, ProvisionException.ARTIFACT_NOT_FOUND, NLS.bind(Messages.artifact_not_found, toDownload), t);
 		}

--- a/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryTransport.java
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryTransport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2022 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  * The code, documentation and other materials contained herein have been
  * licensed under the Eclipse Public License - v 1.0 by the copyright holder
  * listed above, as the Initial Contributor under such license. The text of
@@ -147,6 +147,7 @@ public class RepositoryTransport extends Transport {
 					String msg = NLS.bind(Messages.RepositoryTransport_failedReadRepo, secureToDownload);
 					DownloadStatus ds = new DownloadStatus(IStatus.ERROR, Activator.ID,
 							ProvisionException.REPOSITORY_FAILED_READ, msg, null);
+					ds.setUri(secureToDownload);
 					return statusOn(target, ds, reader);
 				}
 				if (result.getSeverity() == IStatus.CANCEL) {
@@ -158,12 +159,17 @@ public class RepositoryTransport extends Transport {
 
 				// Download status is expected on success
 				DownloadStatus status = new DownloadStatus(IStatus.OK, Activator.ID, Status.OK_STATUS.getMessage());
+				status.setUri(secureToDownload);
 				return statusOn(target, status, reader);
 			} catch (UserCancelledException e) {
-				statusOn(target, new DownloadStatus(IStatus.CANCEL, Activator.ID, 1, "", null), reader); //$NON-NLS-1$
+				DownloadStatus cancelStatus = new DownloadStatus(IStatus.CANCEL, Activator.ID, 1, "", null); //$NON-NLS-1$
+				cancelStatus.setUri(secureToDownload);
+				statusOn(target, cancelStatus, reader);
 				throw new OperationCanceledException();
 			} catch (OperationCanceledException e) {
-				statusOn(target, new DownloadStatus(IStatus.CANCEL, Activator.ID, 1, "", null), reader); //$NON-NLS-1$
+				DownloadStatus cancelStatus = new DownloadStatus(IStatus.CANCEL, Activator.ID, 1, "", null); //$NON-NLS-1$
+				cancelStatus.setUri(secureToDownload);
+				statusOn(target, cancelStatus, reader);
 				throw e;
 			} catch (CoreException e) {
 				if (e.getStatus().getException() == null) {
@@ -178,6 +184,7 @@ public class RepositoryTransport extends Transport {
 				DownloadStatus status = new DownloadStatus(IStatus.ERROR, Activator.ID,
 						ProvisionException.REPOSITORY_FAILED_AUTHENTICATION, //
 						NLS.bind(Messages.UnableToRead_0_UserCanceled, secureToDownload), null);
+				status.setUri(secureToDownload);
 				return statusOn(target, status, null);
 			} catch (JREHttpClientRequiredException e) {
 				if (!useJREHttp) {
@@ -191,6 +198,7 @@ public class RepositoryTransport extends Transport {
 		DownloadStatus status = new DownloadStatus(IStatus.ERROR, Activator.ID,
 				ProvisionException.REPOSITORY_FAILED_AUTHENTICATION, //
 				NLS.bind(Messages.UnableToRead_0_TooManyAttempts, secureToDownload), null);
+		status.setUri(secureToDownload);
 		return statusOn(target, status, null);
 	}
 
@@ -319,15 +327,27 @@ public class RepositoryTransport extends Transport {
 	}
 
 	public static DownloadStatus forStatus(IStatus original, URI toDownload) {
+		DownloadStatus status = forStatus0(original, toDownload);
+		status.setUri(toDownload);
+		return status;
+	}
+
+	private static DownloadStatus forStatus0(IStatus original, URI toDownload) {
 		Throwable t = original.getException();
 		if (isForgiveableException(t) && original.getCode() == IArtifactRepository.CODE_RETRY) {
 			return new DownloadStatus(original.getSeverity(), Activator.ID, original.getCode(), original.getMessage(),
-					t);
+				t);
 		}
-		return forException(t, toDownload);
+		return forException0(t, toDownload);
 	}
 
 	public static DownloadStatus forException(Throwable t, URI toDownload) {
+		DownloadStatus status = forException0(t, toDownload);
+		status.setUri(toDownload);
+		return status;
+	}
+
+	private static DownloadStatus forException0(Throwable t, URI toDownload) {
 		if (isForgiveableException(t)) {
 			int retry = Integer.getInteger(TIMEOUT_RETRY, 0);
 			if (retry > 0) {


### PR DESCRIPTION
DownloadStatus already tracked file size, last-modified timestamp, and transfer rate, but had no field to identify which URL the status was recorded for, making it impossible for callers to correlate a status object back to the download that produced it. A uri field is added with `getUri()` / `setUri(URI)` accessors and included in `toString()`, following the same mutable-setter pattern as the existing fields to avoid any constructor API break. In `RepositoryTransport`, the URI was already flowing through as a parameter at every `DownloadStatus` construction site but was never attached to the resulting object; this fix wires it in across all exit paths — success, cancellation, authentication failure, and retry exhaustion — via thin public wrappers around internal helpers, with the same pattern applied symmetrically to RepositoryStatus. Nine unit tests are added in `DownloadStatusTest` covering the new field, the `toString()` null fallback, and all four factory methods across both classes.

Fix: https://github.com/eclipse-equinox/p2/issues/178