### PR TITLE
Fix #862: Once-a-month auto-update schedule fails with IllegalArgumentException due to int overflow

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/META-INF/MANIFEST.MF
@@ -20,6 +20,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
  org.eclipse.equinox.p2.ui.importexport;bundle-version="1.0.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: org.eclipse.equinox.internal.p2.operations,
+ org.eclipse.equinox.internal.p2.ui.sdk.scheduler,
  org.eclipse.equinox.p2.operations;version="[2.0.0,3.0.0)",
  org.mockito,
  org.mockito.stubbing

--- a/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/misc/AllTests.java
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/misc/AllTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2008, 2018 IBM Corporation and others.
+ *  Copyright (c) 2008, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,7 @@ import org.junit.runners.Suite;
  * Performs all UI action tests.
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ LicenseManagerTest.class })
+@Suite.SuiteClasses({ LicenseManagerTest.class, AutomaticUpdateSchedulerTest.class })
 public class AllTests {
 // test suite
 }

--- a/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/misc/AutomaticUpdateSchedulerTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/misc/AutomaticUpdateSchedulerTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - regression test for bug #862 (int overflow in computeFuzzyPoll)
+ *******************************************************************************/
+package org.eclipse.equinox.p2.tests.ui.misc;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Method;
+import org.eclipse.equinox.internal.p2.ui.sdk.scheduler.AutomaticUpdateMessages;
+import org.eclipse.equinox.internal.p2.ui.sdk.scheduler.AutomaticUpdateScheduler;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceStore;
+import org.junit.Test;
+
+public class AutomaticUpdateSchedulerTest {
+
+	private static final String P_FUZZY_RECURRENCE = AutomaticUpdateScheduler.P_FUZZY_RECURRENCE;
+
+	// 30 * 86,400,000 = 2,592,000,000 > Integer.MAX_VALUE (2,147,483,647).
+	@Test
+	public void testComputeFuzzyPollOnceAMonthDoesNotOverflow() throws Exception {
+		long result = invokeComputeFuzzyPoll(AutomaticUpdateMessages.SchedulerStartup_OnceAMonth);
+		assertEquals("Once-a-month poll period must equal 30 days in ms, was negative before fix (bug #862)",
+				30L * 24 * 60 * 60 * 1000, result);
+	}
+
+	private static long invokeComputeFuzzyPoll(String recurrence) throws Exception {
+		Method m = AutomaticUpdateScheduler.class.getDeclaredMethod("computeFuzzyPoll", IPreferenceStore.class);
+		m.setAccessible(true);
+		PreferenceStore store = new PreferenceStore();
+		store.setValue(P_FUZZY_RECURRENCE, recurrence);
+		return (long) m.invoke(null, store);
+	}
+}

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdateScheduler.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdateScheduler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2017 IBM Corporation and others.
+ * Copyright (c) 2008, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -56,8 +56,8 @@ public class AutomaticUpdateScheduler implements EventHandler {
 	public static final String[] FUZZY_RECURRENCE = { AutomaticUpdateMessages.SchedulerStartup_OnceADay,
 			AutomaticUpdateMessages.SchedulerStartup_OnceAWeek, AutomaticUpdateMessages.SchedulerStartup_OnceAMonth };
 
-	private static final int ONE_HOUR_IN_MS = 60 * 60 * 1000;
-	private static final int ONE_DAY_IN_MS = 24 * ONE_HOUR_IN_MS;
+	private static final long ONE_HOUR_IN_MS = 60 * 60 * 1000;
+	private static final long ONE_DAY_IN_MS = 24 * ONE_HOUR_IN_MS;
 
 	private IUpdateListener listener;
 	private IUpdateChecker checker;
@@ -213,12 +213,12 @@ public class AutomaticUpdateScheduler implements EventHandler {
 		if (now - lastCheckForUpdateSinceEpoch >= poll + getMaxDelay(pref)) {
 			// Last check for update has exceeded the max delay we allow,
 			// let's do it sometime in the next hour.
-			return new Random().nextInt(ONE_HOUR_IN_MS);
+			return new Random().nextLong(ONE_HOUR_IN_MS);
 		}
 		long delay = now - lastCheckForUpdateSinceEpoch;
 		// We do delay the next check sometime in the 8 hours after the computed
 		// schedule
-		return poll - delay + new Random().nextInt(8 * ONE_HOUR_IN_MS);
+		return poll - delay + new Random().nextLong(8 * ONE_HOUR_IN_MS);
 	}
 
 	private static long getMaxDelay(IPreferenceStore pref) {


### PR DESCRIPTION
Changed `ONE_HOUR_IN_MS` and `ONE_DAY_IN_MS` from `int` to `long` so all time  arithmetic in `computeFuzzyPoll()` and `getMaxDelay()` operates in `long`,  eliminating the overflow for any multiplier. Updated the two `Random.nextInt()`  call sites to `Random.nextLong()` accordingly.


fix: https://github.com/eclipse-equinox/p2/issues/862