### PR TITLE
Repository Location field should suggest previously known sites

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/dialogs/AddRepositoryDialogTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/dialogs/AddRepositoryDialogTest.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ *  Copyright (c) 2026 IBM Corporation and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.p2.tests.ui.dialogs;
+
+import java.net.URI;
+import java.util.Arrays;
+import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.equinox.internal.p2.ui.dialogs.RepositoryNameAndLocationDialog;
+import org.eclipse.equinox.internal.p2.ui.dialogs.TextAutoCompleteField;
+import org.eclipse.equinox.p2.tests.ui.AbstractProvisioningUITest;
+import org.eclipse.jface.fieldassist.IContentProposal;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * Tests that {@link RepositoryNameAndLocationDialog} wires autocomplete
+ * proposals from the repository manager into its Location field.
+ */
+public class AddRepositoryDialogTest extends AbstractProvisioningUITest {
+
+	/**
+	 * Dialog subclass that exposes the protected autocomplete field for testing.
+	 */
+	static class TestDialog extends RepositoryNameAndLocationDialog {
+		TestDialog(Shell shell, org.eclipse.equinox.p2.ui.ProvisioningUI ui) {
+			super(shell, ui);
+			setBlockOnOpen(false);
+		}
+
+		@Override
+		public TextAutoCompleteField getUrlAutoComplete() {
+			return super.getUrlAutoComplete();
+		}
+	}
+
+	private URI enabledRepo;
+	private URI disabledRepo;
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		enabledRepo = new URI("https://enabled.example.com/p2");
+		disabledRepo = new URI("https://disabled.example.com/p2");
+		ui.getRepositoryTracker().addRepository(enabledRepo, null, ui.getSession());
+		ui.getRepositoryTracker().addRepository(disabledRepo, null, ui.getSession());
+		metaManager.setEnabled(disabledRepo, false);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		ui.getRepositoryTracker().removeRepositories(new URI[] { enabledRepo, disabledRepo }, ui.getSession());
+		super.tearDown();
+	}
+
+	/**
+	 * Enabled repositories must NOT be proposed
+	 */
+	public void testEnabledRepoIsNotProposed() {
+		TestDialog dialog = new TestDialog(null, ui);
+		dialog.open();
+		try {
+			String[] proposals = getProposalContents(dialog, "enabled.example");
+			assertFalse("Enabled repo URL should not be proposed",
+					Arrays.asList(proposals).contains(URIUtil.toUnencodedString(enabledRepo)));
+		} finally {
+			dialog.close();
+		}
+	}
+
+	/**
+	 * Disabled repositories must be proposed
+	 */
+	public void testDisabledRepoIsProposed() {
+		TestDialog dialog = new TestDialog(null, ui);
+		dialog.open();
+		try {
+			String[] proposals = getProposalContents(dialog, "disabled.example");
+			assertTrue("Disabled repo URL should be proposed",
+					Arrays.asList(proposals).contains(URIUtil.toUnencodedString(disabledRepo)));
+		} finally {
+			dialog.close();
+		}
+	}
+
+	private String[] getProposalContents(TestDialog dialog, String filter) {
+		IContentProposal[] raw = dialog.getUrlAutoComplete().getProposals(filter);
+		String[] result = new String[raw.length];
+		for (int i = 0; i < raw.length; i++) {
+			result[i] = raw[i].getContent();
+		}
+		return result;
+	}
+}

--- a/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/dialogs/AllTests.java
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/dialogs/AllTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2008, 2018 IBM Corporation and others.
+ *  Copyright (c) 2008, 2026 IBM Corporation and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,7 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({ InstallWizardTest.class, InstalledSoftwarePageTest.class, InstallWithRemediationTest.class,
 		InstallationHistoryPageTest.class, UpdateWizardTest.class, UninstallWizardTest.class,
 		RepositoryManipulationPageTest.class, IUPropertyPagesTest.class, PreferencePagesTest.class,
-		EECompatibilityTest.class })
+		EECompatibilityTest.class, TextAutoCompleteFieldTest.class, AddRepositoryDialogTest.class })
 public class AllTests {
 	// test suite
 }

--- a/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/dialogs/TextAutoCompleteFieldTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests.ui/src/org/eclipse/equinox/p2/tests/ui/dialogs/TextAutoCompleteFieldTest.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ *  Copyright (c) 2026 IBM Corporation and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.p2.tests.ui.dialogs;
+
+import org.eclipse.equinox.internal.p2.ui.dialogs.TextAutoCompleteField;
+import org.eclipse.equinox.p2.tests.ui.AbstractProvisioningUITest;
+import org.eclipse.jface.fieldassist.IContentProposal;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.*;
+
+/**
+ * Tests for {@link TextAutoCompleteField} proposal filtering logic.
+ */
+public class TextAutoCompleteFieldTest extends AbstractProvisioningUITest {
+
+	private Shell shell;
+	private Text text;
+	private TextAutoCompleteField field;
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		Display display = Display.getDefault();
+		shell = new Shell(display);
+		text = new Text(shell, SWT.BORDER);
+		field = new TextAutoCompleteField(text);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		shell.dispose();
+		super.tearDown();
+	}
+
+	/** Substring match — proposal containing the typed text is returned. */
+	public void testSubstringMatchReturnsProposal() {
+		field.setProposalStrings(new String[] { "https://download.eclipse.org/releases/latest" });
+		IContentProposal[] proposals = field.getProposals("eclipse");
+		assertEquals(1, proposals.length);
+		assertEquals("https://download.eclipse.org/releases/latest", proposals[0].getContent());
+	}
+
+	/** No match — typed text has no match in proposals. */
+	public void testNoMatchReturnsEmpty() {
+		field.setProposalStrings(new String[] { "https://download.eclipse.org/releases/latest" });
+		IContentProposal[] proposals = field.getProposals("xyz999notasite");
+		assertEquals(0, proposals.length);
+	}
+
+	/** Empty input — never show proposals when nothing is typed. */
+	public void testEmptyInputReturnsEmpty() {
+		field.setProposalStrings(new String[] { "https://download.eclipse.org/releases/latest" });
+		IContentProposal[] proposals = field.getProposals("");
+		assertEquals(0, proposals.length);
+	}
+
+	/** No proposal strings set — returns empty. */
+	public void testNullProposalsReturnsEmpty() {
+		field.setProposalStrings(null);
+		IContentProposal[] proposals = field.getProposals("eclipse");
+		assertEquals(0, proposals.length);
+	}
+
+	/** Exact single match suppression — popup should not reopen after acceptance. */
+	public void testExactSingleMatchIsSuppressed() {
+		String url = "https://download.eclipse.org/releases/latest";
+		field.setProposalStrings(new String[] { url });
+		text.setText(url);
+		IContentProposal[] proposals = field.getProposals(url);
+		assertEquals("Exact single match should be suppressed to avoid popup reopening", 0, proposals.length);
+	}
+
+	/** Multiple proposals — all matching entries are returned. */
+	public void testMultipleMatchesReturned() {
+		field.setProposalStrings(new String[] {
+				"https://download.eclipse.org/releases/latest",
+				"https://download.eclipse.org/releases/2024-12",
+				"https://unrelated.example.com/p2"
+		});
+		IContentProposal[] proposals = field.getProposals("eclipse");
+		assertEquals(2, proposals.length);
+	}
+
+	/** Match is case-insensitive. */
+	public void testMatchIsCaseInsensitive() {
+		field.setProposalStrings(new String[] { "https://download.Eclipse.org/releases/latest" });
+		IContentProposal[] proposals = field.getProposals("eclipse");
+		assertEquals(1, proposals.length);
+	}
+
+}

--- a/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Export-Package: org.eclipse.equinox.internal.p2.ui;
    org.eclipse.equinox.p2.ui.sdk.scheduler,
    org.eclipse.equinox.p2.ui.sdk,
    org.eclipse.pde.ui,
-   org.eclipse.equinox.p2.ui.importexport",
+   org.eclipse.equinox.p2.ui.importexport,
+   org.eclipse.equinox.p2.tests.ui",
  org.eclipse.equinox.internal.p2.ui.model;
   x-friends:="org.eclipse.equinox.internal.p2.ui.analysis,
    org.eclipse.equinox.p2.ui.admin,

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/RepositoryNameAndLocationDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/RepositoryNameAndLocationDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2018 IBM Corporation and others.
+ * Copyright (c) 2007, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,9 +16,12 @@ package org.eclipse.equinox.internal.p2.ui.dialogs;
 import java.net.URI;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.equinox.internal.p2.ui.ProvUI;
 import org.eclipse.equinox.internal.p2.ui.ProvUIActivator;
 import org.eclipse.equinox.internal.p2.ui.ProvUIMessages;
 import org.eclipse.equinox.p2.operations.RepositoryTracker;
+import org.eclipse.equinox.p2.repository.IRepositoryManager;
 import org.eclipse.equinox.p2.ui.ProvisioningUI;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
@@ -39,6 +42,7 @@ public class RepositoryNameAndLocationDialog extends StatusDialog {
 
 	Button okButton;
 	Text url, nickname;
+	TextAutoCompleteField urlAutoComplete;
 	ProvisioningUI ui;
 	URI location;
 	String name;
@@ -220,10 +224,35 @@ public class RepositoryNameAndLocationDialog extends StatusDialog {
 		target.setTransfer(URLTransfer.getInstance(), FileTransfer.getInstance());
 		target.addDropListener(new TextURLDropAdapter(url, true));
 		url.addModifyListener(e -> validateRepositoryURL(false));
+		// Offer known repository locations as content assist, including ones theuser has disabled or previously removed, 
+		// so re-adding a familiar site doesn't require retyping or re-finding the URL.
+		urlAutoComplete = new TextAutoCompleteField(url);
+		urlAutoComplete.setProposalStrings(getKnownLocationProposals());
 		initialURL = getInitialLocationText();
 		url.setText(initialURL);
 		url.setSelection(0, url.getText().length());
 		return url;
+	}
+
+	/**
+	 * Return the locations of disabled repositories as content assist proposal
+	 * strings for the location field. Only disabled repositories are included —
+	 * enabled ones are already accessible via the "Work with:" combo on the
+	 * Available Software page and do not need to be re-added.
+	 */
+	private String[] getKnownLocationProposals() {
+		int flags = getRepositoryTracker().getMetadataRepositoryFlags()
+				| IRepositoryManager.REPOSITORIES_DISABLED;
+		URI[] disabled = ProvUI.getMetadataRepositoryManager(ui.getSession()).getKnownRepositories(flags);
+		String[] proposals = new String[disabled.length];
+		for (int i = 0; i < disabled.length; i++) {
+			proposals[i] = URIUtil.toUnencodedString(disabled[i]);
+		}
+		return proposals;
+	}
+
+	protected TextAutoCompleteField getUrlAutoComplete() {
+		return urlAutoComplete;
 	}
 
 	protected ProvisioningUI getProvisioningUI() {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TextAutoCompleteField.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TextAutoCompleteField.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ *  Copyright (c) 2026 IBM Corporation and others.
+ *
+ *  This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License 2.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/legal/epl-2.0/
+ *
+ *  SPDX-License-Identifier: EPL-2.0
+ *
+ *  Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.equinox.internal.p2.ui.dialogs;
+
+import java.util.ArrayList;
+import org.eclipse.core.text.StringMatcher;
+import org.eclipse.jface.fieldassist.*;
+import org.eclipse.swt.widgets.Text;
+
+/**
+ * TextAutoCompleteField is an auto complete field appropriate for pattern
+ * matching the text in a {@link Text} field against a fixed, externally
+ * supplied list of proposal strings. Unlike {@link ComboAutoCompleteField}, it
+ * has no notion of "items already in the widget", since a Text field has no
+ * items of its own; proposals must always be supplied with
+ * {@link #setProposalStrings(String[])}.
+ *
+ * @since 2.10
+ */
+public class TextAutoCompleteField {
+
+	ContentProposalAdapter adapter;
+	Text text;
+	String[] proposalStrings = new String[0];
+
+	public TextAutoCompleteField(Text t) {
+		this.text = t;
+		adapter = new ContentProposalAdapter(text, new TextContentAdapter(), getProposalProvider(), null, null);
+		adapter.setPropagateKeys(true);
+		adapter.setProposalAcceptanceStyle(ContentProposalAdapter.PROPOSAL_REPLACE);
+	}
+
+	public void setProposalStrings(String[] proposals) {
+		proposalStrings = proposals == null ? new String[0] : proposals;
+	}
+
+	public IContentProposal[] getProposals(String contents) {
+		return getProposalProvider().getProposals(contents, contents.length());
+	}
+
+	IContentProposalProvider getProposalProvider() {
+		return (contents, position) -> {
+			if (contents.length() == 0 || proposalStrings.length == 0) {
+				return new IContentProposal[0];
+			}
+			StringMatcher matcher = new StringMatcher("*" + contents + "*", true, false); //$NON-NLS-1$ //$NON-NLS-2$
+			ArrayList<String> matches = new ArrayList<>();
+			for (String item : proposalStrings) {
+				if (matcher.match(item)) {
+					matches.add(item);
+				}
+			}
+
+			// Don't autoactivate if the only proposal exactly matches what's already typed.
+			// Prevents the popup reopening right after a proposal has just been accepted.
+			if (matches.size() == 1 && matches.get(0).equals(text.getText())) {
+				return new IContentProposal[0];
+			}
+
+			if (matches.isEmpty()) {
+				return new IContentProposal[0];
+			}
+
+			IContentProposal[] proposals = new IContentProposal[matches.size()];
+			for (int i = 0; i < matches.size(); i++) {
+				final String proposal = matches.get(i);
+				proposals[i] = new IContentProposal() {
+
+					@Override
+					public String getContent() {
+						return proposal;
+					}
+
+					@Override
+					public int getCursorPosition() {
+						return proposal.length();
+					}
+
+					@Override
+					public String getDescription() {
+						return null;
+					}
+
+					@Override
+					public String getLabel() {
+						return null;
+					}
+				};
+			}
+			return proposals;
+		};
+	}
+}


### PR DESCRIPTION
When adding or editing a repository, the Location field offered no suggestions, requiring users to remember and retype repository URLs manually. This change adds content assist to RepositoryNameAndLocationDialog.createLocationField() using a new TextAutoCompleteField helper.
The content assist suggests previously disabled repository URLs, making it easier to re-add repositories that are no longer discoverable through the existing UI. Implementing this in RepositoryNameAndLocationDialog automatically covers the Add Repository, Edit Repository.

Fixes: https://github.com/eclipse-equinox/p2/issues/1113

<img width="587" height="374" alt="image" src="https://github.com/user-attachments/assets/5d244a41-955b-47e6-b8fc-0bf820f9751b" />

<img width="606" height="465" alt="image" src="https://github.com/user-attachments/assets/c0a7a478-6190-477b-816c-72861aea5a18" />
