### PR TITLE
Make IU list columns sortable in p2 provisioning UI

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUGroup.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/AvailableIUGroup.java
@@ -172,7 +172,7 @@ public class AvailableIUGroup extends StructuredIUGroup {
 		availableIUViewer.setContentProvider(contentProvider);
 
 		// Now the presentation, columns before label provider.
-		setTreeColumns(availableIUViewer.getTree());
+		createSortableTreeColumns(availableIUViewer.getTree(), availableIUViewer, comparator);
 		availableIUViewer.setLabelProvider(labelProvider);
 
 		// Notify the filtered tree so that it can hook listeners on the
@@ -205,18 +205,6 @@ public class AvailableIUGroup extends StructuredIUGroup {
 		availableIUViewer.getControl().addDisposeListener(e -> ProvUI.getProvisioningEventBus(getProvisioningUI().getSession()).removeListener(listener));
 		updateAvailableViewState();
 		return availableIUViewer;
-	}
-
-	private void setTreeColumns(Tree tree) {
-		tree.setHeaderVisible(true);
-
-		IUColumnConfig[] cols = getColumnConfig();
-		for (int i = 0; i < cols.length; i++) {
-			TreeColumn tc = new TreeColumn(tree, SWT.NONE, i);
-			tc.setResizable(true);
-			tc.setText(cols[i].getColumnTitle());
-			tc.setWidth(cols[i].getWidthInPixels(tree));
-		}
 	}
 
 	Object getNewInput() {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/InstalledIUGroup.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/InstalledIUGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2007, 2018 IBM Corporation and others.
+ *  Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -154,7 +154,7 @@ public class InstalledIUGroup extends StructuredIUGroup {
 		});
 
 		// Now the visuals, columns before labels.
-		setTreeColumns(installedIUViewer.getTree());
+		createSortableTreeColumns(installedIUViewer.getTree(), installedIUViewer, comparator);
 		installedIUViewer.setLabelProvider(new IUDetailsLabelProvider(null, getColumnConfig(), null));
 
 		// Input last.
@@ -168,18 +168,6 @@ public class InstalledIUGroup extends StructuredIUGroup {
 		installedIUViewer.getControl().addDisposeListener(
 				e -> ProvUI.getProvisioningEventBus(getProvisioningUI().getSession()).removeListener(listener));
 		return installedIUViewer;
-	}
-
-	private void setTreeColumns(Tree tree) {
-		IUColumnConfig[] columns = getColumnConfig();
-		tree.setHeaderVisible(true);
-
-		for (int i = 0; i < columns.length; i++) {
-			TreeColumn tc = new TreeColumn(tree, SWT.NONE, i);
-			tc.setResizable(true);
-			tc.setText(columns[i].getColumnTitle());
-			tc.setWidth(columns[i].getWidthInPixels(tree));
-		}
 	}
 
 	Object getInput() {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ResolutionResultsWizardPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ResolutionResultsWizardPage.java
@@ -31,6 +31,7 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.viewers.*;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.SashForm;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.*;
 import org.eclipse.swt.widgets.*;
@@ -49,6 +50,7 @@ public abstract class ResolutionResultsWizardPage extends ResolutionStatusPage {
 	protected IUElementListRoot input;
 	ProfileChangeOperation resolvedOperation;
 	TreeViewer treeViewer;
+	IUComparator comparator;
 	ProvElementContentProvider contentProvider;
 	IUDetailsLabelProvider labelProvider;
 	protected Display display;
@@ -124,6 +126,8 @@ public abstract class ResolutionResultsWizardPage extends ResolutionStatusPage {
 				return super.getToolTipText(element);
 			}
 		});
+		nameColumn.getColumn().addSelectionListener(
+				SelectionListener.widgetSelectedAdapter(e -> applySortSelection(tree, (TreeColumn) e.widget, IUComparator.IU_NAME)));
 		final int DEFAULT_COLUMN_WIDTH = 200;
 		// check the operation is for update or installation
 		boolean isUpdate = shouldShowAvailableVersionColumn() && resolvedOperation instanceof UpdateOperation;
@@ -144,6 +148,8 @@ public abstract class ResolutionResultsWizardPage extends ResolutionStatusPage {
 					return iu.getVersion().toString();
 				}
 			});
+			versionColumnOld.getColumn().addSelectionListener(
+					SelectionListener.widgetSelectedAdapter(e -> applySortSelection(tree, (TreeColumn) e.widget, IUComparator.IU_VERSION)));
 		}
 
 		TreeViewerColumn versionColumn = new TreeViewerColumn(treeViewer, SWT.LEFT);
@@ -162,6 +168,8 @@ public abstract class ResolutionResultsWizardPage extends ResolutionStatusPage {
 				return iu.getVersion().toString();
 			}
 		});
+		versionColumn.getColumn().addSelectionListener(
+				SelectionListener.widgetSelectedAdapter(e -> applySortSelection(tree, (TreeColumn) e.widget, IUComparator.IU_VERSION)));
 		TreeViewerColumn idColumn = new TreeViewerColumn(treeViewer, SWT.LEFT);
 		idColumn.getColumn().setText(ProvUIMessages.ProvUI_IdColumnTitle);
 		idColumn.getColumn().setWidth(DEFAULT_COLUMN_WIDTH);
@@ -173,12 +181,17 @@ public abstract class ResolutionResultsWizardPage extends ResolutionStatusPage {
 				return iu.getId();
 			}
 		});
+		idColumn.getColumn().addSelectionListener(
+				SelectionListener.widgetSelectedAdapter(e -> applySortSelection(tree, (TreeColumn) e.widget, IUComparator.IU_ID)));
 
 		// Filters and sorters before establishing content, so we don't refresh unnecessarily.
-		IUComparator comparator = new IUComparator(IUComparator.IU_NAME);
+		comparator = new IUComparator(IUComparator.IU_NAME);
 		comparator.useColumnConfig(getColumnConfig());
 		treeViewer.setComparator(comparator);
 		treeViewer.setComparer(new ProvElementComparer());
+		// Set the initial sort indicator on the Name column.
+		tree.setSortColumn(tree.getColumn(0));
+		tree.setSortDirection(SWT.UP);
 		ColumnViewerToolTipSupport.enableFor(treeViewer);
 		contentProvider = new ProvElementContentProvider();
 		treeViewer.setContentProvider(contentProvider);
@@ -364,5 +377,21 @@ public abstract class ResolutionResultsWizardPage extends ResolutionStatusPage {
 	@Override
 	protected SashForm getSashForm() {
 		return sashForm;
+	}
+
+	private void applySortSelection(Tree tree, TreeColumn tc, int sortKey) {
+		if (sortKey != comparator.getSortKey()) {
+			comparator.setSortKey(sortKey);
+			comparator.sortAscending();
+			tree.setSortDirection(SWT.UP);
+		} else if (comparator.isAscending()) {
+			comparator.sortDescending();
+			tree.setSortDirection(SWT.DOWN);
+		} else {
+			comparator.sortAscending();
+			tree.setSortDirection(SWT.UP);
+		}
+		tree.setSortColumn(tc);
+		treeViewer.refresh();
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/StructuredIUGroup.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/StructuredIUGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2008, 2018 IBM Corporation and others.
+ *  Copyright (c) 2008, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -18,13 +18,16 @@ import java.util.List;
 import org.eclipse.equinox.internal.p2.ui.ProvUI;
 import org.eclipse.equinox.internal.p2.ui.model.ElementUtils;
 import org.eclipse.equinox.internal.p2.ui.viewers.IUColumnConfig;
+import org.eclipse.equinox.internal.p2.ui.viewers.IUComparator;
 import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 import org.eclipse.equinox.p2.operations.ProvisioningSession;
 import org.eclipse.equinox.p2.ui.Policy;
 import org.eclipse.equinox.p2.ui.ProvisioningUI;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.*;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -130,6 +133,49 @@ public abstract class StructuredIUGroup {
 
 	protected int convertHeightInCharsToPixels(int dlus) {
 		return Dialog.convertHeightInCharsToPixels(fm, dlus);
+	}
+
+	protected void createSortableTreeColumns(Tree tree, TreeViewer treeViewer, IUComparator comparator) {
+		tree.setHeaderVisible(true);
+		IUColumnConfig[] cols = getColumnConfig();
+		for (int i = 0; i < cols.length; i++) {
+			TreeColumn tc = new TreeColumn(tree, SWT.NONE, i);
+			tc.setResizable(true);
+			tc.setText(cols[i].getColumnTitle());
+			tc.setWidth(cols[i].getWidthInPixels(tree));
+			int sortKey = toSortKey(cols[i].getColumnType());
+			tc.addSelectionListener(
+					SelectionListener.widgetSelectedAdapter(e -> columnSelected(tree, treeViewer, comparator, (TreeColumn) e.widget, sortKey)));
+		}
+		if (cols.length > 0) {
+			tree.setSortColumn(tree.getColumn(0));
+			tree.setSortDirection(comparator.isAscending() ? SWT.UP : SWT.DOWN);
+		}
+	}
+
+	private static int toSortKey(int columnType) {
+		return switch (columnType) {
+			case IUColumnConfig.COLUMN_ID -> IUComparator.IU_ID;
+			case IUColumnConfig.COLUMN_VERSION, IUColumnConfig.OLD_COLUMN_VERSION, IUColumnConfig.NEW_COLUMN_VERSION -> IUComparator.IU_VERSION;
+			case IUColumnConfig.COLUMN_PROVIDER -> IUComparator.IU_PROVIDER;
+			default -> IUComparator.IU_NAME;
+		};
+	}
+
+	private void columnSelected(Tree tree, TreeViewer treeViewer, IUComparator comparator, TreeColumn tc, int sortKey) {
+		if (sortKey != comparator.getSortKey()) {
+			comparator.setSortKey(sortKey);
+			comparator.sortAscending();
+			tree.setSortDirection(SWT.UP);
+		} else if (comparator.isAscending()) {
+			comparator.sortDescending();
+			tree.setSortDirection(SWT.DOWN);
+		} else {
+			comparator.sortAscending();
+			tree.setSortDirection(SWT.UP);
+		}
+		tree.setSortColumn(tc);
+		treeViewer.refresh();
 	}
 
 	protected Policy getPolicy() {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUComparator.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2000, 2010 IBM Corporation and others.
+ *  Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,13 @@ import org.eclipse.jface.viewers.ViewerComparator;
 public class IUComparator extends ViewerComparator {
 	public static final int IU_NAME = 0;
 	public static final int IU_ID = 1;
-	private final int key;
+
+	public static final int IU_VERSION = 2;
+	public static final int IU_PROVIDER = 3;
+	private static final int ASCENDING = 1;
+	private static final int DESCENDING = -1;
+	private int key;
+	private int direction = ASCENDING;
 	private boolean showingId = false;
 
 	public IUComparator(int sortKey) {
@@ -51,39 +57,65 @@ public class IUComparator extends ViewerComparator {
 			return super.compare(viewer, obj1, obj2);
 		}
 
+		if (key == IU_VERSION) {
+			// Sorting on the version column directly, no string keys needed.
+			int result = iu1.getVersion().compareTo(iu2.getVersion()) * direction;
+			if (result == 0) {
+				result = getNameOrId(iu1).compareToIgnoreCase(getNameOrId(iu2));
+			}
+			return result;
+		}
+
 		String key1, key2;
-		if (key == IU_NAME) {
-			// Compare the iu names in the default locale.
+		if (key == IU_PROVIDER) {
+			key1 = iu1.getProperty(IInstallableUnit.PROP_PROVIDER, ""); //$NON-NLS-1$
+			key2 = iu2.getProperty(IInstallableUnit.PROP_PROVIDER, ""); //$NON-NLS-1$
+		} else if (key == IU_ID) {
+			key1 = iu1.getId();
+			key2 = iu2.getId();
+		} else {
+			// IU_NAME: compare the iu names in the default locale.
 			// If a name is not defined, we use blank if we know the id is shown in another
 			// column. If the id is not shown elsewhere, then we are displaying it, so use
 			// the id instead.
-			key1 = iu1.getProperty(IInstallableUnit.PROP_NAME, null);
-			if (key1 == null) {
-				if (showingId) {
-					key1 = ""; //$NON-NLS-1$
-				} else {
-					key1 = iu1.getId();
-				}
-			}
-			key2 = iu2.getProperty(IInstallableUnit.PROP_NAME, null);
-			if (key2 == null) {
-				if (showingId) {
-					key2 = ""; //$NON-NLS-1$
-				} else {
-					key2 = iu2.getId();
-				}
-			}
-		} else {
-			key1 = iu1.getId();
-			key2 = iu2.getId();
+			key1 = getNameOrId(iu1);
+			key2 = getNameOrId(iu2);
 		}
 
-		int result = 0;
-		result = key1.compareToIgnoreCase(key2);
+		int result = key1.compareToIgnoreCase(key2) * direction;
 		if (result == 0) {
 			// We want to show later versions first so compare backwards.
 			result = iu2.getVersion().compareTo(iu1.getVersion());
 		}
 		return result;
+	}
+
+	private String getNameOrId(IInstallableUnit iu) {
+		String name = iu.getProperty(IInstallableUnit.PROP_NAME, null);
+		if (name == null) {
+			name = showingId ? "" : iu.getId(); //$NON-NLS-1$
+		}
+		return name;
+	}
+
+	public void sortAscending() {
+		direction = ASCENDING;
+	}
+
+	public void sortDescending() {
+		direction = DESCENDING;
+	}
+
+	public boolean isAscending() {
+		return direction == ASCENDING;
+	}
+
+	public void setSortKey(int key) {
+		this.key = key;
+		showingId = showingId || key == IU_ID;
+	}
+
+	public int getSortKey() {
+		return key;
 	}
 }


### PR DESCRIPTION
Column headers in the Available Software, Installed Software, and Install/Update resolution results pages are now clickable. Clicking a header sorts by that column, and clicking again toggles between ascending and descending order.

Fix: https://github.com/eclipse-equinox/p2/issues/1111

<img width="1271" height="267" alt="image" src="https://github.com/user-attachments/assets/77f1b10a-455a-4f64-842c-d772b027a315" />

<img width="811" height="295" alt="image" src="https://github.com/user-attachments/assets/4d796898-50b9-42df-aa8f-1e5091479368" />

<img width="811" height="295" alt="image" src="https://github.com/user-attachments/assets/e413c5d5-e650-43c3-b7e4-08ad2c26d389" />


https://github.com/user-attachments/assets/dc589841-2ec8-48ae-ab7f-98a275d64ca4

